### PR TITLE
chore: set dependency minimumReleaseAge to 1 day

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,6 @@ overrides:
   rollup: ^4.59.0
   esbuild: ^0.28.0
   vite: ^8.0.0
+
+# Supply-chain policy: reject packages published less than 1 day ago (minutes)
+minimumReleaseAge: 1440

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "1 day"
     },
     {
       "description": "Update package managers",
@@ -40,5 +40,5 @@
       "groupName": "devDependencies"
     }
   ],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "1 day"
 }


### PR DESCRIPTION
Aligns the minimum release age across Renovate and the package manager at 1 day:

- `renovate.json`: `minimumReleaseAge` 7 days → 1 day (global and automerge rule)
- `pnpm-workspace.yaml`: explicit `minimumReleaseAge: 1440` (minutes; pnpm 11's built-in default is also 1 day, this makes it deliberate)

One day is enough to block the typical compromised-package window (malicious versions are usually yanked within hours) while keeping security patches flowing quickly.