### PR TITLE
fix: fall back to direct merge when auto-merge is unavailable

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -67,7 +67,7 @@ jobs:
             --base develop \
             --head ${{ steps.branch.outputs.branch }})
 
-          # Auto-merge if no conflicts — wait for CI to pass
+          # Merge if no conflicts — use --auto if required checks exist, else merge directly
           if [ "${{ steps.branch.outputs.conflict }}" != "true" ]; then
-            gh pr merge "$PR_URL" --auto --merge
+            gh pr merge "$PR_URL" --auto --merge || gh pr merge "$PR_URL" --merge
           fi


### PR DESCRIPTION
## Summary

When the target branch has no required status checks, `gh pr merge --auto` fails with "Pull request is in clean status". Fall back to direct `gh pr merge --merge` in that case.