### PR TITLE
chore: extend the shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,49 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "dependencyDashboard": true,
-  "osvVulnerabilityAlerts": true,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
+  "extends": ["github>coo-quack/renovate-config"],
   "packageRules": [
-    {
-      "description": "Automerge all updates when CI passes",
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "1 day"
-    },
-    {
-      "description": "Update package managers",
-      "matchPackagePatterns": [
-        "npm",
-        "pnpm",
-        "bun"
-      ],
-      "enabled": true
-    },
-    {
-      "description": "Group all devDependencies",
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "groupName": "devDependencies"
-    },
     {
       "description": "Skip broken pnpm 11.12.0 (self-installer regression)",
       "matchPackageNames": ["pnpm"],
       "allowedVersions": "<11.12.0 || >11.12.0"
     }
-  ],
-  "minimumReleaseAge": "1 day"
+  ]
 }


### PR DESCRIPTION
40-odd lines → 4. This configuration was a copy of the same block carried by five other repositories, and the copies had drifted. The common part now lives once, in [coo-quack/renovate-config](https://github.com/coo-quack/renovate-config).

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>coo-quack/renovate-config"]
}
```

Two things arrive by inheritance, which this repo did not have before:

- **`helpers:pinGitHubActionDigests`** — action refs get pinned to commit digests and kept current, so a moved tag cannot change what CI runs.
- **The deprecated `matchPackagePatterns` key is gone**, so `renovate-config-validator` stops reporting `Config migration necessary`.

Everything else is unchanged: automerge on green with a one-day minimum release age, the Dependency Dashboard, OSV alerts, lock file maintenance, and devDependencies grouped.

Validated with `renovate-config-validator`, on this file and on the preset.

## Kept locally

The pnpm 11.12.0 exclusion stays here — it is genuinely specific to this repo, not something the other five should inherit:

```json
{
  "description": "Skip broken pnpm 11.12.0 (self-installer regression)",
  "matchPackageNames": ["pnpm"],
  "allowedVersions": "<11.12.0 || >11.12.0"
}
```