### PR TITLE
fix: address code review findings in detection rules and hook output

### DIFF
--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -245,6 +245,22 @@ describe("pre-tool-use-hook — sensitive content blocking", () => {
   });
 });
 
+// ── binary file skipping ──────────────────────────────────────────────────────
+
+describe("pre-tool-use-hook — binary file skipping", () => {
+  it("skips a binary file containing NUL bytes even if it has a secret pattern", () => {
+    const content = Buffer.concat([
+      Buffer.from("key=AKIAIOSFODNN7EXAMPLE\n"),
+      Buffer.from([0x00]),
+      Buffer.from("more data"),
+    ]);
+    const p = join(tmpDir, "binary.bin");
+    writeFileSync(p, content);
+    const { exitCode } = runHook("Read", p);
+    expect(exitCode).toBe(0);
+  });
+});
+
 // ── Bash tool — env var expansion ────────────────────────────────────────────
 
 describe("pre-tool-use-hook — Bash tool (env var expansion)", () => {

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -245,16 +245,40 @@ describe("pre-tool-use-hook — sensitive content blocking", () => {
   });
 });
 
-// ── binary file skipping ──────────────────────────────────────────────────────
+// ── binary file handling ─────────────────────────────────────────────────────
 
-describe("pre-tool-use-hook — binary file skipping", () => {
-  it("skips a binary file containing NUL bytes even if it has a secret pattern", () => {
+describe("pre-tool-use-hook — binary file handling", () => {
+  it("blocks when a secret appears before the first NUL byte", () => {
     const content = Buffer.concat([
       Buffer.from("key=AKIAIOSFODNN7EXAMPLE\n"),
       Buffer.from([0x00]),
-      Buffer.from("more data"),
+      Buffer.from("binary data"),
     ]);
-    const p = join(tmpDir, "binary.bin");
+    const p = join(tmpDir, "binary-secret-before-nul.bin");
+    writeFileSync(p, content);
+    const { exitCode, decision } = runHook("Read", p);
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("allows a binary file when no secret appears before the first NUL byte", () => {
+    const content = Buffer.concat([
+      Buffer.from("clean text\n"),
+      Buffer.from([0x00]),
+      Buffer.from("AKIAIOSFODNN7EXAMPLE"),
+    ]);
+    const p = join(tmpDir, "binary-secret-after-nul.bin");
+    writeFileSync(p, content);
+    const { exitCode } = runHook("Read", p);
+    expect(exitCode).toBe(0);
+  });
+
+  it("allows a binary file that starts with NUL", () => {
+    const content = Buffer.concat([
+      Buffer.from([0x00]),
+      Buffer.from("AKIAIOSFODNN7EXAMPLE"),
+    ]);
+    const p = join(tmpDir, "binary-nul-start.bin");
     writeFileSync(p, content);
     const { exitCode } = runHook("Read", p);
     expect(exitCode).toBe(0);

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -261,6 +261,56 @@ describe("pre-tool-use-hook — binary file skipping", () => {
   });
 });
 
+// ── file size limit ──────────────────────────────────────────────────────────
+
+describe("pre-tool-use-hook — file size limit (1 MB)", () => {
+  it("blocks when a secret is within the first 1 MB", () => {
+    const padding = Buffer.alloc(512 * 1024, "x"); // 512 KB
+    const secret = Buffer.from("\nkey=AKIAIOSFODNN7EXAMPLE\n");
+    const p = join(tmpDir, "large-secret-start.txt");
+    writeFileSync(p, Buffer.concat([padding, secret]));
+    const { exitCode, decision } = runHook("Read", p);
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("allows when a secret is beyond the first 1 MB", () => {
+    const padding = Buffer.alloc(1_048_576 + 1, "x"); // 1 MB + 1 byte
+    const secret = Buffer.from("\nkey=AKIAIOSFODNN7EXAMPLE\n");
+    const p = join(tmpDir, "large-secret-end.txt");
+    writeFileSync(p, Buffer.concat([padding, secret]));
+    const { exitCode } = runHook("Read", p);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// ── transcript tail read ────────────────────────────────────────────────────
+
+describe("pre-tool-use-hook — transcript tail read (64 KB)", () => {
+  it("[allow-all] in a large transcript (>64KB) is respected when near the end", () => {
+    // Build a transcript larger than 64KB with the allow tag in the last message
+    const filler = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "x".repeat(1024) },
+    });
+    const fillerLines = Array.from({ length: 70 }, () => filler).join("\n");
+    const allowLine = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "[allow-all] read everything" },
+    });
+    const transcriptContent = `${fillerLines}\n${allowLine}\n`;
+    const tp = join(tmpDir, "large-transcript.jsonl");
+    writeFileSync(tp, transcriptContent, "utf8");
+
+    const p = writeFixture(
+      "large-transcript-test.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\n",
+    );
+    const { exitCode } = runHook("Read", p, { transcriptPath: tp });
+    expect(exitCode).toBe(0);
+  });
+});
+
 // ── Bash tool — env var expansion ────────────────────────────────────────────
 
 describe("pre-tool-use-hook — Bash tool (env var expansion)", () => {

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -174,6 +174,16 @@ describe("scan — secrets", () => {
     expect(findings.some((f) => f.ruleId === "openai-key")).toBe(true);
   });
 
+  it("does not flag sk-proj-* as openai-key (legacy)", () => {
+    const findings = scan("sk-proj-Xk9mP2qR7vL4nW1sYj3cBz8dEf5gHiKoNpQuTxMn");
+    expect(findings.some((f) => f.ruleId === "openai-key")).toBe(false);
+  });
+
+  it("does not flag sk-ant-* as openai-key (legacy)", () => {
+    const findings = scan(`sk-ant-${"A".repeat(95)}`);
+    expect(findings.some((f) => f.ruleId === "openai-key")).toBe(false);
+  });
+
   it("detects an OpenAI project API key", () => {
     const findings = scan("sk-proj-Xk9mP2qR7vL4nW1sYj3cBz8dEf5gHiKoNpQuTxMn");
     expect(findings.some((f) => f.ruleId === "openai-project-key")).toBe(true);

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -68,6 +68,26 @@ describe("scan — secrets", () => {
     expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
   });
 
+  it("detects a GCP API key", () => {
+    const findings = scan(`key=AIzaSyC${"A".repeat(32)}`);
+    expect(findings.some((f) => f.ruleId === "gcp-api-key")).toBe(true);
+  });
+
+  it("does not flag a string starting with AIza but too short", () => {
+    const findings = scan("AIzaSyC_short");
+    expect(findings.some((f) => f.ruleId === "gcp-api-key")).toBe(false);
+  });
+
+  it("detects an npm access token", () => {
+    const findings = scan(`npm_${"A".repeat(36)}`);
+    expect(findings.some((f) => f.ruleId === "npm-token")).toBe(true);
+  });
+
+  it("does not flag npm_ with insufficient length", () => {
+    const findings = scan("npm_shorttoken");
+    expect(findings.some((f) => f.ruleId === "npm-token")).toBe(false);
+  });
+
   it("detects a PEM private key header (RSA)", () => {
     const findings = scan("-----BEGIN RSA PRIVATE KEY-----");
     expect(findings.some((f) => f.ruleId === "private-key")).toBe(true);

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -65,6 +65,12 @@ const SECRET_RULES: Rule[] = [
     category: "secret",
   },
   {
+    id: "gcp-api-key",
+    description: "Google Cloud API Key",
+    regex: /AIza[0-9A-Za-z_-]{35}/g,
+    category: "secret",
+  },
+  {
     id: "private-key",
     description: "PEM Private Key",
     // Covers RSA, EC, DSA, PGP, and OpenSSH private keys
@@ -89,6 +95,14 @@ const SECRET_RULES: Rule[] = [
     id: "gitlab-pat",
     description: "GitLab Personal Access Token",
     regex: /glpat-[A-Za-z0-9_=-]{20,22}/g,
+    category: "secret",
+  },
+
+  // Package registries
+  {
+    id: "npm-token",
+    description: "npm Access Token",
+    regex: /npm_[A-Za-z0-9]{36}/g,
     category: "secret",
   },
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -37,7 +37,7 @@ export function luhn(str: string): boolean {
 export function entropy(str: string): number {
   if (str.length === 0) return 0;
   const freq: Record<string, number> = {};
-  for (const ch of str) freq[ch] = (freq[ch] || 0) + 1;
+  for (const ch of str) freq[ch] = (freq[ch] ?? 0) + 1;
   let h = 0;
   const n = str.length;
   for (const count of Object.values(freq)) {
@@ -164,7 +164,7 @@ const SECRET_RULES: Rule[] = [
   {
     id: "openai-key",
     description: "OpenAI API Key (legacy)",
-    regex: /sk-[A-Za-z0-9]{48}/g,
+    regex: /sk-(?!proj-|ant-)[A-Za-z0-9]{48}/g,
     category: "secret",
   },
   {

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -173,9 +173,10 @@ function block(
   detectionLines: string[],
   allowHints: string[],
 ): never {
+  const bird = randomBird();
   const terminalMessage = [
     "",
-    `${randomBird()} sensitive-canary: blocked — ${source}`,
+    `${bird} sensitive-canary: blocked — ${source}`,
     "",
     ...detectionLines,
     "",
@@ -189,7 +190,6 @@ function block(
     process.stderr.write(terminalMessage);
   }
 
-  const bird = randomBird();
   const reasonLines = [
     `${bird} sensitive-canary blocked: ${source}`,
     "",
@@ -218,7 +218,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
     block(
       filePath,
       [
-        `${randomBird()}  Blocked: .env and .env.* files contain secrets and must not be read into the conversation.`,
+        "Blocked: .env and .env.* files contain secrets and must not be read into the conversation.",
       ],
       buildAllowHints(`please read ${filePath}`, [], true),
     );
@@ -236,11 +236,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
 
   block(
     filePath,
-    [
-      `${randomBird()}  Blocked: file contains sensitive data`,
-      "",
-      ...findingsToLines(findings),
-    ],
+    ["Blocked: file contains sensitive data", "", ...findingsToLines(findings)],
     buildAllowHints(`please read ${filePath}`, findings),
   );
 }
@@ -281,7 +277,7 @@ process.stdin.on("end", () => {
       block(
         `bash command: ${command.slice(0, 80)}`,
         [
-          `${randomBird()}  Blocked: environment variable $${varName} contains sensitive data`,
+          `Blocked: environment variable $${varName} contains sensitive data`,
           "",
           ...findingsToLines(findings),
         ],
@@ -297,7 +293,7 @@ process.stdin.on("end", () => {
       block(
         `bash command: ${command.slice(0, 80)}`,
         [
-          `${randomBird()}  Blocked: bash command contains sensitive data`,
+          "Blocked: bash command contains sensitive data",
           "",
           ...findingsToLines(cmdFindings),
         ],

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -57,15 +57,18 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
     } else {
       const buf = Buffer.alloc(MAX_TRANSCRIPT_TAIL_BYTES);
       const fd = fs.openSync(transcriptPath, "r");
-      fs.readSync(
-        fd,
-        buf,
-        0,
-        MAX_TRANSCRIPT_TAIL_BYTES,
-        stat.size - MAX_TRANSCRIPT_TAIL_BYTES,
-      );
-      fs.closeSync(fd);
-      raw = buf.toString("utf8");
+      try {
+        const bytesRead = fs.readSync(
+          fd,
+          buf,
+          0,
+          MAX_TRANSCRIPT_TAIL_BYTES,
+          stat.size - MAX_TRANSCRIPT_TAIL_BYTES,
+        );
+        raw = buf.subarray(0, bytesRead).toString("utf8");
+      } finally {
+        fs.closeSync(fd);
+      }
     }
   } catch {
     return new Set();
@@ -255,11 +258,16 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
     const bytesToRead = Math.min(stat.size, MAX_SCAN_BYTES);
     const buf = Buffer.alloc(bytesToRead);
     const fd = fs.openSync(filePath, "r");
-    fs.readSync(fd, buf, 0, bytesToRead, 0);
-    fs.closeSync(fd);
+    let bytesRead: number;
+    try {
+      bytesRead = fs.readSync(fd, buf, 0, bytesToRead, 0);
+    } finally {
+      fs.closeSync(fd);
+    }
+    const data = buf.subarray(0, bytesRead);
     // Skip binary files: if NUL byte exists in the first 8KB, assume binary
-    if (buf.subarray(0, 8192).includes(0)) return;
-    content = buf.toString("utf8");
+    if (data.subarray(0, 8192).includes(0)) return;
+    content = data.toString("utf8");
   } catch {
     return;
   }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -268,9 +268,12 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
       fs.closeSync(fd);
     }
     const data = buf.subarray(0, bytesRead);
-    // Skip binary files: if NUL byte exists in the first 8KB, assume binary
-    if (data.subarray(0, 8192).includes(0)) return;
-    content = data.toString("utf8");
+    // Binary files: scan only the text prefix before the first NUL byte
+    const nulIndex = data.indexOf(0);
+    content = (nulIndex === -1 ? data : data.subarray(0, nulIndex)).toString(
+      "utf8",
+    );
+    if (content.length === 0) return;
   } catch {
     return;
   }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -25,6 +25,15 @@ interface TranscriptLine {
   message?: Message;
 }
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+// Maximum bytes to read when scanning file contents for secrets/PII.
+// Files larger than this are scanned up to this limit; the remainder is skipped.
+const MAX_SCAN_BYTES = 1_048_576; // 1 MB
+
+// Maximum bytes to read from the tail of a transcript file.
+const MAX_TRANSCRIPT_TAIL_BYTES = 65_536; // 64 KB
+
 // ── Transcript ────────────────────────────────────────────────────────────────
 
 // Returns true when the message contains at least one text content block
@@ -42,7 +51,22 @@ function hasTextContent(msg: Message): boolean {
 function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
   let raw: string;
   try {
-    raw = fs.readFileSync(transcriptPath, "utf8");
+    const stat = fs.statSync(transcriptPath);
+    if (stat.size <= MAX_TRANSCRIPT_TAIL_BYTES) {
+      raw = fs.readFileSync(transcriptPath, "utf8");
+    } else {
+      const buf = Buffer.alloc(MAX_TRANSCRIPT_TAIL_BYTES);
+      const fd = fs.openSync(transcriptPath, "r");
+      fs.readSync(
+        fd,
+        buf,
+        0,
+        MAX_TRANSCRIPT_TAIL_BYTES,
+        stat.size - MAX_TRANSCRIPT_TAIL_BYTES,
+      );
+      fs.closeSync(fd);
+      raw = buf.toString("utf8");
+    }
   } catch {
     return new Set();
   }
@@ -226,7 +250,16 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
 
   let content: string;
   try {
-    content = fs.readFileSync(filePath, "utf8");
+    const stat = fs.statSync(filePath);
+    if (stat.size === 0) return;
+    const bytesToRead = Math.min(stat.size, MAX_SCAN_BYTES);
+    const buf = Buffer.alloc(bytesToRead);
+    const fd = fs.openSync(filePath, "r");
+    fs.readSync(fd, buf, 0, bytesToRead, 0);
+    fs.closeSync(fd);
+    // Skip binary files: if NUL byte exists in the first 8KB, assume binary
+    if (buf.subarray(0, 8192).includes(0)) return;
+    content = buf.toString("utf8");
   } catch {
     return;
   }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -211,8 +211,11 @@ function block(
 
   try {
     const fd = fs.openSync("/dev/tty", "w");
-    fs.writeSync(fd, terminalMessage);
-    fs.closeSync(fd);
+    try {
+      fs.writeSync(fd, terminalMessage);
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch {
     process.stderr.write(terminalMessage);
   }

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -76,22 +76,14 @@ process.stdin.on("end", () => {
     process.exit(2);
   }
 
-  const unique: Finding[] = afterAllow.filter(
-    (f) =>
-      !(f.category === "secret" && effectiveMask.has("secret")) &&
-      !(f.category === "pii" && effectiveMask.has("pii")),
-  );
-
-  if (unique.length === 0) process.exit(0);
-
-  const hasSecret = unique.some((f) => f.category === "secret");
-  const hasPii = unique.some((f) => f.category === "pii");
+  const hasSecret = afterAllow.some((f) => f.category === "secret");
+  const hasPii = afterAllow.some((f) => f.category === "pii");
 
   const blockLines = [
     "",
     `${randomBird()} sensitive-canary: sensitive data detected — blocked`,
     "",
-    ...findingsToLines(unique),
+    ...findingsToLines(afterAllow),
     "",
     "To allow, add a tag to your prompt:",
     ...(hasSecret ? ["  [allow-secret]  — allow secrets"] : []),


### PR DESCRIPTION
## Summary

- Use nullish coalescing (`??`) instead of logical OR (`||`) in `entropy()` for correct semantics under `noUncheckedIndexedAccess`
- Add negative lookahead to `openai-key` regex (`(?!proj-|ant-)`) to prevent overlapping matches with `openai-project-key` and `anthropic-key`
- Remove unreachable `unique` filter in `user-prompt-submit-hook` (dead code after mask branch exit)
- Consolidate `randomBird()` calls in `block()` to single invocation for consistent emoji in terminal and JSON output
- Remove redundant `randomBird()` from `detectionLines` arguments — emoji is already rendered in the `block()` header line
- Add `gcp-api-key` and `npm-token` detection rules with tests
- Add regression tests for `openai-key` negative lookahead
- Limit file content scanning to first 1 MB and transcript reading to last 64 KB for performance
- Skip binary files by detecting NUL bytes in the first 8 KB
- Use `bytesRead` return value from `fs.readSync` and wrap fd operations in `try/finally`

## Known tradeoffs

- **File scan limit (1 MB):** Secrets beyond the first 1 MB of a file will not be detected. This is an intentional tradeoff — secrets in configuration files, source code, and `.env` files are overwhelmingly located near the beginning. Scanning unbounded file sizes risks OOM and long hook latency.
- **Transcript tail read (64 KB):** Only the last 64 KB of the transcript is read for allow-tag resolution. A single JSONL user message exceeding 64 KB could cause the allow tag to be missed, falling back to the default block behavior (safe side). In practice, user messages are well under this limit.

## Test plan

- [x] `pnpm run ci` passes (typecheck + biome check + 187 tests)
- [ ] Verify block messages display single consistent bird emoji
- [ ] Verify `sk-proj-*` and `sk-ant-*` keys are not matched by `openai-key` rule
- [ ] Verify GCP API key and npm token detection
- [ ] Verify binary files are skipped