### PR TITLE
fix: make allow tags single-use — consumed after first tool call

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Prompts containing secrets or PII are blocked before being sent.
 ```
 > My AWS key is AKIAIOSFODNN7EXAMPLE. Can you review this code?
 
-⚠️  sensitive-canary: sensitive data detected — blocked
+🐤  sensitive-canary: sensitive data detected — blocked
 
   [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
 
@@ -153,7 +153,7 @@ To allow it through, add the suggested tag:
 
 📄 sensitive-canary: blocked — /path/to/.env
 
-⚠️  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.
+🐤  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.
 
 To allow this, the user must add an allow tag to their next prompt:
   [allow-secret]  — allow secrets
@@ -172,7 +172,7 @@ Non-`.env` files are also blocked if their contents contain secrets or PII.
 
 📄 sensitive-canary: blocked — /path/to/config.yaml
 
-⚠️  Blocked: file contains sensitive data
+🐤  Blocked: file contains sensitive data
 
   [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
 ```

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -32,6 +32,29 @@ function writeTranscript(userMessages: string[]): string {
   return p;
 }
 
+function writeTranscriptWithToolResults(
+  entries: Array<{ text: string } | { toolResult: string }>,
+): string {
+  const lines = entries.map((entry) => {
+    if ("text" in entry) {
+      return JSON.stringify({
+        type: "user",
+        message: { role: "user", content: entry.text },
+      });
+    }
+    return JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: entry.toolResult }],
+      },
+    });
+  });
+  const p = join(tmpDir, `transcript-${++transcriptSeq}.jsonl`);
+  writeFileSync(p, lines.join("\n"), "utf8");
+  return p;
+}
+
 function runHook(
   toolName: string,
   filePath: string,
@@ -506,6 +529,104 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
     const { exitCode } = runBashHook(`cat ${p}`, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
+// ── allow tag consumed after first tool call ──────────────────────────────────
+
+describe("pre-tool-use-hook — allow tag single-use (consumed by first tool call)", () => {
+  it("[allow-all] works when no tool_result has been recorded yet", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] read the config file" },
+    ]);
+    const p = writeFixture(
+      "config-first-call.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode } = runHook("Read", p, { transcriptPath: transcript });
+    expect(exitCode).toBe(0);
+  });
+
+  it("[allow-all] is consumed after a tool_result — second call is blocked", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] read all the config files" },
+      { toolResult: "file contents from first read" },
+    ]);
+    const p = writeFixture(
+      "config-second-call.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-secret] is consumed after a tool_result", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-secret] check these files" },
+      { toolResult: "first tool result" },
+    ]);
+    const p = writeFixture("secret-consumed.txt", "key=AKIAIOSFODNN7EXAMPLE\n");
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-pii] is consumed after a tool_result", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-pii] read the contacts" },
+      { toolResult: "previous tool output" },
+    ]);
+    const p = writeFixture("pii-consumed.txt", "email=user@example.com\n");
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("blocks when latest real user message has no allow tag despite earlier allow", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] read everything" },
+      { toolResult: "some result" },
+      { text: "now do something else" },
+      { toolResult: "another result" },
+    ]);
+    const p = writeFixture(
+      "no-allow-after-new-msg.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-all] consumed for Bash after tool_result", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] run the commands" },
+      { toolResult: "result of first command" },
+    ]);
+    const { exitCode, decision } = runBashHook("echo AKIAIOSFODNN7EXAMPLE", {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-all] works for Bash when no tool_result yet", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] run the command" },
+    ]);
+    const { exitCode } = runBashHook("echo AKIAIOSFODNN7EXAMPLE", {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(0);

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -218,7 +218,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
     block(
       filePath,
       [
-        "⚠️  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.",
+        `${randomBird()}  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.`,
       ],
       buildAllowHints(`please read ${filePath}`, [], true),
     );
@@ -237,7 +237,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
   block(
     filePath,
     [
-      "⚠️  Blocked: file contains sensitive data",
+      `${randomBird()}  Blocked: file contains sensitive data`,
       "",
       ...findingsToLines(findings),
     ],
@@ -281,7 +281,7 @@ process.stdin.on("end", () => {
       block(
         `bash command: ${command.slice(0, 80)}`,
         [
-          `⚠️  Blocked: environment variable $${varName} contains sensitive data`,
+          `${randomBird()}  Blocked: environment variable $${varName} contains sensitive data`,
           "",
           ...findingsToLines(findings),
         ],
@@ -297,7 +297,7 @@ process.stdin.on("end", () => {
       block(
         `bash command: ${command.slice(0, 80)}`,
         [
-          "⚠️  Blocked: bash command contains sensitive data",
+          `${randomBird()}  Blocked: bash command contains sensitive data`,
           "",
           ...findingsToLines(cmdFindings),
         ],

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -27,10 +27,18 @@ interface TranscriptLine {
 
 // ── Transcript ────────────────────────────────────────────────────────────────
 
+// Returns true when the message contains at least one text content block
+// (or is a plain string). Tool-result-only messages are not real user input.
+function hasTextContent(msg: Message): boolean {
+  if (typeof msg.content === "string") return true;
+  return msg.content.some((b) => b.type === "text");
+}
+
 // Load allow tags from the Claude Code session transcript.
 // Transcript format (JSONL): { "type": "user"|"assistant", "message": { role, content }, … }
-// Only the most recent user message is consulted — older messages would make allow tags
-// persist unintentionally across turns.
+// Only the most recent user *text* message is consulted, and only if no tool_result
+// entries have been recorded after it. This means allow tags are consumed by the first
+// tool call — subsequent tool calls in the same AI turn will be blocked.
 function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
   let raw: string;
   try {
@@ -40,6 +48,7 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
   }
 
   let lastUserMessage: Message | null = null;
+  let toolResultAfterLastText = false;
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -47,14 +56,19 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
       const parsed = JSON.parse(trimmed) as TranscriptLine;
       const msg = parsed.message;
       if (msg?.role === "user" && msg.content !== undefined) {
-        lastUserMessage = msg;
+        if (hasTextContent(msg)) {
+          lastUserMessage = msg;
+          toolResultAfterLastText = false;
+        } else {
+          toolResultAfterLastText = true;
+        }
       }
     } catch {
       // skip malformed lines
     }
   }
 
-  if (!lastUserMessage) return new Set();
+  if (!lastUserMessage || toolResultAfterLastText) return new Set();
   return parseAllowTags([lastUserMessage]);
 }
 


### PR DESCRIPTION
## Summary

- Allow tags (`[allow-secret]`, `[allow-pii]`, `[allow-all]`) are now consumed by the first tool call in an AI turn
- After a `tool_result` is recorded in the transcript, subsequent tool calls in the same turn are blocked even if the user's prompt contained an allow tag
- This prevents a single `[allow-all]` from silently permitting all file reads and command executions in a multi-step AI response

## Problem

In the Anthropic API, `tool_result` entries are recorded as `role: "user"` in the transcript. Previously, the hook looked for the last `role: "user"` entry, which meant:
1. User sends `[allow-all] read .env` 
2. First Read → allowed (last user message has allow tag)
3. `tool_result` recorded as `role: "user"` (no allow tag)
4. Second Read → blocked (tool_result became "last user message")

This was inconsistent — the first call was allowed but subsequent calls were accidentally blocked by the tool_result overwrite, not by intentional design.

## Fix

- Add `hasTextContent()` to distinguish real user input from tool_result entries
- Track whether any `tool_result` appears after the last text user message
- If yes, consider the allow tag consumed → return empty set

## Tests

7 new tests (180 total):
- Allow works when no tool_result recorded yet (Read + Bash)
- Allow consumed after tool_result (allow-all / allow-secret / allow-pii / Bash)
- Blocked when new user message without tag follows