### PR TITLE
feat: auto-merge backport PRs when CI passes

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -61,8 +61,13 @@ jobs:
             BODY="Automated backport of #${{ github.event.pull_request.number }} **${{ github.event.pull_request.title }}** to \`develop\`."
           fi
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore: backport #${{ github.event.pull_request.number }} to develop" \
             --body "$(echo -e "$BODY")" \
             --base develop \
-            --head ${{ steps.branch.outputs.branch }}
+            --head ${{ steps.branch.outputs.branch }})
+
+          # Auto-merge if no conflicts — wait for CI to pass
+          if [ "${{ steps.branch.outputs.conflict }}" != "true" ]; then
+            gh pr merge "$PR_URL" --auto --merge
+          fi


### PR DESCRIPTION
## Summary

- Enable auto-merge on backport PRs when there are no conflicts
- After CI passes, the backport PR is automatically merged to `develop`
- When conflicts are detected, auto-merge is skipped and manual resolution is required