### PR TITLE
style: apply biome 2.5.5's formatting

### DIFF
--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -386,23 +386,18 @@ describe("pre-tool-use-hook — Bash tool (command string)", () => {
 // ── Bash tool — file-reading command blocking ─────────────────────────────────
 
 describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
-  it.each([
-    "cat",
-    "head",
-    "tail",
-    "less",
-    "more",
-    "bat",
-    "nl",
-  ])("blocks %s on a file with secrets", (cmd) => {
-    const p = writeFixture(
-      `creds-${cmd}.txt`,
-      "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n",
-    );
-    const { exitCode, decision } = runBashHook(`${cmd} ${p}`);
-    expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
-  });
+  it.each(["cat", "head", "tail", "less", "more", "bat", "nl"])(
+    "blocks %s on a file with secrets",
+    (cmd) => {
+      const p = writeFixture(
+        `creds-${cmd}.txt`,
+        "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n",
+      );
+      const { exitCode, decision } = runBashHook(`${cmd} ${p}`);
+      expect(exitCode).toBe(2);
+      expect(decision).toBe("block");
+    },
+  );
 
   it("blocks cat on a file with PII", () => {
     const p = writeFixture("contacts-bash.txt", "Email: user@example.com\n");


### PR DESCRIPTION
`format` has been red on `develop` since #134 landed biome 2.5.5.

2.5.5 breaks the `it.each` call differently — the array collapses back to one line and the arguments split instead:

```diff
-  it.each([
-    "cat",
-    "head",
-    …
-  ])("blocks %s on a file with secrets", (cmd) => {
+  it.each(["cat", "head", …])(
+    "blocks %s on a file with secrets",
+    (cmd) => {
```

Whitespace only, one file.

My fault: I merged #134 without waiting for its checks. The promotion PR #137 is what surfaced it.

## Verification

`pnpm run ci` with `CI=true`: typecheck, biome, 190 tests passing. `pnpm run format:check` clean.