### PR TITLE
fix: update plugin install command to sensitive-canary@coo-quack

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install in two commands from inside a Claude Code session:
 **2. Install the plugin**
 
 ```
-/plugin install sensitive-canary@sensitive-canary
+/plugin install sensitive-canary@coo-quack
 ```
 
 Done. The hooks are enabled automatically.

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ Run the following two commands inside a Claude Code session:
 **2. Install the plugin**
 
 ```
-/plugin install sensitive-canary@sensitive-canary
+/plugin install sensitive-canary@coo-quack
 ```
 
 Claude Code will download the plugin and register the hooks automatically. No restart is required.


### PR DESCRIPTION
The marketplace.json name was changed from `sensitive-canary` to `coo-quack`, so the install command is now `/plugin install sensitive-canary@coo-quack`. Update README and docs/install.md accordingly.