### PR TITLE
chore: prepare release v0.4.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,13 @@
       "description": "Blocks secrets and PII before they reach the Anthropic API",
       "version": "0.4.0",
       "license": "MIT",
-      "keywords": ["security", "secrets", "pii", "hooks"]
+      "keywords": [
+        "security",
+        "secrets",
+        "pii",
+        "hooks"
+      ]
     }
-  ]
+  ],
+  "version": "0.4.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,16 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.4.0",
+  "version": "0.4.4",
   "author": {
     "name": "coo-quack"
   },
   "repository": "https://github.com/coo-quack/sensitive-canary",
   "license": "MIT",
-  "keywords": ["security", "secrets", "pii", "hooks"]
+  "keywords": [
+    "security",
+    "secrets",
+    "pii",
+    "hooks"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v0.4.4 (2026-03-11)
+
+### Chores
+
+- Add Renovate configuration with automerge on CI success
+- Migrate from npm to pnpm
+- Update GitHub Actions workflows to use pnpm
+
 
 ## v0.4.3 (2026-02-23)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coo-quack/sensitive-canary",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
   "homepage": "https://coo-quack.github.io/sensitive-canary/",
   "type": "module",


### PR DESCRIPTION
## Changes

Prepare for release v0.4.4:
- Update package.json version to 0.4.4
- Update CHANGELOG.md
- Update .claude-plugin versions

This will be included in the develop→main release PR.