### PR TITLE
Fix: use scoped package name @coo-quack/sensitive-canary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if git ls-remote --tags origin "v$VERSION" | grep -q "v$VERSION"; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-          elif npm view "sensitive-canary@$VERSION" version 2>/dev/null; then
+          elif npm view "@coo-quack/sensitive-canary@$VERSION" version 2>/dev/null; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
           else
             echo "should_release=true" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.4.2 (2026-02-23)
+
+### Fixes
+
+- **Scoped package name** — renamed npm package from `sensitive-canary` to `@coo-quack/sensitive-canary`
+- **Homepage** — added `homepage` field pointing to the documentation site
+
+---
+
 ## v0.4.1 (2026-02-23)
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ Done. The hooks are enabled automatically.
 Install locally via npm and configure hooks manually:
 
 ```bash
-npm install -g sensitive-canary
+npm install -g @coo-quack/sensitive-canary
 ```
 
 Update to the latest version:
 
 ```bash
-npm update -g sensitive-canary
+npm update -g @coo-quack/sensitive-canary
 ```
 
 Then add to `~/.claude/settings.json`:
@@ -84,7 +84,7 @@ Then add to `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx $(npm root -g)/sensitive-canary/src/user-prompt-submit-hook.ts"
+            "command": "npx tsx $(npm root -g)/@coo-quack/sensitive-canary/src/user-prompt-submit-hook.ts"
           }
         ]
       }
@@ -95,7 +95,7 @@ Then add to `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx $(npm root -g)/sensitive-canary/src/pre-tool-use-hook.ts"
+            "command": "npx tsx $(npm root -g)/@coo-quack/sensitive-canary/src/pre-tool-use-hook.ts"
           }
         ]
       }

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,13 +36,13 @@ Install globally via npm and configure hooks in your settings:
 **1. Install the package**
 
 ```bash
-npm install -g sensitive-canary
+npm install -g @coo-quack/sensitive-canary
 ```
 
 Update to the latest version:
 
 ```bash
-npm update -g sensitive-canary
+npm update -g @coo-quack/sensitive-canary
 ```
 
 **2. Register hooks**
@@ -58,7 +58,7 @@ Add the following to `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx $(npm root -g)/sensitive-canary/src/pre-tool-use-hook.ts"
+            "command": "npx tsx $(npm root -g)/@coo-quack/sensitive-canary/src/pre-tool-use-hook.ts"
           }
         ]
       }
@@ -68,7 +68,7 @@ Add the following to `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx $(npm root -g)/sensitive-canary/src/user-prompt-submit-hook.ts"
+            "command": "npx tsx $(npm root -g)/@coo-quack/sensitive-canary/src/user-prompt-submit-hook.ts"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "sensitive-canary",
-  "version": "0.4.1",
+  "name": "@coo-quack/sensitive-canary",
+  "version": "0.4.2",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
+  "homepage": "https://coo-quack.github.io/sensitive-canary/",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Rename npm package from `sensitive-canary` to `@coo-quack/sensitive-canary`
- Add `homepage` field pointing to docs site
- Update npm view check in release workflow
- Update install/update commands in README and docs

## Notes

- The unscoped `sensitive-canary@0.4.1` was already published — can be unpublished later
- The `coo-quack` npm org must exist before this can publish successfully