### PR TITLE
Release v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "coo-quack/sensitive-canary"
       },
       "description": "Blocks secrets and PII before they reach the Anthropic API",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "keywords": ["security", "secrets", "pii", "hooks"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": {
     "name": "coo-quack"
   },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if git ls-remote --tags origin "v$VERSION" | grep -q "v$VERSION"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
+          elif npm view "sensitive-canary@$VERSION" version 2>/dev/null; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
@@ -29,17 +31,35 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+      - run: npm run ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           VERSION="v${{ needs.check.outputs.version }}"
-          git tag "$VERSION"
-          git push origin "$VERSION"
+          if git ls-remote --tags origin "$VERSION" | grep -q "$VERSION"; then
+            echo "Tag $VERSION already exists, skipping"
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+          fi
 
       - name: Extract changelog
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.4.0 (2026-02-23)
+
+### Features
+
+- **Allow tags are now single-use** — allow tags are consumed after the first tool call, preventing unintended persistent bypass across multiple tool uses in the same turn
+
+### Fixes
+
+- **Random bird emoji in block messages** — PreToolUse block messages now use `randomBird()` instead of a hardcoded emoji, matching the existing behavior in other messages
+
+### Docs
+
+- **README restructured** — new section order: Why → Quick Start → What Happens → Detection Rules → How It Works → Allow Tags
+- **Docs site headings unified** — "How It Works" → "What Happens", "What Gets Detected" → "Detection Rules" for consistency with README
+
+---
+
 ## v0.3.1 (2026-02-23)
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,9 +1,20 @@
 {
   "name": "sensitive-canary",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
-  "private": true,
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coo-quack/sensitive-canary.git"
+  },
+  "files": [
+    "src/",
+    ".claude-plugin/",
+    "hooks/",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "engines": {
     "node": ">=22.6.0"
   },


### PR DESCRIPTION
## Summary

- Add npm publish automation to release workflow
- Remove `private: true` and add `files`/`repository` fields to package.json
- Allow tags are now single-use (consumed after first tool call)
- Random bird emoji in block messages
- Docs restructured for consistency

## Release checklist

- [x] `npm run ci` passes
- [x] `npm pack --dry-run` verified
- [x] `NPM_TOKEN` configured (org-level secret)