### PR TITLE
ci(pnpm): add packageManager field to pin pnpm everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-        with:
-          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -34,8 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-        with:
-          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -50,8 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-        with:
-          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -66,8 +60,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-        with:
-          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: "10"
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: "10"
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "typescript": "^5.9.3",
     "vitepress": "^1.6.4",
     "vitest": "^4.0.18"
-  }
+  },
+  "packageManager": "pnpm@10.34.4"
 }


### PR DESCRIPTION
## Summary

Follow-up to #84. The workflow-only pin caused a new failure mode: Renovate uses its own pnpm version when regenerating \`pnpm-lock.yaml\`, which drops the \`overrides\` section that v10's \`pnpm install --frozen-lockfile\` expects — every rebased Renovate PR now fails with \`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH\`.

Adding the \`packageManager\` field forces Renovate (which honors it natively) and Corepack-using devs to the same pnpm version as CI.

## Verification

- Affected PRs (#82, #70, #66) currently fail at install with \`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH\`.
- After this lands, Renovate will rebase using pnpm 10 and the lockfile will round-trip cleanly.

## Follow-ups

After merge, re-trigger rebase on #82/#70/#66.