### PR TITLE
release: v0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "coo-quack/sensitive-canary"
       },
       "description": "Blocks secrets and PII before they reach the Anthropic API",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "keywords": ["security", "secrets", "pii", "hooks"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "coo-quack"
   },

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'hotfix/')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,12 +33,12 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         id: branch
         run: |
-          BRANCH="backport/hotfix-${{ github.event.pull_request.number }}-to-develop"
+          BRANCH="backport/pr-${{ github.event.pull_request.number }}-to-develop"
           git checkout -b $BRANCH origin/develop
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Cherry-pick commits from the hotfix PR
+          # Cherry-pick commits from the merged PR
           COMMITS=$(git log origin/develop..origin/main --reverse --format="%H")
           for COMMIT in $COMMITS; do
             git cherry-pick $COMMIT || {
@@ -60,11 +60,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create \
-            --title "chore: backport hotfix #${{ github.event.pull_request.number }} to develop" \
+            --title "chore: backport #${{ github.event.pull_request.number }} to develop" \
             --body "$(cat <<'EOF'
-          Automated backport of #${{ github.event.pull_request.number }} **${{ github.event.pull_request.title }}** to \`develop\`.
+Automated backport of #${{ github.event.pull_request.number }} **${{ github.event.pull_request.title }}** to \`develop\`.
 
-          If this PR contains conflicts, resolve them before merging.
+If this PR contains conflicts, resolve them before merging.
           EOF
           )" \
             --base develop \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.1 (2026-02-23)
+
+### Fixes
+
+- **Bird emoji in PreToolUse block reason** — the bird emoji now appears in the block message shown by Claude Code, not only in the terminal output
+
+---
+
 ## v0.3.0 (2026-02-23)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-canary",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Release v0.3.1 — bird emoji in block messages + backport CI fix.

## Changes since v0.3.0

- **Bird emoji in block reason** ([#9](https://github.com/coo-quack/sensitive-canary/pull/9)) — `reason` field in the JSON output from PreToolUse hook now includes a bird emoji, matching the UserPromptSubmit hook behavior
- **Backport CI fix** — `backport.yml` now triggers on all merges to main, not just `hotfix/` branches
- 3 new tests verifying bird emoji presence (173 total tests)

## Version bump

- `package.json`: 0.3.0 → 0.3.1
- `.claude-plugin/plugin.json`: 0.3.0 → 0.3.1
- `.claude-plugin/marketplace.json`: 0.3.0 → 0.3.1
- `CHANGELOG.md`: v0.3.1 section added