### PR TITLE
feat: allow/mask tag first-occurrence priority and code review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Allow + Mask tag priority** — when both `[allow-*]` and `[mask-*]` tags appear in the same prompt, the first occurrence wins per category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both dimensions at once.
+
+### Fixes
+
+- Plugin install command corrected to `sensitive-canary@coo-quack`
+
+---
+
 ## v0.1.0 (2026-02-22)
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -192,9 +192,39 @@ To intentionally bypass a block, include the appropriate tag in your **current p
 **Important notes:**
 
 - Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass.
+- Tags are case-insensitive: `[ALLOW-SECRET]` and `[Allow-Secret]` are equivalent to `[allow-secret]`.
 - `[allow-secret]` does not bypass PII blocks (and vice versa).
 - The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
 - Allow tags filter the scan results — the scan itself always runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
+
+## Mask tags
+
+`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content, so masking before sending is not possible.
+
+If you include a mask tag, sensitive-canary will explain this and suggest the appropriate allow tag:
+
+```
+> [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
+
+🐦 sensitive-canary: prompt masking is not supported
+
+  Prompt content cannot be rewritten by hooks in Claude Code.
+  To send anyway, use an allow tag instead:
+    [allow-secret]  — allow secrets
+    [allow-all]     — bypass all sensitive-canary checks
+```
+
+To proceed, replace `[mask-secret]` with `[allow-secret]` in your prompt, or redact the value manually before sending.
+
+### Allow + Mask tag priority
+
+When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both categories at once.
+
+| Example | Result |
+|---------|--------|
+| `[allow-secret] [mask-secret] …` | secret allowed |
+| `[mask-secret] [allow-secret] …` | masking not supported error |
+| `[allow-secret] [mask-pii] …` | secret allowed, PII mask error |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -201,20 +201,25 @@ To intentionally bypass a block, include the appropriate tag in your **current p
 
 `[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content, so masking before sending is not possible.
 
-If you include a mask tag, sensitive-canary will explain this and suggest the appropriate allow tag:
+If you include a mask tag, sensitive-canary will explain this and list what was detected:
 
 ```
 > [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
 
 🐦 sensitive-canary: prompt masking is not supported
 
-  Prompt content cannot be rewritten by hooks in Claude Code.
-  To send anyway, use an allow tag instead:
-    [allow-secret]  — allow secrets
-    [allow-all]     — bypass all sensitive-canary checks
-```
+  [mask-secret] cannot mask prompt content.
+  The following sensitive data was detected:
 
-To proceed, replace `[mask-secret]` with `[allow-secret]` in your prompt, or redact the value manually before sending.
+  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
+
+  Please choose one of the following:
+
+  1. Manually redact the values above and resubmit
+  2. To send as-is, add an allow tag to your prompt:
+       [allow-secret]  — allow secrets
+       [allow-all]     — bypass all sensitive-canary checks
+```
 
 ### Allow + Mask tag priority
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,7 @@ sensitive-canary is a best-effort guard, not a guaranteed security boundary:
 - **Entropy filtering** — Generic rules use Shannon entropy thresholds to reduce false positives. Low-entropy values that happen to be real secrets may pass through.
 - **Allow tags** — Any block can be bypassed by the user with `[allow-secret]`, `[allow-pii]`, or `[allow-all]`. This is intentional — the tool assists, not enforces.
 - **Hook execution** — If the Node.js process fails to start (e.g., wrong Node version), the hook exits 0 (pass) to avoid blocking Claude entirely.
+- **Parse errors** — If the hook input cannot be parsed (malformed JSON from Claude Code), the hook exits 0 (pass) as a fail-open fallback.
 - **Scope** — Only `Read` and `Bash` tool calls are intercepted. Other tool types are not scanned.
 
 ---

--- a/docs/install.md
+++ b/docs/install.md
@@ -124,7 +124,24 @@ When a block is triggered, sensitive-canary tells Claude which tag to suggest. Y
 [allow-secret] Please review my .env.example file at /path/to/.env.example
 ```
 
-Allow tags apply only to the message they appear in. They do not persist across turns.
+Allow tags apply only to the message they appear in. They do not persist across turns. Tags are case-insensitive.
+
+## Mask Tags
+
+`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content before it is sent.
+
+If you use a mask tag, sensitive-canary will display an explanation and suggest the appropriate allow tag instead:
+
+```
+🐦 sensitive-canary: prompt masking is not supported
+
+  Prompt content cannot be rewritten by hooks in Claude Code.
+  To send anyway, use an allow tag instead:
+    [allow-secret]  — allow secrets
+    [allow-all]     — bypass all sensitive-canary checks
+```
+
+To proceed, replace the mask tag with the corresponding allow tag, or redact the value manually before sending.
 
 ## Uninstall
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,18 +130,25 @@ Allow tags apply only to the message they appear in. They do not persist across 
 
 `[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content before it is sent.
 
-If you use a mask tag, sensitive-canary will display an explanation and suggest the appropriate allow tag instead:
+If you use a mask tag, sensitive-canary will display an explanation and list what was detected:
 
 ```
 🐦 sensitive-canary: prompt masking is not supported
 
-  Prompt content cannot be rewritten by hooks in Claude Code.
-  To send anyway, use an allow tag instead:
-    [allow-secret]  — allow secrets
-    [allow-all]     — bypass all sensitive-canary checks
+  [mask-secret] cannot mask prompt content.
+  The following sensitive data was detected:
+
+  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
+
+  Please choose one of the following:
+
+  1. Manually redact the values above and resubmit
+  2. To send as-is, add an allow tag to your prompt:
+       [allow-secret]  — allow secrets
+       [allow-all]     — bypass all sensitive-canary checks
 ```
 
-To proceed, replace the mask tag with the corresponding allow tag, or redact the value manually before sending.
+To proceed, either manually redact the sensitive value and resubmit, or replace the mask tag with the corresponding allow tag.
 
 ## Uninstall
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -74,7 +74,7 @@ The entropy threshold filters out low-entropy values (e.g. `API_KEY=placeholder`
 |---------|-------------|-------|
 | `pii-email` | Email Address | Standard RFC 5322-like pattern |
 | `pii-credit-card` | Credit Card Number | Visa, Mastercard, Amex, Discover; validated with Luhn algorithm |
-| `pii-ssn` | US Social Security Number | Excludes invalid prefixes (000, 666, 9xx) |
+| `pii-ssn` | US Social Security Number | Excludes invalid area (000, 666, 9xx), group (00), and serial (0000) numbers |
 | `pii-phone-us` | US Phone Number | With or without country code |
 | `pii-phone-jp` | Japanese Phone Number | Area code + subscriber number format |
 | `pii-postal-jp` | Japanese Postal Code | Requires `〒` prefix to avoid false positives |
@@ -94,7 +94,33 @@ All blocks can be bypassed by including an allow tag in your prompt. Allow tags 
 | `[allow-pii]` | All findings with `category: pii` |
 | `[allow-all]` | All findings regardless of category |
 
-**Note on mask tags:** `[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but not supported for prompts — Claude Code does not allow hooks to rewrite prompt content. If you use a mask tag, sensitive-canary will explain this and suggest the appropriate allow tag instead.
+Tags are **case-insensitive**: `[ALLOW-SECRET]` and `[Allow-Secret]` work the same as `[allow-secret]`.
+
+### Mask Tags
+
+`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content before it is sent to the API.
+
+If you include a mask tag in your prompt, sensitive-canary shows an explanation and suggests the equivalent allow tag instead. The prompt is not sent until you resend with an allow tag or redact the value manually.
+
+| Mask tag | Suggested allow tag |
+|----------|---------------------|
+| `[mask-secret]` | `[allow-secret]` |
+| `[mask-pii]` | `[allow-pii]` |
+| `[mask-all]` | `[allow-all]` |
+
+### Allow + Mask Tag Priority
+
+When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category dimension (`secret`, `pii`).
+
+| Example | secret | pii |
+|---------|--------|-----|
+| `[allow-secret] [mask-secret] …` | allow | — |
+| `[mask-secret] [allow-secret] …` | mask (unsupported) | — |
+| `[allow-all] [mask-secret] …` | allow | allow |
+| `[mask-all] [allow-secret] …` | mask (unsupported) | mask (unsupported) |
+| `[allow-secret] [mask-pii] …` | allow | mask (unsupported) |
+
+`[allow-all]` and `[mask-all]` resolve both dimensions at once.
 
 ## .env File Blocking
 
@@ -102,7 +128,7 @@ All blocks can be bypassed by including an allow tag in your prompt. Allow tags 
 
 Files that end in `.env` but don't start with a dot (e.g. `production.env`) are handled by content scanning rather than name-based blocking.
 
-Any allow tag (`[allow-secret]`, `[allow-pii]`, or `[allow-all]`) bypasses the name-based block.
+Any allow tag (`[allow-secret]`, `[allow-pii]`, or `[allow-all]`) bypasses the name-based block. When an allow tag is present, the file is passed through **immediately without scanning** its contents.
 
 ## Bash Command Scanning
 
@@ -110,4 +136,4 @@ When Claude uses the `Bash` tool, sensitive-canary checks three things:
 
 1. **Environment variables** — any `$VAR` or `${VAR}` references in the command are looked up in the current environment; if their values contain secrets or PII, the command is blocked.
 2. **Command string** — the raw command is scanned (catches inline secrets like `echo AKIAIOSFODNN7EXAMPLE`).
-3. **File-reading commands** — for `cat`, `head`, `tail`, `less`, `more`, `bat`, `nl`, the target files are read and scanned before the command runs.
+3. **File-reading commands** — for `cat`, `head`, `tail`, `less`, `more`, `bat`, `nl`, the target files are read and scanned before the command runs. Compound commands using `|`, `;`, `&&`, `||` are split and each segment is checked independently.

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -18,7 +18,8 @@ function parseHookOutput(stdout: string) {
   }
 }
 
-/** Write a fake Claude Code session transcript and return its path. */
+let transcriptSeq = 0;
+
 function writeTranscript(userMessages: string[]): string {
   const lines = userMessages.map((content) =>
     JSON.stringify({
@@ -26,7 +27,7 @@ function writeTranscript(userMessages: string[]): string {
       message: { role: "user", content },
     }),
   );
-  const p = join(tmpDir, `transcript-${Date.now()}.jsonl`);
+  const p = join(tmpDir, `transcript-${++transcriptSeq}.jsonl`);
   writeFileSync(p, lines.join("\n"), "utf8");
   return p;
 }
@@ -204,7 +205,6 @@ describe("pre-tool-use-hook — sensitive content blocking", () => {
       "A=AKIAIOSFODNN7EXAMPLE\nB=AKIAIOSFODNN7EXAMPLE\n",
     );
     const { reason } = runHook("Read", p);
-    // "[Secret] ... (aws-access-key):" should appear exactly once
     const count = (reason ?? "").split("[Secret]").length - 1;
     expect(count).toBe(1);
   });
@@ -279,54 +279,20 @@ describe("pre-tool-use-hook — Bash tool (command string)", () => {
 // ── Bash tool — file-reading command blocking ─────────────────────────────────
 
 describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
-  it("blocks cat on a file with secrets", () => {
+  it.each([
+    "cat",
+    "head",
+    "tail",
+    "less",
+    "more",
+    "bat",
+    "nl",
+  ])("blocks %s on a file with secrets", (cmd) => {
     const p = writeFixture(
-      "creds-cat.txt",
-      "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n",
+      `creds-${cmd}.txt`,
+      "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runBashHook(`cat ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
-
-  it("blocks head on a file with secrets", () => {
-    const p = writeFixture("creds-head.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`head -5 ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
-
-  it("blocks tail on a file with secrets", () => {
-    const p = writeFixture("creds-tail.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`tail -10 ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
-
-  it("blocks nl on a file with secrets", () => {
-    const p = writeFixture("creds-nl.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`nl ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
-
-  it("blocks bat on a file with secrets", () => {
-    const p = writeFixture("creds-bat.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`bat ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
-
-  it("blocks less on a file with secrets", () => {
-    const p = writeFixture("creds-less.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`less ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
-
-  it("blocks more on a file with secrets", () => {
-    const p = writeFixture("creds-more.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`more ${p}`);
+    const { exitCode, decision } = runBashHook(`${cmd} ${p}`);
     expect(exitCode).toBe(2);
     expect(decision).toBe("block");
   });
@@ -439,8 +405,8 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
 
   it("[allow-all] in the latest message is respected even with older messages", () => {
     const transcript = writeTranscript([
-      "please help me with the config", // older message — no tag
-      "[allow-all] yes read everything", // latest message — has tag
+      "please help me with the config",
+      "[allow-all] yes read everything",
     ]);
     const p = writeFixture(
       "config-allow-latest.txt",
@@ -452,8 +418,8 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
 
   it("old [allow-all] in a past message is NOT respected when latest message has no tag", () => {
     const transcript = writeTranscript([
-      "[allow-all] read this file", // older message — has tag
-      "now do something else", // latest message — no tag
+      "[allow-all] read this file",
+      "now do something else",
     ]);
     const p = writeFixture(
       "config-old-allow.txt",

--- a/src/__tests__/user-prompt-submit-hook.test.ts
+++ b/src/__tests__/user-prompt-submit-hook.test.ts
@@ -142,13 +142,14 @@ describe("user-prompt-submit-hook — [mask-xxx] tags", () => {
     expect(stderr).toContain("[allow-pii]");
   });
 
-  it("[mask-all] with any sensitive data shows the actual tag in message", () => {
+  it("[mask-all] with any sensitive data shows masking not supported", () => {
     const { exitCode, stderr } = runHook(
       "[mask-all] my key is AKIAIOSFODNN7EXAMPLE",
     );
     expect(exitCode).toBe(2);
     expect(stderr).toContain("prompt masking is not supported");
-    expect(stderr).toContain("[mask-all]");
+    // [mask-all] resolves to [mask-secret] + [mask-pii] per dimension
+    expect(stderr).toContain("[mask-secret]");
   });
 
   it("[mask-secret] with only PII falls through to normal block", () => {
@@ -181,6 +182,66 @@ describe("user-prompt-submit-hook — [mask-xxx] tags", () => {
     expect(exitCode).toBe(2);
     expect(stderr).not.toContain("prompt masking is not supported");
     expect(stderr).toContain("sensitive data detected");
+  });
+});
+
+describe("user-prompt-submit-hook — first-occurrence tag priority", () => {
+  it("[allow-secret] before [mask-secret] → passes through (exit 0)", () => {
+    const { exitCode } = runHook(
+      "[allow-secret] [mask-secret] my key is AKIAIOSFODNN7EXAMPLE",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  it("[mask-secret] before [allow-secret] → shows masking not supported (exit 2)", () => {
+    const { exitCode, stderr } = runHook(
+      "[mask-secret] [allow-secret] my key is AKIAIOSFODNN7EXAMPLE",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("prompt masking is not supported");
+  });
+
+  it("[allow-all] before [mask-secret] → passes through (exit 0)", () => {
+    const { exitCode } = runHook(
+      "[allow-all] [mask-secret] my key is AKIAIOSFODNN7EXAMPLE",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  it("[mask-all] before [allow-secret] → shows masking not supported (exit 2)", () => {
+    const { exitCode, stderr } = runHook(
+      "[mask-all] [allow-secret] my key is AKIAIOSFODNN7EXAMPLE",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("prompt masking is not supported");
+  });
+
+  it("[allow-secret] [mask-pii] → secret allowed, pii masked → masking not supported (exit 2)", () => {
+    const { exitCode, stderr } = runHook(
+      "[allow-secret] [mask-pii] key AKIAIOSFODNN7EXAMPLE email user@example.com",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("prompt masking is not supported");
+    expect(stderr).toContain("[mask-pii]");
+    expect(stderr).not.toContain("[mask-secret]");
+  });
+
+  it("[mask-pii] [allow-secret] → secret: allow, pii: mask → masking not supported for email (exit 2)", () => {
+    const { exitCode, stderr } = runHook(
+      "[mask-pii] [allow-secret] key AKIAIOSFODNN7EXAMPLE email user@example.com",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("prompt masking is not supported");
+    expect(stderr).toContain("[mask-pii]");
+  });
+
+  it("[allow-pii] before [mask-pii] → pii allowed, secret still blocked (exit 2)", () => {
+    const { exitCode, stderr } = runHook(
+      "[allow-pii] [mask-pii] key AKIAIOSFODNN7EXAMPLE email user@example.com",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("sensitive data detected");
+    expect(stderr).not.toContain("prompt masking is not supported");
   });
 });
 

--- a/src/__tests__/user-prompt-submit-hook.test.ts
+++ b/src/__tests__/user-prompt-submit-hook.test.ts
@@ -148,8 +148,7 @@ describe("user-prompt-submit-hook — [mask-xxx] tags", () => {
     );
     expect(exitCode).toBe(2);
     expect(stderr).toContain("prompt masking is not supported");
-    // [mask-all] resolves to [mask-secret] + [mask-pii] per dimension
-    expect(stderr).toContain("[mask-secret]");
+    expect(stderr).toContain("[mask-all]");
   });
 
   it("[mask-secret] with only PII falls through to normal block", () => {

--- a/src/lib/__tests__/inspector.test.ts
+++ b/src/lib/__tests__/inspector.test.ts
@@ -5,9 +5,7 @@ import {
   dedupeFindings,
   findingsToLines,
   parseAllowTags,
-  parseMaskTags,
   resolveTagPriority,
-  scanMessages,
 } from "../inspector.ts";
 
 // ── parseAllowTags ────────────────────────────────────────────────────────────
@@ -57,51 +55,6 @@ describe("parseAllowTags", () => {
       },
     ]);
     expect(tags.has("secret")).toBe(true);
-  });
-});
-
-// ── parseMaskTags ─────────────────────────────────────────────────────────────
-
-describe("parseMaskTags", () => {
-  it("returns empty set when no tags are present", () => {
-    const tags = parseMaskTags([{ role: "user", content: "hello" }]);
-    expect(tags.size).toBe(0);
-  });
-
-  it("parses [mask-all]", () => {
-    const tags = parseMaskTags([{ role: "user", content: "[mask-all] send" }]);
-    expect(tags.has("all")).toBe(true);
-  });
-
-  it("parses [mask-secret]", () => {
-    const tags = parseMaskTags([
-      { role: "user", content: "[mask-secret] here is my key" },
-    ]);
-    expect(tags.has("secret")).toBe(true);
-  });
-
-  it("parses [mask-pii]", () => {
-    const tags = parseMaskTags([{ role: "user", content: "[mask-pii] ok" }]);
-    expect(tags.has("pii")).toBe(true);
-  });
-
-  it("is case-insensitive", () => {
-    const tags = parseMaskTags([{ role: "user", content: "[Mask-Secret]" }]);
-    expect(tags.has("secret")).toBe(true);
-  });
-
-  it("ignores tags in assistant messages", () => {
-    const tags = parseMaskTags([
-      { role: "assistant", content: "[mask-all] assistant said this" },
-    ]);
-    expect(tags.size).toBe(0);
-  });
-
-  it("does not pick up [allow-xxx] tags", () => {
-    const tags = parseMaskTags([
-      { role: "user", content: "[allow-all] send anyway" },
-    ]);
-    expect(tags.size).toBe(0);
   });
 });
 
@@ -161,6 +114,7 @@ describe("resolveTagPriority", () => {
     );
     expect(effectiveMask.has("secret")).toBe(true);
     expect(effectiveMask.has("pii")).toBe(true);
+    expect(effectiveMask.has("all")).toBe(true);
     expect(effectiveAllow.size).toBe(0);
   });
 
@@ -177,6 +131,11 @@ describe("resolveTagPriority", () => {
   it("[allow-all] → effectiveAllow has 'all'", () => {
     const { effectiveAllow } = resolveTagPriority("[allow-all] key=abc");
     expect(effectiveAllow.has("all")).toBe(true);
+  });
+
+  it("[mask-all] → effectiveMask has 'all'", () => {
+    const { effectiveMask } = resolveTagPriority("[mask-all] key=abc");
+    expect(effectiveMask.has("all")).toBe(true);
   });
 
   it("is case-insensitive", () => {
@@ -203,7 +162,6 @@ describe("applyAllowTags", () => {
       category: "secret",
       matchRedacted: "AKIA****",
       secretValue: "AKIATEST",
-      location: "test",
     },
     {
       ruleId: "pii-email",
@@ -211,7 +169,6 @@ describe("applyAllowTags", () => {
       category: "pii",
       matchRedacted: "user****",
       secretValue: "user@example.com",
-      location: "test",
     },
   ];
 
@@ -256,7 +213,6 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST",
-        location: "a",
       },
       {
         ruleId: "aws-access-key",
@@ -264,7 +220,6 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST",
-        location: "b",
       },
     ];
     expect(dedupeFindings(findings)).toHaveLength(1);
@@ -278,7 +233,6 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST1",
-        location: "a",
       },
       {
         ruleId: "aws-access-key",
@@ -286,7 +240,6 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST2",
-        location: "b",
       },
     ];
     expect(dedupeFindings(findings)).toHaveLength(2);
@@ -304,7 +257,6 @@ describe("findingsToLines", () => {
         category: "secret",
         matchRedacted: "AKIA****MPLE",
         secretValue: "AKIAIOSFODNN7EXAMPLE",
-        location: "test",
       },
     ];
     const lines = findingsToLines(findings);
@@ -321,126 +273,9 @@ describe("findingsToLines", () => {
         category: "pii",
         matchRedacted: "user****",
         secretValue: "user@example.com",
-        location: "test",
       },
     ];
     const lines = findingsToLines(findings);
     expect(lines[0]).toBe("  [PII] Email Address (pii-email): user****");
-  });
-});
-
-// ── scanMessages ──────────────────────────────────────────────────────────────
-
-describe("scanMessages", () => {
-  it("detects a secret in a user message", () => {
-    const findings = scanMessages([
-      { role: "user", content: "my key is AKIAIOSFODNN7EXAMPLE" },
-    ]);
-    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
-  });
-
-  it("does not scan assistant messages", () => {
-    const findings = scanMessages([
-      {
-        role: "assistant",
-        content: "here is an example key: AKIAIOSFODNN7EXAMPLE",
-      },
-    ]);
-    expect(findings).toHaveLength(0);
-  });
-
-  it("respects [allow-all] in the same message", () => {
-    const findings = scanMessages([
-      {
-        role: "user",
-        content: "[allow-all] my key is AKIAIOSFODNN7EXAMPLE",
-      },
-    ]);
-    expect(findings).toHaveLength(0);
-  });
-
-  it("respects [allow-secret] to bypass a secret", () => {
-    const findings = scanMessages([
-      {
-        role: "user",
-        content: "[allow-secret] my key is AKIAIOSFODNN7EXAMPLE",
-      },
-    ]);
-    expect(findings).toHaveLength(0);
-  });
-
-  it("deduplicates the same secret appearing multiple times", () => {
-    const findings = scanMessages([
-      {
-        role: "user",
-        content: "key1=AKIAIOSFODNN7EXAMPLE key2=AKIAIOSFODNN7EXAMPLE",
-      },
-    ]);
-    const aws = findings.filter((f) => f.ruleId === "aws-access-key");
-    expect(aws).toHaveLength(1);
-  });
-
-  it("returns empty array for clean messages", () => {
-    const findings = scanMessages([
-      { role: "user", content: "hello, how are you?" },
-    ]);
-    expect(findings).toHaveLength(0);
-  });
-
-  it("detects a secret in ContentBlock[] content", () => {
-    const findings = scanMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "my key is AKIAIOSFODNN7EXAMPLE" }],
-      },
-    ]);
-    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
-  });
-
-  it("scans tool_result content (string) inside a user message", () => {
-    const findings = scanMessages([
-      {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            content: "key: AKIAIOSFODNN7EXAMPLE",
-          },
-        ],
-      },
-    ]);
-    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
-  });
-
-  it("scans tool_result content (ContentBlock[]) inside a user message", () => {
-    const findings = scanMessages([
-      {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            content: [{ type: "text", text: "key: AKIAIOSFODNN7EXAMPLE" }],
-          },
-        ],
-      },
-    ]);
-    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
-  });
-
-  it("scans across multiple user messages", () => {
-    const findings = scanMessages([
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "hi there" },
-      { role: "user", content: "my key is AKIAIOSFODNN7EXAMPLE" },
-    ]);
-    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
-  });
-
-  it("allow tag in one message applies to all messages", () => {
-    const findings = scanMessages([
-      { role: "user", content: "[allow-secret] first message" },
-      { role: "user", content: "my key is AKIAIOSFODNN7EXAMPLE" },
-    ]);
-    expect(findings).toHaveLength(0);
   });
 });

--- a/src/lib/__tests__/inspector.test.ts
+++ b/src/lib/__tests__/inspector.test.ts
@@ -6,6 +6,7 @@ import {
   findingsToLines,
   parseAllowTags,
   parseMaskTags,
+  resolveTagPriority,
   scanMessages,
 } from "../inspector.ts";
 
@@ -101,6 +102,94 @@ describe("parseMaskTags", () => {
       { role: "user", content: "[allow-all] send anyway" },
     ]);
     expect(tags.size).toBe(0);
+  });
+});
+
+// ── resolveTagPriority ────────────────────────────────────────────────────────
+
+describe("resolveTagPriority", () => {
+  it("returns empty sets when no tags are present", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority("hello world");
+    expect(effectiveAllow.size).toBe(0);
+    expect(effectiveMask.size).toBe(0);
+  });
+
+  it("[allow-secret] → effectiveAllow has 'secret'", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[allow-secret] key=abc",
+    );
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveMask.has("secret")).toBe(false);
+  });
+
+  it("[mask-secret] → effectiveMask has 'secret'", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[mask-secret] key=abc",
+    );
+    expect(effectiveMask.has("secret")).toBe(true);
+    expect(effectiveAllow.has("secret")).toBe(false);
+  });
+
+  it("[allow-secret] before [mask-secret] → allow wins for secret", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[allow-secret] [mask-secret] key=abc",
+    );
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveMask.has("secret")).toBe(false);
+  });
+
+  it("[mask-secret] before [allow-secret] → mask wins for secret", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[mask-secret] [allow-secret] key=abc",
+    );
+    expect(effectiveMask.has("secret")).toBe(true);
+    expect(effectiveAllow.has("secret")).toBe(false);
+  });
+
+  it("[allow-all] before [mask-secret] → allow wins for both dimensions", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[allow-all] [mask-secret] key=abc",
+    );
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveAllow.has("pii")).toBe(true);
+    expect(effectiveMask.size).toBe(0);
+  });
+
+  it("[mask-all] before [allow-secret] → mask wins for both dimensions", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[mask-all] [allow-secret] key=abc",
+    );
+    expect(effectiveMask.has("secret")).toBe(true);
+    expect(effectiveMask.has("pii")).toBe(true);
+    expect(effectiveAllow.size).toBe(0);
+  });
+
+  it("[allow-secret] [mask-pii] → allow for secret, mask for pii", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[allow-secret] [mask-pii] ...",
+    );
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveMask.has("pii")).toBe(true);
+    expect(effectiveAllow.has("pii")).toBe(false);
+    expect(effectiveMask.has("secret")).toBe(false);
+  });
+
+  it("[allow-all] → effectiveAllow has 'all'", () => {
+    const { effectiveAllow } = resolveTagPriority("[allow-all] key=abc");
+    expect(effectiveAllow.has("all")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    const { effectiveAllow } = resolveTagPriority("[Allow-Secret] key=abc");
+    expect(effectiveAllow.has("secret")).toBe(true);
+  });
+
+  it("unknown tag suffix is ignored", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[allow-unknown] key=abc",
+    );
+    expect(effectiveAllow.size).toBe(0);
+    expect(effectiveMask.size).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -64,78 +64,140 @@ describe("redact", () => {
 
 describe("scan — secrets", () => {
   it("detects an AWS Access Key ID", () => {
-    const findings = scan("key=AKIAIOSFODNN7EXAMPLE", "test");
+    const findings = scan("key=AKIAIOSFODNN7EXAMPLE");
     expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
   });
 
   it("detects a PEM private key header (RSA)", () => {
-    const findings = scan("-----BEGIN RSA PRIVATE KEY-----", "test");
+    const findings = scan("-----BEGIN RSA PRIVATE KEY-----");
     expect(findings.some((f) => f.ruleId === "private-key")).toBe(true);
   });
 
   it("detects an OpenSSH private key header via private-key rule", () => {
-    const findings = scan("-----BEGIN OPENSSH PRIVATE KEY-----", "test");
+    const findings = scan("-----BEGIN OPENSSH PRIVATE KEY-----");
     expect(findings.some((f) => f.ruleId === "private-key")).toBe(true);
   });
 
   it("detects a GitHub PAT", () => {
-    const findings = scan(`token=ghp_${"A".repeat(36)}`, "test");
+    const findings = scan(`token=ghp_${"A".repeat(36)}`);
     expect(findings.some((f) => f.ruleId === "github-pat")).toBe(true);
   });
 
+  it("detects a GitHub fine-grained token", () => {
+    const findings = scan(`github_pat_${"A".repeat(82)}`);
+    expect(findings.some((f) => f.ruleId === "github-fine-grained")).toBe(true);
+  });
+
   it("detects a GitLab PAT", () => {
-    const findings = scan(`token=glpat-${"A".repeat(20)}`, "test");
+    const findings = scan(`token=glpat-${"A".repeat(20)}`);
     expect(findings.some((f) => f.ruleId === "gitlab-pat")).toBe(true);
   });
 
   it("detects a Slack token", () => {
-    const findings = scan("xoxb-123456789012-ABCDEFGHIJ", "test");
+    const findings = scan("xoxb-123456789012-ABCDEFGHIJ");
     expect(findings.some((f) => f.ruleId === "slack-token")).toBe(true);
   });
 
-  it("detects a Stripe secret key", () => {
-    const findings = scan(`sk_live_${"A".repeat(24)}`, "test");
-    expect(findings.some((f) => f.ruleId === "stripe-secret-key")).toBe(true);
+  it("detects a Slack webhook URL", () => {
+    const findings = scan(
+      `https://hooks.slack.com/services/TABCDEFGH/BABCDEFGHIJ/${"A".repeat(24)}`,
+    );
+    expect(findings.some((f) => f.ruleId === "slack-webhook")).toBe(true);
+  });
+
+  it("detects a Discord webhook URL", () => {
+    const findings = scan(
+      `https://discord.com/api/webhooks/123456789012345678/${"A".repeat(68)}`,
+    );
+    expect(findings.some((f) => f.ruleId === "discord-webhook")).toBe(true);
+  });
+
+  it("detects a Telegram bot token", () => {
+    const findings = scan(`12345678:AA${"A".repeat(33)}`);
+    expect(findings.some((f) => f.ruleId === "telegram-bot-token")).toBe(true);
+  });
+
+  it("detects a Twilio Account SID", () => {
+    const findings = scan(`AC${"a".repeat(32)}`);
+    expect(findings.some((f) => f.ruleId === "twilio-sid")).toBe(true);
   });
 
   it("detects a SendGrid API key", () => {
-    const findings = scan(`SG.${"A".repeat(22)}.${"B".repeat(43)}`, "test");
+    const findings = scan(`SG.${"A".repeat(22)}.${"B".repeat(43)}`);
     expect(findings.some((f) => f.ruleId === "sendgrid-key")).toBe(true);
+  });
+
+  it("detects a Mailgun API key", () => {
+    const findings = scan(`key-${"a".repeat(32)}`);
+    expect(findings.some((f) => f.ruleId === "mailgun-key")).toBe(true);
+  });
+
+  it("detects a Mailchimp API key", () => {
+    const findings = scan(`${"a".repeat(32)}-us1`);
+    expect(findings.some((f) => f.ruleId === "mailchimp-key")).toBe(true);
+  });
+
+  it("detects a Stripe secret key", () => {
+    const findings = scan(`sk_live_${"A".repeat(24)}`);
+    expect(findings.some((f) => f.ruleId === "stripe-secret-key")).toBe(true);
+  });
+
+  it("detects a Stripe restricted key", () => {
+    const findings = scan(`rk_test_${"A".repeat(24)}`);
+    expect(findings.some((f) => f.ruleId === "stripe-restricted-key")).toBe(
+      true,
+    );
+  });
+
+  it("detects an OpenAI legacy API key", () => {
+    const findings = scan(`sk-${"A".repeat(48)}`);
+    expect(findings.some((f) => f.ruleId === "openai-key")).toBe(true);
+  });
+
+  it("detects an OpenAI project API key", () => {
+    const findings = scan("sk-proj-Xk9mP2qR7vL4nW1sYj3cBz8dEf5gHiKoNpQuTxMn");
+    expect(findings.some((f) => f.ruleId === "openai-project-key")).toBe(true);
+  });
+
+  it("detects an Anthropic API key", () => {
+    const findings = scan(`sk-ant-${"A".repeat(95)}`);
+    expect(findings.some((f) => f.ruleId === "anthropic-key")).toBe(true);
   });
 
   it("detects a JWT", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
-    const findings = scan(jwt, "test");
+    const findings = scan(jwt);
     expect(findings.some((f) => f.ruleId === "jwt")).toBe(true);
   });
 
-  it("detects an OpenAI project API key", () => {
-    // 40 chars after prefix (meets {40,} minimum), high entropy
-    const findings = scan(
-      "sk-proj-Xk9mP2qR7vL4nW1sYj3cBz8dEf5gHiKoNpQuTxMn",
-      "test",
-    );
-    expect(findings.some((f) => f.ruleId === "openai-project-key")).toBe(true);
+  it("detects a generic API key assignment with sufficient entropy", () => {
+    const findings = scan("api_key=Xk9mP2qR7vL4nW1sYj3cBz8dEf5g");
+    expect(findings.some((f) => f.ruleId === "generic-secret")).toBe(true);
+  });
+
+  it("does not flag a low-entropy generic API key value", () => {
+    const findings = scan("api_key=placeholder");
+    expect(findings.some((f) => f.ruleId === "generic-secret")).toBe(false);
   });
 
   it("detects a database connection string with credentials", () => {
-    const findings = scan("postgres://user:password@localhost/mydb", "test");
+    const findings = scan("postgres://user:password@localhost/mydb");
     expect(findings.some((f) => f.ruleId === "connection-string")).toBe(true);
   });
 
   it("detects an .env style assignment with sufficient entropy", () => {
-    const findings = scan("DATABASE_PASSWORD=Xk9mP2qR7vL4nW1s", "test");
+    const findings = scan("DATABASE_PASSWORD=Xk9mP2qR7vL4nW1s");
     expect(findings.some((f) => f.ruleId === "env-assignment")).toBe(true);
   });
 
   it("does not flag a low-entropy .env value", () => {
-    const findings = scan("DATABASE_PASSWORD=password", "test");
+    const findings = scan("DATABASE_PASSWORD=password");
     expect(findings.some((f) => f.ruleId === "env-assignment")).toBe(false);
   });
 
   it("returns no findings for clean text", () => {
-    expect(scan("hello world, nothing sensitive here", "test")).toHaveLength(0);
+    expect(scan("hello world, nothing sensitive here")).toHaveLength(0);
   });
 });
 
@@ -143,80 +205,118 @@ describe("scan — secrets", () => {
 
 describe("scan — PII", () => {
   it("detects an email address", () => {
-    const findings = scan("contact: user@example.com", "test");
+    const findings = scan("contact: user@example.com");
     expect(findings.some((f) => f.ruleId === "pii-email")).toBe(true);
   });
 
   it("detects a valid credit card number — no separators", () => {
-    const findings = scan("card: 4111111111111111", "test");
+    const findings = scan("card: 4111111111111111");
     expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(true);
   });
 
   it("detects a valid credit card number — space separated", () => {
-    const findings = scan("card: 4111 1111 1111 1111", "test");
+    const findings = scan("card: 4111 1111 1111 1111");
     expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(true);
   });
 
   it("detects a valid credit card number — hyphen separated", () => {
-    const findings = scan("card: 4111-1111-1111-1111", "test");
+    const findings = scan("card: 4111-1111-1111-1111");
     expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(true);
   });
 
   it("does not flag an invalid credit card number", () => {
-    const findings = scan("card: 4111111111111112", "test");
+    const findings = scan("card: 4111111111111112");
     expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(false);
   });
 
   it("detects a US SSN", () => {
-    const findings = scan("ssn: 123-45-6789", "test");
+    const findings = scan("ssn: 123-45-6789");
     expect(findings.some((f) => f.ruleId === "pii-ssn")).toBe(true);
   });
 
-  it("does not flag an SSN starting with 000", () => {
-    expect(
-      scan("ssn: 000-45-6789", "test").some((f) => f.ruleId === "pii-ssn"),
-    ).toBe(false);
+  it("does not flag an SSN with area 000", () => {
+    expect(scan("ssn: 000-45-6789").some((f) => f.ruleId === "pii-ssn")).toBe(
+      false,
+    );
   });
 
-  it("does not flag an SSN starting with 666", () => {
-    expect(
-      scan("ssn: 666-45-6789", "test").some((f) => f.ruleId === "pii-ssn"),
-    ).toBe(false);
+  it("does not flag an SSN with area 666", () => {
+    expect(scan("ssn: 666-45-6789").some((f) => f.ruleId === "pii-ssn")).toBe(
+      false,
+    );
   });
 
-  it("does not flag an SSN starting with 9xx", () => {
-    expect(
-      scan("ssn: 900-45-6789", "test").some((f) => f.ruleId === "pii-ssn"),
-    ).toBe(false);
+  it("does not flag an SSN with area 9xx", () => {
+    expect(scan("ssn: 900-45-6789").some((f) => f.ruleId === "pii-ssn")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag an SSN with group 00", () => {
+    expect(scan("ssn: 123-00-6789").some((f) => f.ruleId === "pii-ssn")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag an SSN with serial 0000", () => {
+    expect(scan("ssn: 123-45-0000").some((f) => f.ruleId === "pii-ssn")).toBe(
+      false,
+    );
   });
 
   it("detects a US phone number", () => {
-    const findings = scan("call: (555) 123-4567", "test");
+    const findings = scan("call: (555) 123-4567");
     expect(findings.some((f) => f.ruleId === "pii-phone-us")).toBe(true);
   });
 
   it("detects a Japanese phone number", () => {
-    const findings = scan("tel: 03-1234-5678", "test");
+    const findings = scan("tel: 03-1234-5678");
     expect(findings.some((f) => f.ruleId === "pii-phone-jp")).toBe(true);
   });
 
   it("detects a Japanese postal code with 〒 prefix", () => {
-    const findings = scan("address: 〒150-0001", "test");
+    const findings = scan("address: 〒150-0001");
     expect(findings.some((f) => f.ruleId === "pii-postal-jp")).toBe(true);
   });
 
   it("does not flag a postal-like number without 〒", () => {
-    const findings = scan("zip: 150-0001", "test");
+    const findings = scan("zip: 150-0001");
     expect(findings.some((f) => f.ruleId === "pii-postal-jp")).toBe(false);
   });
 
-  it("detects a private IPv4 address", () => {
-    const findings = scan("server: 192.168.1.100", "test");
+  it("detects a 192.168.x.x private IPv4 address", () => {
+    const findings = scan("server: 192.168.1.100");
     expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(true);
   });
 
+  it("detects a 10.x.x.x private IPv4 address", () => {
+    const findings = scan("server: 10.0.0.1");
+    expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(true);
+  });
+
+  it("detects a 172.16–31.x.x private IPv4 address", () => {
+    expect(scan("host: 172.16.0.1").some((f) => f.ruleId === "pii-ipv4")).toBe(
+      true,
+    );
+    expect(
+      scan("host: 172.31.255.255").some((f) => f.ruleId === "pii-ipv4"),
+    ).toBe(true);
+  });
+
+  it("does not flag 172.15.x.x (outside private range)", () => {
+    expect(scan("host: 172.15.1.1").some((f) => f.ruleId === "pii-ipv4")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag 172.32.x.x (outside private range)", () => {
+    expect(scan("host: 172.32.1.1").some((f) => f.ruleId === "pii-ipv4")).toBe(
+      false,
+    );
+  });
+
   it("does not flag a public IPv4 address", () => {
-    const findings = scan("server: 8.8.8.8", "test");
+    const findings = scan("server: 8.8.8.8");
     expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(false);
   });
 });

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -73,6 +73,53 @@ export function parseMaskTags(messages: Message[]): Set<string> {
 }
 
 /**
+ * Resolve effective allow and mask tags based on first-occurrence priority.
+ *
+ * For each category dimension ("secret", "pii"), the first matching tag wins.
+ * [allow-all] / [mask-all] resolve both dimensions at once.
+ *
+ * Examples:
+ *   "[allow-secret] [mask-secret] ..." → secret: allow (allow came first)
+ *   "[mask-secret] [allow-secret] ..." → secret: mask  (mask came first)
+ *   "[allow-all]   [mask-secret] ..." → secret: allow, pii: allow
+ *   "[allow-secret] [mask-pii]   ..." → secret: allow, pii: mask
+ */
+export function resolveTagPriority(prompt: string): {
+  effectiveAllow: Set<string>;
+  effectiveMask: Set<string>;
+} {
+  const pattern = /\[(allow|mask)-(all|secret|pii)\]/gi;
+  const effectiveAllow = new Set<string>();
+  const effectiveMask = new Set<string>();
+  const resolved = new Set<string>(); // dimensions already decided: "secret", "pii"
+
+  for (const [, kind, tag] of prompt.matchAll(pattern)) {
+    if (!kind || !tag) continue;
+    const dimensions: string[] =
+      tag.toLowerCase() === "all" ? ["secret", "pii"] : [tag.toLowerCase()];
+
+    for (const dim of dimensions) {
+      if (!resolved.has(dim)) {
+        resolved.add(dim);
+        if (kind.toLowerCase() === "allow") {
+          effectiveAllow.add(dim);
+        } else {
+          effectiveMask.add(dim);
+        }
+      }
+    }
+  }
+
+  // Add "all" to effectiveAllow when both dimensions are allowed
+  // (applyAllowTags checks allowTags.has("all") for a fast-path return)
+  if (effectiveAllow.has("secret") && effectiveAllow.has("pii")) {
+    effectiveAllow.add("all");
+  }
+
+  return { effectiveAllow, effectiveMask };
+}
+
+/**
  * Filter findings by allow tags.
  */
 export function applyAllowTags(

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -1,9 +1,9 @@
-import { type Finding, scan } from "./rules.ts";
+import type { Finding } from "./rules.ts";
 
-const BIRD_EMOJIS = ["🐦", "🐧", "🐤", "🐔"] as const;
+const BIRD_EMOJIS = ["🐦", "🐧", "🐤", "🐔"];
 
 export function randomBird(): string {
-  return BIRD_EMOJIS[Math.floor(Math.random() * BIRD_EMOJIS.length)] as string;
+  return BIRD_EMOJIS[Math.floor(Math.random() * BIRD_EMOJIS.length)] ?? "🐦";
 }
 
 export type { Finding };
@@ -21,25 +21,18 @@ export interface Message {
   content: string | ContentBlock[];
 }
 
-/**
- * Parse [prefix-xxx] tags from user message texts.
- */
 function parseTagsOfType(prefix: string, messages: Message[]): Set<string> {
   const tags = new Set<string>();
-  if (!Array.isArray(messages)) return tags;
-
   const pattern = new RegExp(`\\[${prefix}-([^\\]]+)\\]`, "gi");
 
   for (const msg of messages) {
     if (msg.role !== "user") continue;
-    const texts: string[] =
+    const texts =
       typeof msg.content === "string"
         ? [msg.content]
-        : Array.isArray(msg.content)
-          ? (msg.content as ContentBlock[])
-              .filter((b): b is TextBlock => b.type === "text")
-              .map((b) => b.text)
-          : [];
+        : msg.content
+            .filter((b): b is TextBlock => b.type === "text")
+            .map((b) => b.text);
 
     for (const text of texts) {
       for (const [, tag] of text.matchAll(pattern)) {
@@ -50,40 +43,17 @@ function parseTagsOfType(prefix: string, messages: Message[]): Set<string> {
   return tags;
 }
 
-/**
- * Parse [allow-xxx] bypass tags from user message texts.
- * Supported forms:
- *   [allow-all]    — skip all rules
- *   [allow-pii]    — skip all PII rules
- *   [allow-secret] — skip all secret rules
- */
 export function parseAllowTags(messages: Message[]): Set<string> {
   return parseTagsOfType("allow", messages);
 }
 
-/**
- * Parse [mask-xxx] tags from user message texts.
- * Supported forms:
- *   [mask-all]    — mask all sensitive data
- *   [mask-pii]    — mask PII
- *   [mask-secret] — mask secrets
- */
-export function parseMaskTags(messages: Message[]): Set<string> {
-  return parseTagsOfType("mask", messages);
-}
-
-/**
- * Resolve effective allow and mask tags based on first-occurrence priority.
- *
- * For each category dimension ("secret", "pii"), the first matching tag wins.
- * [allow-all] / [mask-all] resolve both dimensions at once.
- *
- * Examples:
- *   "[allow-secret] [mask-secret] ..." → secret: allow (allow came first)
- *   "[mask-secret] [allow-secret] ..." → secret: mask  (mask came first)
- *   "[allow-all]   [mask-secret] ..." → secret: allow, pii: allow
- *   "[allow-secret] [mask-pii]   ..." → secret: allow, pii: mask
- */
+// Resolve effective allow/mask tags based on first-occurrence priority.
+// For each category dimension ("secret", "pii"), the first matching tag wins.
+// [allow-all] / [mask-all] resolve both dimensions at once.
+//
+//   "[allow-secret] [mask-secret] ..." → secret: allow
+//   "[mask-secret] [allow-secret] ..." → secret: mask
+//   "[allow-secret] [mask-pii]   ..." → secret: allow, pii: mask
 export function resolveTagPriority(prompt: string): {
   effectiveAllow: Set<string>;
   effectiveMask: Set<string>;
@@ -91,37 +61,32 @@ export function resolveTagPriority(prompt: string): {
   const pattern = /\[(allow|mask)-(all|secret|pii)\]/gi;
   const effectiveAllow = new Set<string>();
   const effectiveMask = new Set<string>();
-  const resolved = new Set<string>(); // dimensions already decided: "secret", "pii"
+  const resolved = new Set<string>();
 
   for (const [, kind, tag] of prompt.matchAll(pattern)) {
     if (!kind || !tag) continue;
-    const dimensions: string[] =
-      tag.toLowerCase() === "all" ? ["secret", "pii"] : [tag.toLowerCase()];
+    const k = kind.toLowerCase() as "allow" | "mask";
+    const t = tag.toLowerCase();
+    const dims = t === "all" ? ["secret", "pii"] : [t];
 
-    for (const dim of dimensions) {
+    for (const dim of dims) {
       if (!resolved.has(dim)) {
         resolved.add(dim);
-        if (kind.toLowerCase() === "allow") {
-          effectiveAllow.add(dim);
-        } else {
-          effectiveMask.add(dim);
-        }
+        (k === "allow" ? effectiveAllow : effectiveMask).add(dim);
       }
     }
   }
 
-  // Add "all" to effectiveAllow when both dimensions are allowed
-  // (applyAllowTags checks allowTags.has("all") for a fast-path return)
   if (effectiveAllow.has("secret") && effectiveAllow.has("pii")) {
     effectiveAllow.add("all");
+  }
+  if (effectiveMask.has("secret") && effectiveMask.has("pii")) {
+    effectiveMask.add("all");
   }
 
   return { effectiveAllow, effectiveMask };
 }
 
-/**
- * Filter findings by allow tags.
- */
 export function applyAllowTags(
   findings: Finding[],
   allowTags: Set<string>,
@@ -131,9 +96,6 @@ export function applyAllowTags(
   return findings.filter((f) => !allowTags.has(f.category));
 }
 
-/**
- * Deduplicate findings by secretValue, keeping the first occurrence.
- */
 export function dedupeFindings(findings: Finding[]): Finding[] {
   const seen = new Set<string>();
   return findings.filter((f) => {
@@ -143,96 +105,9 @@ export function dedupeFindings(findings: Finding[]): Finding[] {
   });
 }
 
-/**
- * Format findings as human-readable lines for display.
- */
 export function findingsToLines(findings: Finding[]): string[] {
   return findings.map((f) => {
     const tag = f.category === "pii" ? "PII" : "Secret";
     return `  [${tag}] ${f.description} (${f.ruleId}): ${f.matchRedacted}`;
   });
-}
-
-/**
- * Extract plain text strings from a single message content value.
- */
-function extractTexts(
-  content: string | ContentBlock[],
-  basePath: string,
-): Array<{ text: string; location: string }> {
-  const results: Array<{ text: string; location: string }> = [];
-
-  if (typeof content === "string") {
-    results.push({ text: content, location: basePath });
-    return results;
-  }
-
-  if (!Array.isArray(content)) return results;
-
-  for (let i = 0; i < content.length; i++) {
-    const block = content[i];
-    const path = `${basePath}[${i}]`;
-
-    if (!block || typeof block !== "object") continue;
-
-    if (block.type === "text") {
-      results.push({ text: block.text, location: `${path}.text` });
-    } else if (block.type === "tool_result") {
-      const inner = block.content;
-      if (typeof inner === "string") {
-        results.push({ text: inner, location: `${path}.content` });
-      } else if (Array.isArray(inner)) {
-        for (let j = 0; j < inner.length; j++) {
-          const ib = inner[j];
-          if (ib && ib.type === "text") {
-            results.push({
-              text: (ib as TextBlock).text,
-              location: `${path}.content[${j}].text`,
-            });
-          }
-        }
-      }
-    } else if (block.type === "tool_use") {
-      if (block.input && typeof block.input === "object") {
-        results.push({
-          text: JSON.stringify(block.input),
-          location: `${path}.input`,
-        });
-      }
-    }
-  }
-
-  return results;
-}
-
-/**
- * Scan all user messages for secrets/PII, respecting allow tags.
- */
-export function scanMessages(messages: Message[]): Finding[] {
-  if (!Array.isArray(messages)) return [];
-
-  const allowTags = parseAllowTags(messages);
-  const findings: Finding[] = [];
-  const seen = new Set<string>();
-
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (!msg || !msg.content) continue;
-    if (msg.role !== "user") continue;
-
-    const texts = extractTexts(msg.content, `messages[${i}].content`);
-
-    for (const { text, location } of texts) {
-      const results = scan(text, location);
-      for (const finding of results) {
-        const key = `${finding.ruleId}:${finding.secretValue}`;
-        if (!seen.has(key)) {
-          seen.add(key);
-          findings.push(finding);
-        }
-      }
-    }
-  }
-
-  return applyAllowTags(findings, allowTags);
 }

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -4,7 +4,6 @@ export interface Finding {
   category: "secret" | "pii";
   matchRedacted: string;
   secretValue: string;
-  location: string;
 }
 
 interface Rule {
@@ -17,10 +16,7 @@ interface Rule {
   category: "secret" | "pii";
 }
 
-/**
- * Luhn algorithm checksum validation for credit card numbers.
- * Returns true if the number (digits only) passes the Luhn check.
- */
+// Luhn algorithm checksum validation. Returns true if the number (digits only) passes.
 export function luhn(str: string): boolean {
   const digits = str.replace(/\D/g, "");
   let sum = 0;
@@ -37,9 +33,7 @@ export function luhn(str: string): boolean {
   return sum % 10 === 0;
 }
 
-/**
- * Shannon entropy of a string (bits per character, 0-8 scale)
- */
+// Shannon entropy (bits per character, 0–8 scale)
 export function entropy(str: string): number {
   if (str.length === 0) return 0;
   const freq: Record<string, number> = {};
@@ -53,18 +47,11 @@ export function entropy(str: string): number {
   return h;
 }
 
-/**
- * Secret and PII detection rules.
- * Patterns are sourced from gitleaks and TruffleHog detector definitions.
- *
- * Each rule:
- *   id               - unique identifier
- *   description      - human-readable name
- *   regex            - RegExp (with /g flag) to match against text
- *   secretGroup      - capture group index containing the secret (default: 0 = full match)
- *   entropyThreshold - minimum entropy required (optional, to reduce false positives)
- *   category         - 'secret' | 'pii'
- */
+// Patterns sourced from gitleaks and TruffleHog detector definitions.
+// Each rule:
+//   regex        — must have /g flag
+//   secretGroup  — capture group containing the secret (default: 0 = full match)
+//   entropyThreshold — skip match if entropy(secretValue) is below threshold
 
 // ── Secrets ───────────────────────────────────────────────────────────────────
 
@@ -285,27 +272,17 @@ const PII_RULES: Rule[] = [
 
 export const RULES: Rule[] = [...SECRET_RULES, ...PII_RULES];
 
-/**
- * Redact a matched string: show first 4 + **** + last 4 chars
- */
+// Show first 4 + **** + last 4 chars; fully mask strings of 8 chars or fewer
 export function redact(str: string): string {
-  if (!str) return "****";
   if (str.length <= 8) return "****";
   return `${str.slice(0, 4)}****${str.slice(-4)}`;
 }
 
-/**
- * Scan text with all rules, return array of findings.
- */
-export function scan(text: string, location: string): Finding[] {
+export function scan(text: string): Finding[] {
   const findings: Finding[] = [];
 
   for (const rule of RULES) {
-    rule.regex.lastIndex = 0;
-
-    let match: RegExpExecArray | null;
-    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop pattern
-    while ((match = rule.regex.exec(text)) !== null) {
+    for (const match of text.matchAll(rule.regex)) {
       const secretValue =
         rule.secretGroup != null ? match[rule.secretGroup] : match[0];
 
@@ -323,7 +300,6 @@ export function scan(text: string, location: string): Finding[] {
         category: rule.category,
         matchRedacted: redact(secretValue),
         secretValue,
-        location,
       });
     }
   }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -1,26 +1,5 @@
 #!/usr/bin/env node
 
-/**
- * Claude Code PreToolUse hook.
- *
- * For Read tool calls and file-reading Bash commands (cat, head, tail, …):
- *   - Block if the file is a .env file
- *   - Block if the file contents contain secrets or PII
- *
- * For Bash tool calls in general:
- *   - Block if the command string itself contains secrets or PII
- *     (e.g. `echo AKIAIOSFODNN7EXAMPLE`)
- *   - Block if a referenced env var ($TOKEN) contains secrets or PII
- *
- * Allow tags: if the user's most recent prompt includes an [allow-xxx] tag,
- * the corresponding block is bypassed.  The hook reads allow tags from the
- * session transcript supplied via transcript_path.
- *
- * Exit codes:
- *   0 - allow
- *   2 - block
- */
-
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -42,6 +21,10 @@ interface HookInput {
   };
 }
 
+interface TranscriptLine {
+  message?: Message;
+}
+
 // ── Transcript ────────────────────────────────────────────────────────────────
 
 // Load allow tags from the Claude Code session transcript.
@@ -56,25 +39,15 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
     return new Set();
   }
 
-  // Collect all user messages, then take only the last one
   let lastUserMessage: Message | null = null;
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-      // biome-ignore lint/complexity/useLiteralKeys: bracket notation required by noPropertyAccessFromIndexSignature
-      const msg = parsed["message"] as Record<string, unknown> | undefined;
-      if (
-        msg &&
-        // biome-ignore lint/complexity/useLiteralKeys: bracket notation required by noPropertyAccessFromIndexSignature
-        typeof msg["role"] === "string" &&
-        // biome-ignore lint/complexity/useLiteralKeys: bracket notation required by noPropertyAccessFromIndexSignature
-        msg["role"] === "user" &&
-        // biome-ignore lint/complexity/useLiteralKeys: bracket notation required by noPropertyAccessFromIndexSignature
-        msg["content"] !== undefined
-      ) {
-        lastUserMessage = msg as unknown as Message;
+      const parsed = JSON.parse(trimmed) as TranscriptLine;
+      const msg = parsed.message;
+      if (msg?.role === "user" && msg.content !== undefined) {
+        lastUserMessage = msg;
       }
     } catch {
       // skip malformed lines
@@ -87,7 +60,6 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
 
 // ── Bash helpers ──────────────────────────────────────────────────────────────
 
-// Bash commands that read file contents
 const FILE_READ_COMMANDS = new Set([
   "cat",
   "head",
@@ -98,29 +70,19 @@ const FILE_READ_COMMANDS = new Set([
   "nl",
 ]);
 
-/**
- * Extract environment variable names referenced in a shell command string.
- * Matches $VAR and ${VAR} but ignores special variables like $?, $!, $$, $0.
- */
 function extractEnvVarNames(command: string): string[] {
   const names = new Set<string>();
   const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
-  let match: RegExpExecArray | null;
-  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
-  while ((match = re.exec(command)) !== null) {
-    names.add((match[1] ?? match[2]) as string);
+  for (const match of command.matchAll(re)) {
+    const name = match[1] ?? match[2];
+    if (name) names.add(name);
   }
   return [...names];
 }
 
-/**
- * Extract file paths targeted by file-reading commands in a shell command string.
- * Handles compound commands split by |, ;, &&, ||.
- */
 function extractFilePathsFromCommand(command: string): string[] {
   const paths: string[] = [];
-  // Split compound commands into segments
-  const segments = command.split(/\s*(?:[|;&]|&&|\|\|)\s*/);
+  const segments = command.split(/\s*[|;&]+\s*/);
 
   for (const seg of segments) {
     const tokens = seg.trim().split(/\s+/).filter(Boolean);
@@ -137,9 +99,7 @@ function extractFilePathsFromCommand(command: string): string[] {
       }
       const tok = tokens[i];
       if (!tok) continue;
-      // Skip flags
       if (tok.startsWith("-")) continue;
-      // Skip redirect operators and their target
       if (tok === ">" || tok === ">>" || tok === "<") {
         skipNext = true;
         continue;
@@ -181,11 +141,14 @@ function buildAllowHints(
   lines.push("  [allow-all]     — bypass all sensitive-canary checks");
   lines.push("");
 
-  const example = hasSecret
-    ? "allow-secret"
-    : hasPii
-      ? "allow-pii"
-      : "allow-all";
+  const example =
+    hasSecret && hasPii
+      ? "allow-all"
+      : hasSecret
+        ? "allow-secret"
+        : hasPii
+          ? "allow-pii"
+          : "allow-all";
   lines.push(`Example: "[${example}] ${exampleContext}"`);
 
   return lines;
@@ -196,7 +159,6 @@ function block(
   detectionLines: string[],
   allowHints: string[],
 ): never {
-  // Human-readable message for the terminal
   const terminalMessage = [
     "",
     `${randomBird()} sensitive-canary: blocked — ${source}`,
@@ -205,7 +167,6 @@ function block(
     "",
   ].join("\n");
 
-  // Write directly to /dev/tty so the user always sees the message
   try {
     const fd = fs.openSync("/dev/tty", "w");
     fs.writeSync(fd, terminalMessage);
@@ -214,7 +175,6 @@ function block(
     process.stderr.write(terminalMessage);
   }
 
-  // Structured reason for Claude — explain the block and how to allow it
   const reasonLines = [
     `sensitive-canary blocked: ${source}`,
     "",
@@ -238,8 +198,6 @@ function block(
 // ── Core scan logic ───────────────────────────────────────────────────────────
 
 function scanFile(filePath: string, allowTags: Set<string>): void {
-  // 1. .env / .env.* — blocked unconditionally by name.
-  //    Any allow tag ([allow-secret], [allow-pii], [allow-all]) bypasses this.
   if (isBlockedEnvFile(filePath)) {
     if (allowTags.size > 0) return;
     block(
@@ -251,18 +209,14 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
     );
   }
 
-  // 2. Read and scan contents for secrets/PII.
   let content: string;
   try {
     content = fs.readFileSync(filePath, "utf8");
   } catch {
-    return; // file unreadable — let the tool handle the error
+    return;
   }
 
-  const findings = applyAllowTags(
-    dedupeFindings(scan(content, filePath)),
-    allowTags,
-  );
+  const findings = applyAllowTags(dedupeFindings(scan(content)), allowTags);
   if (findings.length === 0) return;
 
   block(
@@ -292,29 +246,22 @@ process.stdin.on("end", () => {
   const tool = data.tool_name ?? "";
   const input = data.tool_input ?? {};
 
-  // Load allow tags from the session transcript (empty set if unavailable)
   const allowTags = data.transcript_path
     ? loadAllowTagsFromTranscript(data.transcript_path)
     : new Set<string>();
 
-  // ── Read tool ──────────────────────────────────────────────────────────────
   if (tool === "Read") {
     scanFile(input.file_path ?? "", allowTags);
     process.exit(0);
   }
 
-  // ── Bash tool ──────────────────────────────────────────────────────────────
   if (tool === "Bash") {
     const command = input.command ?? "";
 
-    // 1. Expand env vars referenced in the command and scan their values
     for (const varName of extractEnvVarNames(command)) {
       const value = process.env[varName];
       if (!value) continue;
-      const findings = applyAllowTags(
-        dedupeFindings(scan(value, `$${varName}`)),
-        allowTags,
-      );
+      const findings = applyAllowTags(dedupeFindings(scan(value)), allowTags);
       if (findings.length === 0) continue;
       block(
         `bash command: ${command.slice(0, 80)}`,
@@ -327,9 +274,8 @@ process.stdin.on("end", () => {
       );
     }
 
-    // 2. Scan the command string itself (catches inline literals like `echo AKIA…`)
     const cmdFindings = applyAllowTags(
-      dedupeFindings(scan(command, "(bash command)")),
+      dedupeFindings(scan(command)),
       allowTags,
     );
     if (cmdFindings.length > 0) {
@@ -344,7 +290,6 @@ process.stdin.on("end", () => {
       );
     }
 
-    // 3. For file-reading commands, scan each referenced file
     for (const fp of extractFilePathsFromCommand(command)) {
       scanFile(fp, allowTags);
     }
@@ -352,6 +297,5 @@ process.stdin.on("end", () => {
     process.exit(0);
   }
 
-  // All other tools — allow
   process.exit(0);
 });

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -13,9 +13,8 @@ import {
   dedupeFindings,
   type Finding,
   findingsToLines,
-  parseAllowTags,
-  parseMaskTags,
   randomBird,
+  resolveTagPriority,
 } from "./lib/inspector.ts";
 import { scan } from "./lib/rules.ts";
 
@@ -36,63 +35,69 @@ process.stdin.on("end", () => {
 
   const prompt = data.prompt ?? "";
 
-  const messages = [{ role: "user", content: prompt }];
-
   // Scan for secrets/PII
   const allFindings = scan(prompt, "prompt");
 
   if (allFindings.length === 0) process.exit(0);
 
-  // [mask-xxx] tag: prompt masking is not supported — inform user
-  const maskTags = parseMaskTags(messages);
-  if (maskTags.size > 0) {
-    const maskCoversSecret = maskTags.has("all") || maskTags.has("secret");
-    const maskCoversPii = maskTags.has("all") || maskTags.has("pii");
-    const maskableFindings = allFindings.filter(
-      (f) =>
-        (f.category === "secret" && maskCoversSecret) ||
-        (f.category === "pii" && maskCoversPii),
-    );
+  // Resolve effective allow/mask tags based on first-occurrence priority.
+  // For each category dimension, whichever tag type appears first in the
+  // prompt wins. [allow-all] / [mask-all] resolve both dimensions at once.
+  const { effectiveAllow, effectiveMask } = resolveTagPriority(prompt);
 
-    if (maskableFindings.length > 0) {
-      const hasSecret = maskableFindings.some((f) => f.category === "secret");
-      const hasPii = maskableFindings.some((f) => f.category === "pii");
-      const usedTags = ["all", "secret", "pii"]
-        .filter((t) => maskTags.has(t))
-        .map((t) => `[mask-${t}]`)
-        .join(", ");
-      const maskBlockLines = [
-        "",
-        `${randomBird()} sensitive-canary: prompt masking is not supported`,
-        "",
-        `  ${usedTags} cannot mask prompt content.`,
-        "  The following sensitive data was detected:",
-        "",
-        ...findingsToLines(dedupeFindings(maskableFindings)),
-        "",
-        "  Please choose one of the following:",
-        "",
-        "  1. Manually redact the values above and resubmit",
-        "  2. To send as-is, add an allow tag to your prompt:",
-        ...(hasSecret ? ["       [allow-secret]  — allow secrets"] : []),
-        ...(hasPii ? ["       [allow-pii]     — allow PII"] : []),
-        "       [allow-all]     — bypass all sensitive-canary checks",
-        "",
-      ];
-      process.stderr.write(maskBlockLines.join("\n"));
-      process.exit(2);
-    }
+  // Apply effective allow tags
+  const afterAllow: Finding[] = dedupeFindings(
+    applyAllowTags(allFindings, effectiveAllow),
+  );
+
+  if (afterAllow.length === 0) process.exit(0);
+
+  // [mask-xxx] tag: prompt masking is not supported — inform user
+  // Only for findings whose dimension was resolved to mask (not allow).
+  const maskableFindings = afterAllow.filter(
+    (f) =>
+      (f.category === "secret" && effectiveMask.has("secret")) ||
+      (f.category === "pii" && effectiveMask.has("pii")),
+  );
+
+  if (maskableFindings.length > 0) {
+    const hasSecret = maskableFindings.some((f) => f.category === "secret");
+    const hasPii = maskableFindings.some((f) => f.category === "pii");
+    const usedTags = (["secret", "pii"] as const)
+      .filter((d) => effectiveMask.has(d))
+      .map((d) => `[mask-${d}]`)
+      .join(", ");
+    const maskBlockLines = [
+      "",
+      `${randomBird()} sensitive-canary: prompt masking is not supported`,
+      "",
+      `  ${usedTags} cannot mask prompt content.`,
+      "  The following sensitive data was detected:",
+      "",
+      ...findingsToLines(dedupeFindings(maskableFindings)),
+      "",
+      "  Please choose one of the following:",
+      "",
+      "  1. Manually redact the values above and resubmit",
+      "  2. To send as-is, add an allow tag to your prompt:",
+      ...(hasSecret ? ["       [allow-secret]  — allow secrets"] : []),
+      ...(hasPii ? ["       [allow-pii]     — allow PII"] : []),
+      "       [allow-all]     — bypass all sensitive-canary checks",
+      "",
+    ];
+    process.stderr.write(maskBlockLines.join("\n"));
+    process.exit(2);
   }
 
-  // Apply [allow-xxx] bypass tags
-  const allowTags = parseAllowTags(messages);
-  const unique: Finding[] = dedupeFindings(
-    applyAllowTags(allFindings, allowTags),
+  // Findings not covered by allow or mask — block
+  const unique: Finding[] = afterAllow.filter(
+    (f) =>
+      !(f.category === "secret" && effectiveMask.has("secret")) &&
+      !(f.category === "pii" && effectiveMask.has("pii")),
   );
 
   if (unique.length === 0) process.exit(0);
 
-  // Block and report what was detected
   const hasSecret = unique.some((f) => f.category === "secret");
   const hasPii = unique.some((f) => f.category === "pii");
 

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -1,13 +1,5 @@
 #!/usr/bin/env node
 
-/**
- * Claude Code UserPromptSubmit hook.
- *
- * - Secrets/PII detected → exit 2 (block)
- * - [allow-xxx] tag present → exit 0 (allow)
- * - Nothing detected       → exit 0 (allow)
- */
-
 import {
   applyAllowTags,
   dedupeFindings,
@@ -35,25 +27,18 @@ process.stdin.on("end", () => {
 
   const prompt = data.prompt ?? "";
 
-  // Scan for secrets/PII
-  const allFindings = scan(prompt, "prompt");
+  const allFindings = scan(prompt);
 
   if (allFindings.length === 0) process.exit(0);
 
-  // Resolve effective allow/mask tags based on first-occurrence priority.
-  // For each category dimension, whichever tag type appears first in the
-  // prompt wins. [allow-all] / [mask-all] resolve both dimensions at once.
   const { effectiveAllow, effectiveMask } = resolveTagPriority(prompt);
 
-  // Apply effective allow tags
   const afterAllow: Finding[] = dedupeFindings(
     applyAllowTags(allFindings, effectiveAllow),
   );
 
   if (afterAllow.length === 0) process.exit(0);
 
-  // [mask-xxx] tag: prompt masking is not supported — inform user
-  // Only for findings whose dimension was resolved to mask (not allow).
   const maskableFindings = afterAllow.filter(
     (f) =>
       (f.category === "secret" && effectiveMask.has("secret")) ||
@@ -63,10 +48,12 @@ process.stdin.on("end", () => {
   if (maskableFindings.length > 0) {
     const hasSecret = maskableFindings.some((f) => f.category === "secret");
     const hasPii = maskableFindings.some((f) => f.category === "pii");
-    const usedTags = (["secret", "pii"] as const)
-      .filter((d) => effectiveMask.has(d))
-      .map((d) => `[mask-${d}]`)
-      .join(", ");
+    const usedTags = effectiveMask.has("all")
+      ? "[mask-all]"
+      : (["secret", "pii"] as const)
+          .filter((d) => effectiveMask.has(d))
+          .map((d) => `[mask-${d}]`)
+          .join(", ");
     const maskBlockLines = [
       "",
       `${randomBird()} sensitive-canary: prompt masking is not supported`,
@@ -89,7 +76,6 @@ process.stdin.on("end", () => {
     process.exit(2);
   }
 
-  // Findings not covered by allow or mask — block
   const unique: Finding[] = afterAllow.filter(
     (f) =>
       !(f.category === "secret" && effectiveMask.has("secret")) &&


### PR DESCRIPTION
## Summary

- **First-occurrence tag priority**: when both `[allow-*]` and `[mask-*]` tags appear in the same prompt, the first occurrence wins per category (`secret`, `pii`). `[allow-all]` / `[mask-all]` resolve both dimensions at once.
- **Code review refactor**: removed dead code, fixed types, simplified regex, and improved test coverage.
- **Docs**: updated mask tag output examples to match actual terminal output; added Unreleased changelog entry.

## Behaviour

When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, the tag that appears first in the text wins for each category dimension:

| Prompt | secret | pii |
|--------|--------|-----|
| `[allow-secret] [mask-secret] …` | allow | — |
| `[mask-secret] [allow-secret] …` | mask (unsupported) | — |
| `[allow-all] [mask-secret] …` | allow | allow |
| `[mask-all] [allow-secret] …` | mask (unsupported) | mask (unsupported) |
| `[allow-secret] [mask-pii] …` | allow | mask (unsupported) |

## Changes in detail

### New behaviour

- `resolveTagPriority()` resolves effective allow/mask per category based on first occurrence
- `[mask-all]` now displays as `[mask-all]` in the terminal message (was `[mask-secret], [mask-pii]`)
- `buildAllowHints` example tag uses `allow-all` when both secret and PII are present

### Refactoring

- Removed dead functions `parseMaskTags`, `scanMessages`, `extractTexts` from `inspector.ts`
- Removed `Finding.location` field and `location` parameter from `scan()`
- `TranscriptLine` interface in `pre-tool-use-hook.ts` replaces 4 `biome-ignore` comments and unsafe cast
- `extractEnvVarNames` converted from exec loop to `matchAll`
- `extractFilePathsFromCommand` split regex simplified to `/\s*[|;&]+\s*/` (removed unreachable `&&`/`||` alternatives)
- All JSDoc block comments removed from source files

### Tests

- Removed `parseMaskTags` and `scanMessages` test suites (dead code)
- Added 11 missing rule tests: mailgun-key, mailchimp-key, discord-webhook, slack-webhook, telegram-bot-token, twilio-sid, openai-key (legacy), anthropic-key, generic-secret, github-fine-grained, stripe-restricted-key
- Added SSN exclusion tests for group=00 and serial=0000
- Added private IPv4 range tests for 10.x and 172.16–31.x
- Consolidated 7 repetitive file-reading command tests with `it.each`
- Replaced `Date.now()` filename suffix with monotonic counter

## Test plan

- [x] `resolveTagPriority` unit tests (11 cases)
- [x] First-occurrence integration tests (7 cases)
- [x] All 170 tests pass (`npm run ci`)