### PR TITLE
docs: improve landing page with usage guide and leak prevention messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,47 +11,28 @@ No proxy server. No background process. Native Claude Code hooks only.
 
 ---
 
-## How It Works
+## Why sensitive-canary?
 
-### ① UserPromptSubmit hook
+Claude Code is a powerful development tool, but file reads and command executions can inadvertently send secrets and personal information to the Anthropic API. API keys in `.env` files, tokens embedded in config files, credentials pasted into the terminal — once sent to the API, they leave your machine.
 
-Runs just before a prompt is sent to the API.
+**sensitive-canary intercepts them before they are sent, preventing unintended data leaks.**
 
-```
-User presses Enter
-      ↓
-UserPromptSubmit hook
-      ↓ scans prompt
-      ├─ secret / PII detected AND no matching [allow-xxx] tag → block (exit 2)
-      └─ nothing detected OR tag present → pass (exit 0)
-```
+| Without sensitive-canary | With sensitive-canary |
+|--------------------------|----------------------|
+| `cat .env` → full contents sent to Claude ❌ | Blocked by name before Claude reads it ✅ |
+| Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
+| Tool result contains user@email.com ❌ | PII detected and blocked ✅ |
+| `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
-When blocked, the terminal shows what was detected and how to bypass it.
-
-### ② PreToolUse hook
-
-Runs just before Claude calls the `Read` or `Bash` tool.
-
-```
-Claude calls Read / Bash tool
-      ↓
-PreToolUse hook
-      ↓
-      ── Read tool ─────────────────────────────────────────────────────
-      │  1. filename is .env / .env.* → blocked unconditionally
-      │  2. file contents contain secret / PII → blocked
-      └─ Bash tool ─────────────────────────────────────────────────────
-         1. env var values referenced in the command contain secret / PII → blocked
-         2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
-         3. cat / head / tail / etc. targeting a file → file contents scanned
-```
-
-When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
-The terminal also receives a direct message (via `/dev/tty`).
+- **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
+- **29 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **Entropy filtering** — reduces false positives on low-entropy values
+- **Luhn validation** — credit card numbers are validated, not just pattern-matched
+- **Local only** — all scanning runs in your terminal; nothing is sent anywhere
 
 ---
 
-## Installation
+## Quick Start
 
 ### Requirements
 
@@ -76,9 +57,8 @@ Install in two commands from inside a Claude Code session:
 
 Done. The hooks are enabled automatically.
 
----
-
-### Manual setup
+<details>
+<summary>Manual setup</summary>
 
 If you prefer to configure hooks without the plugin system:
 
@@ -118,9 +98,11 @@ git clone https://github.com/coo-quack/sensitive-canary.git ~/sensitive-canary
 }
 ```
 
+</details>
+
 ---
 
-## Usage
+## What Happens
 
 ### Prompt blocked
 
@@ -177,9 +159,7 @@ Non-`.env` files are also blocked if their contents contain secrets or PII.
   [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
 ```
 
----
-
-## Allow tags
+### Allow tags
 
 To intentionally bypass a block, include the appropriate tag in your **current prompt**.
 
@@ -189,47 +169,7 @@ To intentionally bypass a block, include the appropriate tag in your **current p
 | `[allow-pii]` | Skip all PII-category checks |
 | `[allow-all]` | Skip all sensitive-canary checks |
 
-**Important notes:**
-
-- Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass.
-- Tags are case-insensitive: `[ALLOW-SECRET]` and `[Allow-Secret]` are equivalent to `[allow-secret]`.
-- `[allow-secret]` does not bypass PII blocks (and vice versa).
-- The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
-- Allow tags filter the scan results — the scan itself always runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
-
-## Mask tags
-
-`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content, so masking before sending is not possible.
-
-If you include a mask tag, sensitive-canary will explain this and list what was detected:
-
-```
-> [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
-
-🐦 sensitive-canary: prompt masking is not supported
-
-  [mask-secret] cannot mask prompt content.
-  The following sensitive data was detected:
-
-  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
-
-  Please choose one of the following:
-
-  1. Manually redact the values above and resubmit
-  2. To send as-is, add an allow tag to your prompt:
-       [allow-secret]  — allow secrets
-       [allow-all]     — bypass all sensitive-canary checks
-```
-
-### Allow + Mask tag priority
-
-When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both categories at once.
-
-| Example | Result |
-|---------|--------|
-| `[allow-secret] [mask-secret] …` | secret allowed |
-| `[mask-secret] [allow-secret] …` | masking not supported error |
-| `[allow-secret] [mask-pii] …` | secret allowed, PII mask error |
+> **Note:** Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass. Tags are case-insensitive. `[allow-secret]` does not bypass PII blocks (and vice versa). The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
 
 ---
 
@@ -275,6 +215,86 @@ When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag t
 | `pii-ipv4` | IPv4 address (RFC 1918 private ranges only) | — |
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
+
+---
+
+## How It Works
+
+### ① UserPromptSubmit hook
+
+Runs just before a prompt is sent to the API.
+
+```
+User presses Enter
+      ↓
+UserPromptSubmit hook
+      ↓ scans prompt
+      ├─ secret / PII detected AND no matching [allow-xxx] tag → block (exit 2)
+      └─ nothing detected OR tag present → pass (exit 0)
+```
+
+When blocked, the terminal shows what was detected and how to bypass it.
+
+### ② PreToolUse hook
+
+Runs just before Claude calls the `Read` or `Bash` tool.
+
+```
+Claude calls Read / Bash tool
+      ↓
+PreToolUse hook
+      ↓
+      ── Read tool ─────────────────────────────────────────────────────
+      │  1. filename is .env / .env.* → blocked unconditionally
+      │  2. file contents contain secret / PII → blocked
+      └─ Bash tool ─────────────────────────────────────────────────────
+         1. env var values referenced in the command contain secret / PII → blocked
+         2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
+         3. cat / head / tail / etc. targeting a file → file contents scanned
+```
+
+When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
+The terminal also receives a direct message (via `/dev/tty`).
+
+---
+
+## Allow Tags (detailed)
+
+Allow tags filter the scan results — the scan itself always runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
+
+### Mask tags
+
+`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content, so masking before sending is not possible.
+
+If you include a mask tag, sensitive-canary will explain this and list what was detected:
+
+```
+> [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
+
+🐦 sensitive-canary: prompt masking is not supported
+
+  [mask-secret] cannot mask prompt content.
+  The following sensitive data was detected:
+
+  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
+
+  Please choose one of the following:
+
+  1. Manually redact the values above and resubmit
+  2. To send as-is, add an allow tag to your prompt:
+       [allow-secret]  — allow secrets
+       [allow-all]     — bypass all sensitive-canary checks
+```
+
+### Allow + Mask tag priority
+
+When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both categories at once.
+
+| Example | Result |
+|---------|--------|
+| `[allow-secret] [mask-secret] …` | secret allowed |
+| `[mask-secret] [allow-secret] …` | masking not supported error |
+| `[allow-secret] [mask-pii] …` | secret allowed, PII mask error |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/coo-quack/sensitive-canary/actions/workflows/ci.yml/badge.svg)](https://github.com/coo-quack/sensitive-canary/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A security tool that uses Claude Code's hook system to block secrets and PII from being sent to the Anthropic API — whether they come from your prompts or from files Claude reads.
+A security plugin that prevents unintended data leaks from Claude Code. Automatically detects and blocks secrets and PII — in prompts, file reads, and command executions — before they are sent to the Anthropic API.
 
 No proxy server. No background process. Native Claude Code hooks only.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ Install with two commands inside a Claude Code session:
 
 After installation, restart Claude Code and the hooks are active. No additional configuration needed.
 
-### How It Works
+### What Happens
 
 Just use Claude Code as usual. sensitive-canary runs in the background and automatically scans at three points:
 
@@ -85,7 +85,7 @@ When sensitive data is detected, the action is blocked and the terminal shows wh
 
 See [installation guide →](/install) for manual setup options.
 
-## What Gets Detected
+## Detection Rules
 
 | Category | Examples |
 |----------|---------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: sensitive-canary
   text: Secrets and PII guard for Claude Code
-  tagline: Automatically blocks AWS keys, tokens, emails, credit cards, and more before they leave your machine
+  tagline: A security plugin that prevents unintended data leaks from Claude Code. Automatically detects and blocks AWS keys, tokens, email addresses, credit card numbers, and more before they are sent to the API.
   image:
     src: /logo.svg
     alt: sensitive-canary
@@ -42,9 +42,9 @@ features:
 
 ## Why sensitive-canary?
 
-Secrets and PII end up in AI conversations more often than you'd expect — pasted from a terminal, echoed in a config file, or embedded in a tool result. Once they reach the API, they leave your machine.
+Claude Code is a powerful development tool, but file reads and command executions can inadvertently send secrets and personal information to the Anthropic API. API keys in `.env` files, tokens embedded in config files, credentials pasted into the terminal — once sent to the API, they leave your machine.
 
-**sensitive-canary intercepts them first.**
+**sensitive-canary intercepts them before they are sent, preventing unintended data leaks.**
 
 | Without sensitive-canary | With sensitive-canary |
 |--------------------------|----------------------|
@@ -61,12 +61,29 @@ Secrets and PII end up in AI conversations more often than you'd expect — past
 
 ## Quick Start
 
+Install with two commands inside a Claude Code session:
+
 ```bash
-# Install as a Claude Code plugin
-claude plugin install coo-quack/sensitive-canary
+# 1. Register the marketplace
+/plugin marketplace add coo-quack/sensitive-canary
+
+# 2. Install the plugin
+/plugin install sensitive-canary@coo-quack
 ```
 
-Once installed, sensitive-canary runs automatically on every session. See [installation →](/install) for manual setup options.
+After installation, restart Claude Code and the hooks are active. No additional configuration needed.
+
+### How It Works
+
+Just use Claude Code as usual. sensitive-canary runs in the background and automatically scans at three points:
+
+- **On prompt submission** — checks your input for secrets and PII before it reaches the API
+- **On file read** — checks file names and contents before Claude reads them
+- **On command execution** — checks Bash commands and environment variable values for secrets
+
+When sensitive data is detected, the action is blocked and the terminal shows what was found. To intentionally allow it, add `[allow-secret]` or `[allow-all]` to your prompt.
+
+See [installation guide →](/install) for manual setup options.
 
 ## What Gets Detected
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -80,7 +80,7 @@ Check your Node.js version:
 node --version
 ```
 
-## How It Works
+## What Happens
 
 sensitive-canary adds two hooks to your Claude Code session:
 


### PR DESCRIPTION
## Summary

- Update docs site landing page (`docs/index.md`) with Japanese introduction explaining how the plugin prevents unintended information leaks
- Add Quick Start section with installation commands and usage guide
- Describe the three scan timings: prompt submission, file read, and command execution
- Update README.md description to focus on leak prevention messaging