### PR TITLE
fix: remove push trigger from CI to avoid duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   typecheck:


### PR DESCRIPTION
## Summary

- Remove `push` trigger from CI workflow, keeping only `pull_request`
- Add concurrency group to cancel in-progress runs for the same PR

## Why

Having both `push` and `pull_request` triggers causes duplicate CI runs when a PR is merged (one for the push to main, one for the PR event). The release workflow already handles main/develop branch pushes, so the CI workflow only needs to run on pull requests.

The new concurrency group (`ci-<PR number>`) ensures that outdated CI runs are cancelled when new commits are pushed to the same PR, saving runner minutes.