### PR TITLE
release: v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "coo-quack/sensitive-canary"
       },
       "description": "Blocks secrets and PII before they reach the Anthropic API",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "keywords": ["security", "secrets", "pii", "hooks"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": {
     "name": "coo-quack"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.4.0 (2026-02-23)
+
+### Features
+
+- **Allow tags are now single-use** — allow tags are consumed after the first tool call, preventing unintended persistent bypass across multiple tool uses in the same turn
+
+### Fixes
+
+- **Random bird emoji in block messages** — PreToolUse block messages now use `randomBird()` instead of a hardcoded emoji, matching the existing behavior in other messages
+
+### Docs
+
+- **README restructured** — new section order: Why → Quick Start → What Happens → Detection Rules → How It Works → Allow Tags
+- **Docs site headings unified** — "How It Works" → "What Happens", "What Gets Detected" → "Detection Rules" for consistency with README
+
+---
+
 ## v0.3.1 (2026-02-23)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -11,47 +11,28 @@ No proxy server. No background process. Native Claude Code hooks only.
 
 ---
 
-## How It Works
+## Why sensitive-canary?
 
-### ① UserPromptSubmit hook
+Claude Code is a powerful development tool, but file reads and command executions can inadvertently send secrets and personal information to the Anthropic API. API keys in `.env` files, tokens embedded in config files, credentials pasted into the terminal — once sent to the API, they leave your machine.
 
-Runs just before a prompt is sent to the API.
+**sensitive-canary intercepts them before they are sent, preventing unintended data leaks.**
 
-```
-User presses Enter
-      ↓
-UserPromptSubmit hook
-      ↓ scans prompt
-      ├─ secret / PII detected AND no matching [allow-xxx] tag → block (exit 2)
-      └─ nothing detected OR tag present → pass (exit 0)
-```
+| Without sensitive-canary | With sensitive-canary |
+|--------------------------|----------------------|
+| `cat .env` → full contents sent to Claude ❌ | Blocked by name before Claude reads it ✅ |
+| Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
+| Tool result contains user@email.com ❌ | PII detected and blocked ✅ |
+| `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
-When blocked, the terminal shows what was detected and how to bypass it.
-
-### ② PreToolUse hook
-
-Runs just before Claude calls the `Read` or `Bash` tool.
-
-```
-Claude calls Read / Bash tool
-      ↓
-PreToolUse hook
-      ↓
-      ── Read tool ─────────────────────────────────────────────────────
-      │  1. filename is .env / .env.* → blocked unconditionally
-      │  2. file contents contain secret / PII → blocked
-      └─ Bash tool ─────────────────────────────────────────────────────
-         1. env var values referenced in the command contain secret / PII → blocked
-         2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
-         3. cat / head / tail / etc. targeting a file → file contents scanned
-```
-
-When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
-The terminal also receives a direct message (via `/dev/tty`).
+- **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
+- **29 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **Entropy filtering** — reduces false positives on low-entropy values
+- **Luhn validation** — credit card numbers are validated, not just pattern-matched
+- **Local only** — all scanning runs in your terminal; nothing is sent anywhere
 
 ---
 
-## Installation
+## Quick Start
 
 ### Requirements
 
@@ -76,9 +57,8 @@ Install in two commands from inside a Claude Code session:
 
 Done. The hooks are enabled automatically.
 
----
-
-### Manual setup
+<details>
+<summary>Manual setup</summary>
 
 If you prefer to configure hooks without the plugin system:
 
@@ -118,9 +98,11 @@ git clone https://github.com/coo-quack/sensitive-canary.git ~/sensitive-canary
 }
 ```
 
+</details>
+
 ---
 
-## Usage
+## What Happens
 
 ### Prompt blocked
 
@@ -177,9 +159,7 @@ Non-`.env` files are also blocked if their contents contain secrets or PII.
   [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
 ```
 
----
-
-## Allow tags
+### Allow tags
 
 To intentionally bypass a block, include the appropriate tag in your **current prompt**.
 
@@ -189,47 +169,7 @@ To intentionally bypass a block, include the appropriate tag in your **current p
 | `[allow-pii]` | Skip all PII-category checks |
 | `[allow-all]` | Skip all sensitive-canary checks |
 
-**Important notes:**
-
-- Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass.
-- Tags are case-insensitive: `[ALLOW-SECRET]` and `[Allow-Secret]` are equivalent to `[allow-secret]`.
-- `[allow-secret]` does not bypass PII blocks (and vice versa).
-- The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
-- Allow tags filter the scan results — the scan itself always runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
-
-## Mask tags
-
-`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content, so masking before sending is not possible.
-
-If you include a mask tag, sensitive-canary will explain this and list what was detected:
-
-```
-> [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
-
-🐦 sensitive-canary: prompt masking is not supported
-
-  [mask-secret] cannot mask prompt content.
-  The following sensitive data was detected:
-
-  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
-
-  Please choose one of the following:
-
-  1. Manually redact the values above and resubmit
-  2. To send as-is, add an allow tag to your prompt:
-       [allow-secret]  — allow secrets
-       [allow-all]     — bypass all sensitive-canary checks
-```
-
-### Allow + Mask tag priority
-
-When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both categories at once.
-
-| Example | Result |
-|---------|--------|
-| `[allow-secret] [mask-secret] …` | secret allowed |
-| `[mask-secret] [allow-secret] …` | masking not supported error |
-| `[allow-secret] [mask-pii] …` | secret allowed, PII mask error |
+> **Note:** Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass. Tags are case-insensitive. `[allow-secret]` does not bypass PII blocks (and vice versa). The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
 
 ---
 
@@ -275,6 +215,86 @@ When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag t
 | `pii-ipv4` | IPv4 address (RFC 1918 private ranges only) | — |
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
+
+---
+
+## How It Works
+
+### ① UserPromptSubmit hook
+
+Runs just before a prompt is sent to the API.
+
+```
+User presses Enter
+      ↓
+UserPromptSubmit hook
+      ↓ scans prompt
+      ├─ secret / PII detected AND no matching [allow-xxx] tag → block (exit 2)
+      └─ nothing detected OR tag present → pass (exit 0)
+```
+
+When blocked, the terminal shows what was detected and how to bypass it.
+
+### ② PreToolUse hook
+
+Runs just before Claude calls the `Read` or `Bash` tool.
+
+```
+Claude calls Read / Bash tool
+      ↓
+PreToolUse hook
+      ↓
+      ── Read tool ─────────────────────────────────────────────────────
+      │  1. filename is .env / .env.* → blocked unconditionally
+      │  2. file contents contain secret / PII → blocked
+      └─ Bash tool ─────────────────────────────────────────────────────
+         1. env var values referenced in the command contain secret / PII → blocked
+         2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
+         3. cat / head / tail / etc. targeting a file → file contents scanned
+```
+
+When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
+The terminal also receives a direct message (via `/dev/tty`).
+
+---
+
+## Allow Tags (detailed)
+
+Allow tags filter the scan results — the scan itself always runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
+
+### Mask tags
+
+`[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content, so masking before sending is not possible.
+
+If you include a mask tag, sensitive-canary will explain this and list what was detected:
+
+```
+> [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
+
+🐦 sensitive-canary: prompt masking is not supported
+
+  [mask-secret] cannot mask prompt content.
+  The following sensitive data was detected:
+
+  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
+
+  Please choose one of the following:
+
+  1. Manually redact the values above and resubmit
+  2. To send as-is, add an allow tag to your prompt:
+       [allow-secret]  — allow secrets
+       [allow-all]     — bypass all sensitive-canary checks
+```
+
+### Allow + Mask tag priority
+
+When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both categories at once.
+
+| Example | Result |
+|---------|--------|
+| `[allow-secret] [mask-secret] …` | secret allowed |
+| `[mask-secret] [allow-secret] …` | masking not supported error |
+| `[allow-secret] [mask-pii] …` | secret allowed, PII mask error |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/coo-quack/sensitive-canary/actions/workflows/ci.yml/badge.svg)](https://github.com/coo-quack/sensitive-canary/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A security tool that uses Claude Code's hook system to block secrets and PII from being sent to the Anthropic API — whether they come from your prompts or from files Claude reads.
+A security plugin that prevents unintended data leaks from Claude Code. Automatically detects and blocks secrets and PII — in prompts, file reads, and command executions — before they are sent to the Anthropic API.
 
 No proxy server. No background process. Native Claude Code hooks only.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Prompts containing secrets or PII are blocked before being sent.
 ```
 > My AWS key is AKIAIOSFODNN7EXAMPLE. Can you review this code?
 
-⚠️  sensitive-canary: sensitive data detected — blocked
+🐤  sensitive-canary: sensitive data detected — blocked
 
   [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
 
@@ -153,7 +153,7 @@ To allow it through, add the suggested tag:
 
 📄 sensitive-canary: blocked — /path/to/.env
 
-⚠️  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.
+🐤  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.
 
 To allow this, the user must add an allow tag to their next prompt:
   [allow-secret]  — allow secrets
@@ -172,7 +172,7 @@ Non-`.env` files are also blocked if their contents contain secrets or PII.
 
 📄 sensitive-canary: blocked — /path/to/config.yaml
 
-⚠️  Blocked: file contains sensitive data
+🐤  Blocked: file contains sensitive data
 
   [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ Install with two commands inside a Claude Code session:
 
 After installation, restart Claude Code and the hooks are active. No additional configuration needed.
 
-### How It Works
+### What Happens
 
 Just use Claude Code as usual. sensitive-canary runs in the background and automatically scans at three points:
 
@@ -85,7 +85,7 @@ When sensitive data is detected, the action is blocked and the terminal shows wh
 
 See [installation guide →](/install) for manual setup options.
 
-## What Gets Detected
+## Detection Rules
 
 | Category | Examples |
 |----------|---------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: sensitive-canary
   text: Secrets and PII guard for Claude Code
-  tagline: Automatically blocks AWS keys, tokens, emails, credit cards, and more before they leave your machine
+  tagline: A security plugin that prevents unintended data leaks from Claude Code. Automatically detects and blocks AWS keys, tokens, email addresses, credit card numbers, and more before they are sent to the API.
   image:
     src: /logo.svg
     alt: sensitive-canary
@@ -42,9 +42,9 @@ features:
 
 ## Why sensitive-canary?
 
-Secrets and PII end up in AI conversations more often than you'd expect — pasted from a terminal, echoed in a config file, or embedded in a tool result. Once they reach the API, they leave your machine.
+Claude Code is a powerful development tool, but file reads and command executions can inadvertently send secrets and personal information to the Anthropic API. API keys in `.env` files, tokens embedded in config files, credentials pasted into the terminal — once sent to the API, they leave your machine.
 
-**sensitive-canary intercepts them first.**
+**sensitive-canary intercepts them before they are sent, preventing unintended data leaks.**
 
 | Without sensitive-canary | With sensitive-canary |
 |--------------------------|----------------------|
@@ -61,12 +61,29 @@ Secrets and PII end up in AI conversations more often than you'd expect — past
 
 ## Quick Start
 
+Install with two commands inside a Claude Code session:
+
 ```bash
-# Install as a Claude Code plugin
-claude plugin install coo-quack/sensitive-canary
+# 1. Register the marketplace
+/plugin marketplace add coo-quack/sensitive-canary
+
+# 2. Install the plugin
+/plugin install sensitive-canary@coo-quack
 ```
 
-Once installed, sensitive-canary runs automatically on every session. See [installation →](/install) for manual setup options.
+After installation, restart Claude Code and the hooks are active. No additional configuration needed.
+
+### How It Works
+
+Just use Claude Code as usual. sensitive-canary runs in the background and automatically scans at three points:
+
+- **On prompt submission** — checks your input for secrets and PII before it reaches the API
+- **On file read** — checks file names and contents before Claude reads them
+- **On command execution** — checks Bash commands and environment variable values for secrets
+
+When sensitive data is detected, the action is blocked and the terminal shows what was found. To intentionally allow it, add `[allow-secret]` or `[allow-all]` to your prompt.
+
+See [installation guide →](/install) for manual setup options.
 
 ## What Gets Detected
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -80,7 +80,7 @@ Check your Node.js version:
 node --version
 ```
 
-## How It Works
+## What Happens
 
 sensitive-canary adds two hooks to your Claude Code session:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-canary",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
   "private": true,
   "type": "module",

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -32,6 +32,29 @@ function writeTranscript(userMessages: string[]): string {
   return p;
 }
 
+function writeTranscriptWithToolResults(
+  entries: Array<{ text: string } | { toolResult: string }>,
+): string {
+  const lines = entries.map((entry) => {
+    if ("text" in entry) {
+      return JSON.stringify({
+        type: "user",
+        message: { role: "user", content: entry.text },
+      });
+    }
+    return JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: entry.toolResult }],
+      },
+    });
+  });
+  const p = join(tmpDir, `transcript-${++transcriptSeq}.jsonl`);
+  writeFileSync(p, lines.join("\n"), "utf8");
+  return p;
+}
+
 function runHook(
   toolName: string,
   filePath: string,
@@ -506,6 +529,104 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
     const { exitCode } = runBashHook(`cat ${p}`, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
+// ── allow tag consumed after first tool call ──────────────────────────────────
+
+describe("pre-tool-use-hook — allow tag single-use (consumed by first tool call)", () => {
+  it("[allow-all] works when no tool_result has been recorded yet", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] read the config file" },
+    ]);
+    const p = writeFixture(
+      "config-first-call.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode } = runHook("Read", p, { transcriptPath: transcript });
+    expect(exitCode).toBe(0);
+  });
+
+  it("[allow-all] is consumed after a tool_result — second call is blocked", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] read all the config files" },
+      { toolResult: "file contents from first read" },
+    ]);
+    const p = writeFixture(
+      "config-second-call.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-secret] is consumed after a tool_result", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-secret] check these files" },
+      { toolResult: "first tool result" },
+    ]);
+    const p = writeFixture("secret-consumed.txt", "key=AKIAIOSFODNN7EXAMPLE\n");
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-pii] is consumed after a tool_result", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-pii] read the contacts" },
+      { toolResult: "previous tool output" },
+    ]);
+    const p = writeFixture("pii-consumed.txt", "email=user@example.com\n");
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("blocks when latest real user message has no allow tag despite earlier allow", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] read everything" },
+      { toolResult: "some result" },
+      { text: "now do something else" },
+      { toolResult: "another result" },
+    ]);
+    const p = writeFixture(
+      "no-allow-after-new-msg.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode, decision } = runHook("Read", p, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-all] consumed for Bash after tool_result", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] run the commands" },
+      { toolResult: "result of first command" },
+    ]);
+    const { exitCode, decision } = runBashHook("echo AKIAIOSFODNN7EXAMPLE", {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("[allow-all] works for Bash when no tool_result yet", () => {
+    const transcript = writeTranscriptWithToolResults([
+      { text: "[allow-all] run the command" },
+    ]);
+    const { exitCode } = runBashHook("echo AKIAIOSFODNN7EXAMPLE", {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(0);

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -218,7 +218,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
     block(
       filePath,
       [
-        "⚠️  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.",
+        `${randomBird()}  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.`,
       ],
       buildAllowHints(`please read ${filePath}`, [], true),
     );
@@ -237,7 +237,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
   block(
     filePath,
     [
-      "⚠️  Blocked: file contains sensitive data",
+      `${randomBird()}  Blocked: file contains sensitive data`,
       "",
       ...findingsToLines(findings),
     ],
@@ -281,7 +281,7 @@ process.stdin.on("end", () => {
       block(
         `bash command: ${command.slice(0, 80)}`,
         [
-          `⚠️  Blocked: environment variable $${varName} contains sensitive data`,
+          `${randomBird()}  Blocked: environment variable $${varName} contains sensitive data`,
           "",
           ...findingsToLines(findings),
         ],
@@ -297,7 +297,7 @@ process.stdin.on("end", () => {
       block(
         `bash command: ${command.slice(0, 80)}`,
         [
-          "⚠️  Blocked: bash command contains sensitive data",
+          `${randomBird()}  Blocked: bash command contains sensitive data`,
           "",
           ...findingsToLines(cmdFindings),
         ],

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -27,10 +27,18 @@ interface TranscriptLine {
 
 // ── Transcript ────────────────────────────────────────────────────────────────
 
+// Returns true when the message contains at least one text content block
+// (or is a plain string). Tool-result-only messages are not real user input.
+function hasTextContent(msg: Message): boolean {
+  if (typeof msg.content === "string") return true;
+  return msg.content.some((b) => b.type === "text");
+}
+
 // Load allow tags from the Claude Code session transcript.
 // Transcript format (JSONL): { "type": "user"|"assistant", "message": { role, content }, … }
-// Only the most recent user message is consulted — older messages would make allow tags
-// persist unintentionally across turns.
+// Only the most recent user *text* message is consulted, and only if no tool_result
+// entries have been recorded after it. This means allow tags are consumed by the first
+// tool call — subsequent tool calls in the same AI turn will be blocked.
 function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
   let raw: string;
   try {
@@ -40,6 +48,7 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
   }
 
   let lastUserMessage: Message | null = null;
+  let toolResultAfterLastText = false;
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -47,14 +56,19 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
       const parsed = JSON.parse(trimmed) as TranscriptLine;
       const msg = parsed.message;
       if (msg?.role === "user" && msg.content !== undefined) {
-        lastUserMessage = msg;
+        if (hasTextContent(msg)) {
+          lastUserMessage = msg;
+          toolResultAfterLastText = false;
+        } else {
+          toolResultAfterLastText = true;
+        }
       }
     } catch {
       // skip malformed lines
     }
   }
 
-  if (!lastUserMessage) return new Set();
+  if (!lastUserMessage || toolResultAfterLastText) return new Set();
   return parseAllowTags([lastUserMessage]);
 }
 


### PR DESCRIPTION
## Summary

Release v0.4.0 — single-use allow tags, randomBird() fix, and documentation restructure.

## Changes since v0.3.1

### Features

- **Allow tags are now single-use** (#19) — allow tags are consumed after the first tool call, preventing unintended persistent bypass across multiple tool uses in the same turn

### Fixes

- **Random bird emoji in block messages** (#19) — PreToolUse block messages now use `randomBird()` instead of a hardcoded emoji

### Docs

- **README restructured** (#18) — new section order: Why → Quick Start → What Happens → Detection Rules → How It Works → Allow Tags
- **Docs site headings unified** (#18) — "How It Works" → "What Happens", "What Gets Detected" → "Detection Rules"

## Version bump

- `package.json`: 0.3.1 → 0.4.0
- `.claude-plugin/plugin.json`: 0.3.1 → 0.4.0
- `.claude-plugin/marketplace.json`: 0.3.1 → 0.4.0
- `CHANGELOG.md`: v0.4.0 section added