### PR TITLE
docs: replace Japanese text with English in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Then add to `~/.claude/settings.json`:
 }
 ```
 
-> **Note:** `node_modules` 内の TypeScript は `--experimental-strip-types` で実行できないため、`npx tsx` を使用します。
+> **Note:** Node.js does not support `--experimental-strip-types` for files inside `node_modules`, so `npx tsx` is used instead.
 
 </details>
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -77,7 +77,7 @@ Add the following to `~/.claude/settings.json`:
 }
 ```
 
-> **Note:** `node_modules` 内の TypeScript は `--experimental-strip-types` で実行できないため、`npx tsx` を使用します。No build step is required.
+> **Note:** Node.js does not support `--experimental-strip-types` for files inside `node_modules`, so `npx tsx` is used instead. No build step is required.
 
 ## Manual Setup (git clone)
 


### PR DESCRIPTION
## Summary

- Replace Japanese note about `npx tsx` usage with English in README and docs/install.md