### PR TITLE
ci(pnpm): pin pnpm to v10 to match lockfile format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: "10"
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: "24"


### PR DESCRIPTION
## Summary

CI used `pnpm/action-setup@v6` with `version: latest`, so it began pulling **pnpm 11** once released. pnpm 11 changes lockfile format and enforces `ERR_PNPM_IGNORED_BUILDS` strictly, both of which broke every CI job at `pnpm install --frozen-lockfile`.

## Change

Pin pnpm to `version: "10"` in `ci.yml`, `docs.yml`, `release.yml`. The current `pnpm-lock.yaml` is `lockfileVersion: 9.0` (pnpm 10 format), so no lockfile churn is required.

## Verification

Locally with pnpm 10.2.1, `pnpm install --frozen-lockfile` exits 0 cleanly.

## Follow-ups

After this lands, the 4 open Renovate PRs need to be rebased to pick up the pin.