### PR TITLE
feat: include bird emoji in PreToolUse block reason

### DIFF
--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -143,6 +143,12 @@ describe("pre-tool-use-hook — .env/.env.* unconditional block", () => {
     expect(reason).toContain("[allow-pii]");
     expect(reason).toContain("[allow-all]");
   });
+
+  it("includes a bird emoji in .env block reason", () => {
+    const p = writeFixture(".env.bird", "KEY=value");
+    const { reason } = runHook("Read", p);
+    expect(reason).toMatch(/[🐦🐧🐤🐔]/u);
+  });
 });
 
 // ── clean file ────────────────────────────────────────────────────────────────
@@ -190,6 +196,12 @@ describe("pre-tool-use-hook — sensitive content blocking", () => {
     const { reason } = runHook("Read", p);
     expect(reason).toContain("[allow-secret]");
     expect(reason).toContain("[allow-all]");
+  });
+
+  it("includes a bird emoji in the reason", () => {
+    const p = writeFixture("bird.txt", "key=AKIAIOSFODNN7EXAMPLE\n");
+    const { reason } = runHook("Read", p);
+    expect(reason).toMatch(/[🐦🐧🐤🐔]/u);
   });
 
   it("includes [allow-pii] and [allow-all] hints in reason for PII", () => {
@@ -273,6 +285,11 @@ describe("pre-tool-use-hook — Bash tool (command string)", () => {
   it("includes aws-access-key in reason for inline secret", () => {
     const { reason } = runBashHook("echo AKIAIOSFODNN7EXAMPLE");
     expect(reason).toContain("aws-access-key");
+  });
+
+  it("includes a bird emoji in the reason for Bash block", () => {
+    const { reason } = runBashHook("echo AKIAIOSFODNN7EXAMPLE");
+    expect(reason).toMatch(/[🐦🐧🐤🐔]/u);
   });
 });
 

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -175,8 +175,9 @@ function block(
     process.stderr.write(terminalMessage);
   }
 
+  const bird = randomBird();
   const reasonLines = [
-    `sensitive-canary blocked: ${source}`,
+    `${bird} sensitive-canary blocked: ${source}`,
     "",
     ...detectionLines,
     "",


### PR DESCRIPTION
## Summary

- Add bird emoji to the `reason` field in PreToolUse hook block output, so Claude Code displays it alongside the block message
- Previously the bird emoji only appeared in the terminal (`/dev/tty`) output but was missing from the structured reason returned to Claude Code
- Add 3 tests verifying bird emoji presence in `.env` block, content block, and Bash command block reasons