### PR TITLE
ci: fail on a high advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GitHub auto-dismissed a CVSS 7.5 advisory in a sibling repo, so its alert
+  # list read as clean while the advisory was live in the tree. `pnpm audit`
+  # reported it throughout. This is the check that notices.
+  #
+  # The threshold is `high`: below that, an upstream package with no fix
+  # available would hold the branch red for something not worth blocking on.
+  # To accept a specific high knowingly, add `--ignore <GHSA-id>` with a
+  # comment saying why — visible and reviewable, unlike a silent dismissal.
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.0'
+      - run: corepack enable pnpm
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.0'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm audit --audit-level high
+
   typecheck:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
GitHub auto-dismissed **GHSA-mh99-v99m-4gvg** (CVSS 7.5) in `talkative-lobster`. That repository's Dependabot alert list read as zero open while the advisory was live in its tree; `pnpm audit` reported it throughout. It surfaced only because someone ran the audit by hand.

The same blind spot applies here. This closes it.

## Threshold

`high`. Below that, an upstream package with no fix available holds the branch red over something not worth blocking a merge on — `openclaw-cursor-cli` has two such moderates right now, both owned by a dependency it does not ship.

To accept a specific high knowingly:

```
- run: pnpm audit --audit-level high --ignore GHSA-xxxx-xxxx-xxxx  # why
```

That lands in a diff and gets reviewed, unlike a dismissal that happens somewhere else and leaves no trace in the repository.

## State today

```
pnpm audit → {"info":0,"low":0,"moderate":0,"high":0,"critical":0}
```

Green from the first run.

## Follow-up

Adding `audit` to `ci_contexts` in `coo-quack/iac` would make it blocking. Worth doing once it has a track record.