### PR TITLE
Release v0.4.1: npm publish automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if git ls-remote --tags origin "v$VERSION" | grep -q "v$VERSION"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
+          elif npm view "sensitive-canary@$VERSION" version 2>/dev/null; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
@@ -29,17 +31,35 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+      - run: npm run ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           VERSION="v${{ needs.check.outputs.version }}"
-          git tag "$VERSION"
-          git push origin "$VERSION"
+          if git ls-remote --tags origin "$VERSION" | grep -q "$VERSION"; then
+            echo "Tag $VERSION already exists, skipping"
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+          fi
 
       - name: Extract changelog
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.4.1 (2026-02-23)
+
+### Improvements
+
+- **npm publish automation** — release workflow now publishes to npm with provenance on merge to main
+- **Package metadata** — added `repository` and `files` fields, removed `private: true` for npm publishing
+- **npm install docs** — added `npm install -g` setup instructions to README and docs
+
+---
+
 ## v0.4.0 (2026-02-23)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -57,18 +57,73 @@ Install in two commands from inside a Claude Code session:
 
 Done. The hooks are enabled automatically.
 
+> **Keeping up to date:** Third-party marketplaces have auto-update disabled by default. To receive automatic updates, run `/plugin` → **Marketplaces** tab → select the marketplace → **Enable auto-update**. You can also update manually from the same tab. See [Discover and install plugins](https://docs.anthropic.com/en/docs/claude-code/discover-plugins) for details.
+
 <details>
-<summary>Manual setup</summary>
+<summary>npm install</summary>
 
-If you prefer to configure hooks without the plugin system:
+Install locally via npm and configure hooks manually:
 
-**1. Clone the repository**
+```bash
+npm install -g sensitive-canary
+```
+
+Update to the latest version:
+
+```bash
+npm update -g sensitive-canary
+```
+
+Then add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx $(npm root -g)/sensitive-canary/src/user-prompt-submit-hook.ts"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx $(npm root -g)/sensitive-canary/src/pre-tool-use-hook.ts"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **Note:** `node_modules` 内の TypeScript は `--experimental-strip-types` で実行できないため、`npx tsx` を使用します。
+
+</details>
+
+<details>
+<summary>Manual setup (git clone)</summary>
+
+Clone the repository and configure hooks manually:
 
 ```bash
 git clone https://github.com/coo-quack/sensitive-canary.git ~/sensitive-canary
 ```
 
-**2. Register the hooks in `~/.claude/settings.json`**
+Update to the latest version:
+
+```bash
+cd ~/sensitive-canary && git pull
+```
+
+Then add to `~/.claude/settings.json`:
 
 ```json
 {

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,14 +20,79 @@ Run the following two commands inside a Claude Code session:
 
 Claude Code will download the plugin and register the hooks automatically. No restart is required.
 
-## Manual Setup
+### Updating
 
-If you prefer to configure hooks manually, clone the repository and point your hooks configuration at the scripts.
+Third-party marketplaces have auto-update disabled by default. To receive automatic updates:
+
+1. Run `/plugin` → **Marketplaces** tab
+2. Select the marketplace → **Enable auto-update**
+
+You can also update manually from the same tab. See [Discover and install plugins](https://docs.anthropic.com/en/docs/claude-code/discover-plugins) for details.
+
+## npm Install
+
+Install globally via npm and configure hooks in your settings:
+
+**1. Install the package**
+
+```bash
+npm install -g sensitive-canary
+```
+
+Update to the latest version:
+
+```bash
+npm update -g sensitive-canary
+```
+
+**2. Register hooks**
+
+Add the following to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx $(npm root -g)/sensitive-canary/src/pre-tool-use-hook.ts"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx $(npm root -g)/sensitive-canary/src/user-prompt-submit-hook.ts"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **Note:** `node_modules` 内の TypeScript は `--experimental-strip-types` で実行できないため、`npx tsx` を使用します。No build step is required.
+
+## Manual Setup (git clone)
+
+Clone the repository and point your hooks configuration at the scripts:
 
 **1. Clone the repository**
 
 ```bash
 git clone https://github.com/coo-quack/sensitive-canary.git ~/.claude/plugins/sensitive-canary
+```
+
+Update to the latest version:
+
+```bash
+cd ~/.claude/plugins/sensitive-canary && git pull
 ```
 
 **2. Install dependencies**

--- a/package.json
+++ b/package.json
@@ -1,9 +1,20 @@
 {
   "name": "sensitive-canary",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
-  "private": true,
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coo-quack/sensitive-canary.git"
+  },
+  "files": [
+    "src/",
+    ".claude-plugin/",
+    "hooks/",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "engines": {
     "node": ">=22.6.0"
   },


### PR DESCRIPTION
## Summary

- Add npm publish with provenance to the release workflow
- Remove `private: true`, add `files` and `repository` fields to package.json
- Check both git tag and npm registry in the release gate

## Changes

- **`.github/workflows/release.yml`** — npm publish step with `--provenance --access public`, `id-token: write` permission, npm registry duplicate check
- **`package.json`** — version bump to 0.4.1, add `repository`/`files`, remove `private: true`
- **`CHANGELOG.md`** — v0.4.1 entry

## Prerequisites

- [x] `NPM_TOKEN` configured as org-level secret (`coo-quack`)