### PR TITLE
fix(ci): mint an app token for the marketplace sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,23 @@ jobs:
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Scoped to the one repository this needs to reach, and minted per run.
+      # It replaces a personal access token that was issued in March and never
+      # rotated. calc-mcp already dispatches this way.
+      - name: Mint app token for marketplace sync
+        if: steps.gh_release.outputs.created == 'true'
+        id: marketplace-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+          owner: coo-quack
+          repositories: claude-code-marketplace
+
       - name: Sync marketplace
         if: steps.gh_release.outputs.created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
+          GH_TOKEN: ${{ steps.marketplace-token.outputs.token }}
         run: |
           gh api repos/coo-quack/claude-code-marketplace/dispatches \
             -f event_type=plugin-released \


### PR DESCRIPTION
The marketplace dispatch used `MARKETPLACE_TOKEN`, a personal access token issued **2026-03-15 and never rotated**. Nothing in the repository records what scope it carries.

`calc-mcp` already does this the other way — an app token minted per run and scoped with `repositories: claude-code-marketplace`, so it reaches exactly the one repository the dispatch targets and expires on its own.

## Why this is safe without a trial release

The credentials are the ones `backport.yml` in **this** repository already uses: the org `BACKPORT_APP_ID` variable and the org `BACKPORT_APP_PRIVATE_KEY` secret, both of which list this repo. That workflow minted a token successfully today (`Sync main to develop`, 2026-07-26, success).

What is new is the `repositories:` scoping, and `calc-mcp` proves that: its dispatches reached `claude-code-marketplace` on v2.0.3 and v2.0.4. Those syncs failed inside the receiving repository at `gh pr create`, well past the dispatch — fixed separately in claude-code-marketplace#31.

## One difference from do-not-compact

That repo's dispatch carries `continue-on-error: true`; this one does not. So a token that failed to mint would fail the release job here.

That is the right outcome. The alternative is a release that ships while the marketplace never hears about it — which is exactly what happened to `calc-mcp` for two releases and left the marketplace advertising 2.0.2 against a real 2.0.4.

The minting step carries the same `if` as the dispatch it feeds, so neither runs when no GitHub Release was created.

## Follow-up

`MARKETPLACE_TOKEN` gets deleted from this repository once this lands. `do-not-compact` carries the same PAT and gets the same change in #47.