### PR TITLE
feat: add SENSITIVE_CANARY_CATEGORIES to filter rule categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,40 @@
-## v0.5.2 (2026-03-31)
-
-### Security
-
-- Add `minimumReleaseAge` to renovate.json to prevent supply chain attacks
-  - Waits 7 days before auto-merging dependency updates
-  - Reduces risk of package takeover attacks
-  - Blocks immediate auto-merge of newly published packages
-
----
-
-## v0.5.2 (2026-03-31)
-
-### Security
-
-- Add `minimumReleaseAge` to renovate.json to prevent supply chain attacks
-  - Waits 7 days before auto-merging dependency updates
-  - Reduces risk of package takeover attacks
-  - Blocks immediate auto-merge of newly published packages
-
----
-
 # Changelog
+
+## v0.6.0 (Unreleased)
+
+### Features
+
+- Add `SENSITIVE_CANARY_CATEGORIES` environment variable to limit which rule categories are active
+  - Accepts `secret`, `pii`, `secret,pii`, or `all` (comma-separated, case-insensitive); unset/empty/invalid means all categories
+  - Useful for reducing PII false positives (e.g. credit card or phone number rules firing on test fixtures) by scanning secrets only
+  - The name-based `.env`/`.env.*` block is a secret guard and is disabled when the `secret` category is not enabled
+
+---
+
+## v0.5.3 (2026-06-27)
+
+### CI
+
+- Rework the main→develop sync to open a PR with auto-merge, using a minted GitHub App token so the created PR triggers CI
+- Disable persist-credentials in the sync workflow so the App token push works
+
+### Dependencies
+
+- Pin pnpm via the `packageManager` field and update pnpm to v11 (security)
+- Update node to v24, vite to v8, typescript to v6, and other dev dependencies and GitHub Actions
+
+---
+
+## v0.5.2 (2026-03-31)
+
+### Security
+
+- Add `minimumReleaseAge` to renovate.json to prevent supply chain attacks
+  - Waits 7 days before auto-merging dependency updates
+  - Reduces risk of package takeover attacks
+  - Blocks immediate auto-merge of newly published packages
+
+---
 
 ## v0.5.1 (2026-03-15)
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ To allow it through, add the suggested tag:
 
 ### .env file blocked
 
-`.env` / `.env.*` files are blocked unconditionally, regardless of their contents.
+`.env` / `.env.*` files are blocked by filename, regardless of their contents. This name-based block is a secret guard and only applies while the `secret` category is enabled (the default).
 
 ```
 > Read .env
@@ -225,6 +225,32 @@ To intentionally bypass a block, include the appropriate tag in your **current p
 | `[allow-all]` | Skip all sensitive-canary checks |
 
 > **Note:** Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass. Tags are case-insensitive. `[allow-secret]` does not bypass PII blocks (and vice versa). The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
+
+---
+
+## Configuration
+
+### `SENSITIVE_CANARY_CATEGORIES`
+
+Limit which rule categories are active. Set it in the `env` block of your Claude Code `settings.json`:
+
+```json
+{
+  "env": {
+    "SENSITIVE_CANARY_CATEGORIES": "secret"
+  }
+}
+```
+
+| Value | Effect |
+|---|---|
+| `secret` | Scan for secrets only — PII rules are disabled |
+| `pii` | Scan for PII only — secret rules and the name-based `.env`/`.env.*` block are disabled |
+| `secret,pii` / `all` | Scan everything (default) |
+
+Values are comma-separated and case-insensitive. Unset, empty, or containing no valid token means all categories are enabled.
+
+This is a persistent filter, unlike allow tags which apply per prompt. The category filter is applied first, then allow tags. A typical use is setting `secret` when PII rules (credit card numbers, phone numbers, …) are too noisy against test fixtures.
 
 ---
 
@@ -302,7 +328,7 @@ Claude calls Read / Bash tool
 PreToolUse hook
       ↓
       ── Read tool ─────────────────────────────────────────────────────
-      │  1. filename is .env / .env.* → blocked unconditionally
+      │  1. filename is .env / .env.* → blocked (secret category only)
       │  2. file contents contain secret / PII → blocked
       └─ Bash tool ─────────────────────────────────────────────────────
          1. env var values referenced in the command contain secret / PII → blocked
@@ -317,7 +343,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 
 ## Allow Tags (detailed)
 
-Allow tags filter the scan results — the scan itself always runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
+Allow tags filter the scan results — the scan still runs. The `.env`/`.env.*` name block is the only exception: when an allow tag is present, the file is passed through immediately without scanning.
 
 ### Mask tags
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ Sensitive Canary intercepts secrets and PII before they leave your machine:
 | Secret in prompt | `UserPromptSubmit` | Blocks the prompt before the API call |
 | PII in prompt | `UserPromptSubmit` | Blocks the prompt before the API call |
 | Secret in file Claude reads | `PreToolUse` (Read) | Blocks the file read before contents are sent |
-| `.env` file exposure | `PreToolUse` (Read) | Blocks by filename, unconditionally |
+| `.env` file exposure | `PreToolUse` (Read) | Blocks by filename (secret category only) |
 | Secret in Bash command | `PreToolUse` (Bash) | Blocks the command before execution |
 | Secret in env var value | `PreToolUse` (Bash) | Expands and scans `$VAR` references |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,26 @@ When sensitive data is detected, the action is blocked and the terminal shows wh
 
 Tags apply only to the message they appear in. They do not persist across turns. For PreToolUse hooks, allow tags are single-use — they are consumed by the first tool call. If Claude needs to perform multiple tool calls for the same request, you may need to include the tag again.
 
+## Configuration
+
+Set `SENSITIVE_CANARY_CATEGORIES` in the `env` block of your Claude Code `settings.json` to limit which rule categories are active:
+
+```json
+{
+  "env": {
+    "SENSITIVE_CANARY_CATEGORIES": "secret"
+  }
+}
+```
+
+| Value | Effect |
+|-------|--------|
+| `secret` | Scan for secrets only — PII rules are disabled |
+| `pii` | Scan for PII only — secret rules and the name-based `.env`/`.env.*` block are disabled |
+| `secret,pii` / `all` | Scan everything (default) |
+
+This persistent filter is applied before allow tags. A typical use is setting `secret` when PII rules are too noisy against test fixtures.
+
 ## Next Steps
 
 - [Installation](/install) — alternative installation methods

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 
 | Without Sensitive Canary | With Sensitive Canary |
 |--------------------------|----------------------|
-| `cat .env` → full contents sent to Claude ❌ | Blocked by name before Claude reads it ✅ |
+| `cat .env` → full contents sent to Claude ❌ | Blocked by name by default before Claude reads it ✅ |
 | Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
 | Tool result contains user@email.com ❌ | PII detected and blocked ✅ |
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |

--- a/docs/install.md
+++ b/docs/install.md
@@ -167,7 +167,7 @@ To allow, add a tag to your prompt:
 
 Runs before Claude uses the `Read` or `Bash` tool. It blocks:
 
-- `.env` and `.env.*` files unconditionally (by filename)
+- `.env` and `.env.*` files by filename (a secret guard; only while the `secret` category is enabled)
 - Any file whose contents contain secrets or PII
 - `cat`, `head`, `tail`, and other file-reading commands targeting sensitive files
 - Bash commands containing secrets inline (e.g. `echo AKIAIOSFODNN7EXAMPLE`)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -129,9 +129,21 @@ When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag t
 
 `[allow-all]` and `[mask-all]` resolve both dimensions at once.
 
+## Category Filtering
+
+Set the `SENSITIVE_CANARY_CATEGORIES` environment variable (e.g. in the `env` block of Claude Code `settings.json`) to limit which rule categories are active:
+
+| Value | Effect |
+|-------|--------|
+| `secret` | Scan for secrets only — PII rules are disabled |
+| `pii` | Scan for PII only — secret rules and the name-based `.env`/`.env.*` block are disabled |
+| `secret,pii` / `all` | Scan everything (default) |
+
+Values are comma-separated and case-insensitive. Unset, empty, or containing no valid token means all categories are enabled. This persistent filter is applied before allow tags.
+
 ## .env File Blocking
 
-`.env` and `.env.*` files (e.g. `.env.local`, `.env.production`) are blocked **unconditionally by filename** when Claude attempts to read them, regardless of content.
+`.env` and `.env.*` files (e.g. `.env.local`, `.env.production`) are blocked **by filename** when Claude attempts to read them, regardless of content. This name-based block is a secret guard: it only applies while the `secret` category is enabled via `SENSITIVE_CANARY_CATEGORIES`.
 
 Files that end in `.env` but don't start with a dot (e.g. `production.env`) are handled by content scanning rather than name-based blocking.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,9 +23,9 @@ If legitimate content is being blocked:
 - Allow tags apply only to the current message and do not persist
 - For PreToolUse hooks, allow tags are single-use — they are consumed by the first tool call. If Claude performs multiple tool calls, you may need to include the tag again
 
-## .env files always blocked
+## .env file blocking
 
-This is by design. `.env` and `.env.*` files are blocked unconditionally by filename, regardless of their contents. Any allow tag (`[allow-secret]`, `[allow-pii]`, or `[allow-all]`) will bypass this block if you need Claude to read an `.env` file intentionally.
+This is by design. `.env` and `.env.*` files are blocked by filename, regardless of their contents, but only while the `secret` category is enabled (the default). Any allow tag (`[allow-secret]`, `[allow-pii]`, or `[allow-all]`) will bypass this block if you need Claude to read an `.env` file intentionally.
 
 ## Plugin not found after marketplace registration
 

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -58,7 +58,7 @@ function writeTranscriptWithToolResults(
 function runHook(
   toolName: string,
   filePath: string,
-  opts?: { transcriptPath?: string },
+  opts?: { env?: Record<string, string>; transcriptPath?: string },
 ) {
   const input = JSON.stringify({
     transcript_path: opts?.transcriptPath,
@@ -68,6 +68,7 @@ function runHook(
   const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
     input,
     encoding: "utf8",
+    env: { ...process.env, ...opts?.env },
   });
   const { decision, reason } = parseHookOutput(result.stdout);
   return {
@@ -135,9 +136,9 @@ describe("pre-tool-use-hook — non-Read/non-Bash tools", () => {
   });
 });
 
-// ── .env / .env.* — unconditional name block ──────────────────────────────────
+// ── .env / .env.* — secret name block ─────────────────────────────────────────
 
-describe("pre-tool-use-hook — .env/.env.* unconditional block", () => {
+describe("pre-tool-use-hook — .env/.env.* name block (secret category)", () => {
   it("blocks .env regardless of content", () => {
     const p = writeFixture(".env", "DEBUG=true\nNODE_ENV=development\n");
     const { exitCode, decision } = runHook("Read", p);
@@ -704,5 +705,75 @@ describe("pre-tool-use-hook — malformed input", () => {
       encoding: "utf8",
     });
     expect(result.status).toBe(0);
+  });
+});
+
+// ── SENSITIVE_CANARY_CATEGORIES ───────────────────────────────────────────────
+
+describe("pre-tool-use-hook — SENSITIVE_CANARY_CATEGORIES", () => {
+  it("pii-only: allows reading .env files (secret guard disabled)", () => {
+    const dir = join(tmpDir, "pii-only-env");
+    mkdirSync(dir, { recursive: true });
+    const p = join(dir, ".env");
+    writeFileSync(p, "DEBUG=true\n", "utf8");
+    const { exitCode } = runHook("Read", p, {
+      env: { SENSITIVE_CANARY_CATEGORIES: "pii" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("pii-only: allows a file containing only secrets", () => {
+    const p = writeFixture("pii-only-secret.txt", "key=AKIAIOSFODNN7EXAMPLE");
+    const { exitCode } = runHook("Read", p, {
+      env: { SENSITIVE_CANARY_CATEGORIES: "pii" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("pii-only: still blocks a file containing PII", () => {
+    const p = writeFixture("pii-only-pii.txt", "card: 4111111111111111");
+    const { exitCode, decision } = runHook("Read", p, {
+      env: { SENSITIVE_CANARY_CATEGORIES: "pii" },
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("secret-only: allows a file containing only PII", () => {
+    const p = writeFixture("secret-only-pii.txt", "card: 4111111111111111");
+    const { exitCode } = runHook("Read", p, {
+      env: { SENSITIVE_CANARY_CATEGORIES: "secret" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("secret-only: still blocks a file containing secrets", () => {
+    const p = writeFixture(
+      "secret-only-secret.txt",
+      "key=AKIAIOSFODNN7EXAMPLE",
+    );
+    const { exitCode, decision } = runHook("Read", p, {
+      env: { SENSITIVE_CANARY_CATEGORIES: "secret" },
+    });
+    expect(exitCode).toBe(2);
+    expect(decision).toBe("block");
+  });
+
+  it("secret-only: allows a bash command containing only PII", () => {
+    const { exitCode } = runBashHook("echo 4111111111111111", {
+      env: { SENSITIVE_CANARY_CATEGORIES: "secret" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("unset: blocks both secrets and PII (default behavior)", () => {
+    const p = writeFixture(
+      "default-both.txt",
+      "key=AKIAIOSFODNN7EXAMPLE\ncard: 4111111111111111",
+    );
+    const { exitCode, reason } = runHook("Read", p);
+    expect(exitCode).toBe(2);
+    expect(reason).toContain("aws-access-key");
+    expect(reason).toContain("pii-credit-card");
   });
 });

--- a/src/__tests__/user-prompt-submit-hook.test.ts
+++ b/src/__tests__/user-prompt-submit-hook.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, it } from "vitest";
 const HOOK = new URL("../user-prompt-submit-hook.ts", import.meta.url).pathname;
 const NODE_FLAGS = ["--experimental-strip-types"];
 
-function runHook(prompt: string) {
+function runHook(prompt: string, opts?: { env?: Record<string, string> }) {
   const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
     input: JSON.stringify({ prompt }),
     encoding: "utf8",
+    env: { ...process.env, ...opts?.env },
   });
   return {
     exitCode: result.status ?? -1,
@@ -251,5 +252,46 @@ describe("user-prompt-submit-hook — malformed input", () => {
       encoding: "utf8",
     });
     expect(result.status).toBe(0);
+  });
+});
+
+describe("user-prompt-submit-hook — SENSITIVE_CANARY_CATEGORIES", () => {
+  it("pii-only: passes a prompt containing only secrets", () => {
+    const { exitCode } = runHook("my key is AKIAIOSFODNN7EXAMPLE", {
+      env: { SENSITIVE_CANARY_CATEGORIES: "pii" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("pii-only: still blocks a prompt containing PII", () => {
+    const { exitCode, stderr } = runHook("my card is 4111111111111111", {
+      env: { SENSITIVE_CANARY_CATEGORIES: "pii" },
+    });
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("sensitive data detected");
+  });
+
+  it("secret-only: passes a prompt containing only PII", () => {
+    const { exitCode } = runHook("my card is 4111111111111111", {
+      env: { SENSITIVE_CANARY_CATEGORIES: "secret" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("secret-only: still blocks a prompt containing secrets", () => {
+    const { exitCode, stderr } = runHook("my key is AKIAIOSFODNN7EXAMPLE", {
+      env: { SENSITIVE_CANARY_CATEGORIES: "secret" },
+    });
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("sensitive data detected");
+  });
+
+  it("unset: blocks both secrets and PII (default behavior)", () => {
+    const { exitCode, stderr } = runHook(
+      "key AKIAIOSFODNN7EXAMPLE card 4111111111111111",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("aws-access-key");
+    expect(stderr).toContain("pii-credit-card");
   });
 });

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { entropy, luhn, redact, scan } from "../rules.ts";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  enabledCategoriesFromEnv,
+  entropy,
+  luhn,
+  parseCategories,
+  redact,
+  scan,
+} from "../rules.ts";
 
 // ── luhn ──────────────────────────────────────────────────────────────────────
 
@@ -348,5 +355,94 @@ describe("scan — PII", () => {
   it("does not flag a public IPv4 address", () => {
     const findings = scan("server: 8.8.8.8");
     expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(false);
+  });
+});
+
+// ── parseCategories ───────────────────────────────────────────────────────────
+
+describe("parseCategories", () => {
+  it("defaults to all categories when unset", () => {
+    expect(parseCategories(undefined)).toEqual(new Set(["secret", "pii"]));
+  });
+
+  it("defaults to all categories when empty", () => {
+    expect(parseCategories("")).toEqual(new Set(["secret", "pii"]));
+  });
+
+  it("parses a single category", () => {
+    expect(parseCategories("secret")).toEqual(new Set(["secret"]));
+    expect(parseCategories("pii")).toEqual(new Set(["pii"]));
+  });
+
+  it("parses a comma-separated list", () => {
+    expect(parseCategories("secret,pii")).toEqual(new Set(["secret", "pii"]));
+  });
+
+  it("treats 'all' as every category", () => {
+    expect(parseCategories("all")).toEqual(new Set(["secret", "pii"]));
+    expect(parseCategories("secret,all")).toEqual(new Set(["secret", "pii"]));
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(parseCategories(" Secret , PII ")).toEqual(
+      new Set(["secret", "pii"]),
+    );
+  });
+
+  it("falls back to all when no valid token is present", () => {
+    expect(parseCategories("foo,bar")).toEqual(new Set(["secret", "pii"]));
+  });
+});
+
+// ── scan: category filter ─────────────────────────────────────────────────────
+
+describe("scan — category filter", () => {
+  const text = "key=AKIAIOSFODNN7EXAMPLE card: 4111111111111111";
+
+  it("scans all categories by default", () => {
+    const findings = scan(text);
+    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
+    expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(true);
+  });
+
+  it("scans only secrets when limited to the secret category", () => {
+    const findings = scan(text, new Set(["secret"]));
+    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(true);
+    expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(false);
+  });
+
+  it("scans only PII when limited to the pii category", () => {
+    const findings = scan(text, new Set(["pii"]));
+    expect(findings.some((f) => f.ruleId === "aws-access-key")).toBe(false);
+    expect(findings.some((f) => f.ruleId === "pii-credit-card")).toBe(true);
+  });
+
+  it("returns nothing when no categories are enabled", () => {
+    expect(scan(text, new Set())).toEqual([]);
+  });
+});
+
+// ── enabledCategoriesFromEnv ──────────────────────────────────────────────────
+
+describe("enabledCategoriesFromEnv", () => {
+  const ENV_KEY = "SENSITIVE_CANARY_CATEGORIES";
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it("returns all categories when the env var is unset", () => {
+    delete process.env[ENV_KEY];
+    expect(enabledCategoriesFromEnv()).toEqual(new Set(["secret", "pii"]));
+  });
+
+  it("returns the parsed categories when the env var is set", () => {
+    process.env[ENV_KEY] = "pii";
+    expect(enabledCategoriesFromEnv()).toEqual(new Set(["pii"]));
   });
 });

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -1,7 +1,9 @@
+export type Category = "secret" | "pii";
+
 export interface Finding {
   ruleId: string;
   description: string;
-  category: "secret" | "pii";
+  category: Category;
   matchRedacted: string;
   secretValue: string;
 }
@@ -13,7 +15,30 @@ interface Rule {
   secretGroup?: number;
   entropyThreshold?: number;
   validate?: (str: string) => boolean;
-  category: "secret" | "pii";
+  category: Category;
+}
+
+const ALL_CATEGORIES: ReadonlySet<Category> = new Set(["secret", "pii"]);
+
+// Parse the SENSITIVE_CANARY_CATEGORIES env var: a comma-separated list of
+// "secret", "pii", or "all" (e.g. "secret" or "secret,pii"). Unset, empty, or
+// containing no valid token means all categories are enabled.
+export function parseCategories(value: string | undefined): Set<Category> {
+  const categories = new Set<Category>();
+  for (const token of (value ?? "").split(",")) {
+    const normalized = token.trim().toLowerCase();
+    if (normalized === "all") return new Set(ALL_CATEGORIES);
+    if (normalized === "secret" || normalized === "pii")
+      categories.add(normalized);
+  }
+  return categories.size > 0 ? categories : new Set(ALL_CATEGORIES);
+}
+
+// Rule categories enabled for this process, from SENSITIVE_CANARY_CATEGORIES
+// ("secret", "pii", "secret,pii", or "all"; default: all).
+export function enabledCategoriesFromEnv(): Set<Category> {
+  const { SENSITIVE_CANARY_CATEGORIES } = process.env;
+  return parseCategories(SENSITIVE_CANARY_CATEGORIES);
 }
 
 // Luhn algorithm checksum validation. Returns true if the number (digits only) passes.
@@ -292,10 +317,14 @@ export function redact(str: string): string {
   return `${str.slice(0, 4)}****${str.slice(-4)}`;
 }
 
-export function scan(text: string): Finding[] {
+export function scan(
+  text: string,
+  categories: ReadonlySet<Category> = ALL_CATEGORIES,
+): Finding[] {
   const findings: Finding[] = [];
 
   for (const rule of RULES) {
+    if (!categories.has(rule.category)) continue;
     for (const match of text.matchAll(rule.regex)) {
       const secretValue =
         rule.secretGroup != null ? match[rule.secretGroup] : match[0];

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -10,7 +10,7 @@ import {
   parseAllowTags,
   randomBird,
 } from "./lib/inspector.ts";
-import { type Finding, scan } from "./lib/rules.ts";
+import { enabledCategoriesFromEnv, type Finding, scan } from "./lib/rules.ts";
 
 interface HookInput {
   transcript_path?: string;
@@ -29,6 +29,8 @@ interface TranscriptLine {
 
 // Maximum bytes to read from the tail of a transcript file.
 const MAX_TRANSCRIPT_TAIL_BYTES = 65_536; // 64 KB
+
+const ENABLED_CATEGORIES = enabledCategoriesFromEnv();
 
 // ── Transcript ────────────────────────────────────────────────────────────────
 
@@ -150,12 +152,19 @@ function extractFilePathsFromCommand(command: string): string[] {
 
 // ── .env pattern ──────────────────────────────────────────────────────────────
 
-// .env and .env.* (e.g. .env.local, .env.production) are blocked unconditionally.
+// .env and .env.* (e.g. .env.local, .env.production) match the env filename pattern.
+// The block only applies while the "secret" category is enabled (see shouldBlockEnvFile).
 // Files that merely end in .env (e.g. production.env) are handled by content scanning.
 function isBlockedEnvFile(filePath: string): boolean {
   if (!filePath) return false;
   const base = path.basename(filePath);
   return base === ".env" || base.startsWith(".env.");
+}
+
+// The .env name-based block is a secret guard: it only applies while the
+// "secret" category is enabled.
+function shouldBlockEnvFile(filePath: string): boolean {
+  return ENABLED_CATEGORIES.has("secret") && isBlockedEnvFile(filePath);
 }
 
 // ── Output helpers ────────────────────────────────────────────────────────────
@@ -239,7 +248,7 @@ function block(
 // ── Core scan logic ───────────────────────────────────────────────────────────
 
 function scanFile(filePath: string, allowTags: Set<string>): void {
-  if (isBlockedEnvFile(filePath)) {
+  if (shouldBlockEnvFile(filePath)) {
     if (allowTags.size > 0) return;
     block(
       filePath,
@@ -263,7 +272,10 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
     return;
   }
 
-  const findings = applyAllowTags(dedupeFindings(scan(content)), allowTags);
+  const findings = applyAllowTags(
+    dedupeFindings(scan(content, ENABLED_CATEGORIES)),
+    allowTags,
+  );
   if (findings.length === 0) return;
 
   block(
@@ -308,7 +320,10 @@ process.stdin.on("end", () => {
     for (const varName of extractEnvVarNames(command)) {
       const value = process.env[varName];
       if (!value) continue;
-      const findings = applyAllowTags(dedupeFindings(scan(value)), allowTags);
+      const findings = applyAllowTags(
+        dedupeFindings(scan(value, ENABLED_CATEGORIES)),
+        allowTags,
+      );
       if (findings.length === 0) continue;
       block(
         `bash command: ${command.slice(0, 80)}`,
@@ -322,7 +337,7 @@ process.stdin.on("end", () => {
     }
 
     const cmdFindings = applyAllowTags(
-      dedupeFindings(scan(command)),
+      dedupeFindings(scan(command, ENABLED_CATEGORIES)),
       allowTags,
     );
     if (cmdFindings.length > 0) {

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -8,11 +8,13 @@ import {
   randomBird,
   resolveTagPriority,
 } from "./lib/inspector.ts";
-import { scan } from "./lib/rules.ts";
+import { enabledCategoriesFromEnv, scan } from "./lib/rules.ts";
 
 interface HookInput {
   prompt?: string;
 }
+
+const ENABLED_CATEGORIES = enabledCategoriesFromEnv();
 
 let raw = "";
 process.stdin.setEncoding("utf8");
@@ -27,7 +29,7 @@ process.stdin.on("end", () => {
 
   const prompt = data.prompt ?? "";
 
-  const allFindings = scan(prompt);
+  const allFindings = scan(prompt, ENABLED_CATEGORIES);
 
   if (allFindings.length === 0) process.exit(0);
 


### PR DESCRIPTION
## Summary

- Add `SENSITIVE_CANARY_CATEGORIES` env var to limit which rule categories are active: `secret` / `pii` / `secret,pii` / `all` (comma-separated, case-insensitive; unset/empty/invalid = all)
- Disabled categories are skipped inside `scan()` (regex/entropy work is not performed), wired through every scan site in both hooks (Read, Bash env-var/command-string/file-read, UserPromptSubmit)
- The name-based `.env`/`.env.*` block is a secret guard and is disabled when the `secret` category is not enabled
- Docs: README / getting-started / rules gain a Configuration section; CHANGELOG gains the v0.6.0 entry
- Also fixes pre-existing CHANGELOG.md structure issues: duplicated v0.5.2 section removed, `# Changelog` title restored to the top, missing v0.5.3 (2026-06-27) section added

## Test plan

- [x] `pnpm typecheck` / `pnpm exec biome check src` pass
- [x] `pnpm vitest run` — 215 tests pass (23 new: parseCategories, scan category filter, enabledCategoriesFromEnv, E2E for both hooks incl. .env gating)
- [ ] CI on this PR