### PR TITLE
release: promote develop to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GitHub auto-dismissed a CVSS 7.5 advisory in a sibling repo, so its alert
+  # list read as clean while the advisory was live in the tree. `pnpm audit`
+  # reported it throughout. This is the check that notices.
+  #
+  # The threshold is `high`: below that, an upstream package with no fix
+  # available would hold the branch red for something not worth blocking on.
+  # To accept a specific high knowingly, add `--ignore <GHSA-id>` with a
+  # comment saying why — visible and reviewable, unlike a silent dismissal.
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.0'
+      - run: corepack enable pnpm
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.0'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm audit --audit-level high
+
   typecheck:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,23 @@ jobs:
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Scoped to the one repository this needs to reach, and minted per run.
+      # It replaces a personal access token that was issued in March and never
+      # rotated. calc-mcp already dispatches this way.
+      - name: Mint app token for marketplace sync
+        if: steps.gh_release.outputs.created == 'true'
+        id: marketplace-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+          owner: coo-quack
+          repositories: claude-code-marketplace
+
       - name: Sync marketplace
         if: steps.gh_release.outputs.created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
+          GH_TOKEN: ${{ steps.marketplace-token.outputs.token }}
         run: |
           gh api repos/coo-quack/claude-code-marketplace/dispatches \
             -f event_type=plugin-released \


### PR DESCRIPTION
**Time-sensitive.** `main` still references `secrets.MARKETPLACE_TOKEN`, and that secret has been deleted.

`release.yml` runs on push to `main` using `main`'s copy, so the next release would reach the sync step with an empty secret. Unlike do-not-compact this step has no `continue-on-error`, so the release job would fail — after the GitHub Release was already created.

#141 replaced the PAT with an app token minted per run and scoped to `claude-code-marketplace`. This puts it on `main`, where the release workflow reads it.

The PAT was deleted before this promotion, which was the wrong order. Nothing has released in between, so the window closes here.

## Also carried

#140, the `audit` job — `pnpm audit --audit-level high` on every pull request. GitHub auto-dismissed a CVSS 7.5 advisory in a sibling repo while its alert list read as clean, and this is the check that notices.

## No version bump

`package.json` stays at 0.5.3; only workflows changed. `release.yml` skips when the tag and npm version already exist.