### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@
   - Create `~/.config/sensitive-canary/config.json` or set `SENSITIVE_CANARY_CONFIG` to a custom path
   - Add new rules, override built-in rules by id, and set a custom `contextWindow`
   - Invalid rules are skipped with a warning; the rest of the config loads normally
+- Expand secret detection coverage (39 secret rules, up from 24)
+  - AI services: Replicate, Hugging Face, Groq, OpenRouter, xAI (Grok), Perplexity
+  - Cloud / IaaS: DigitalOcean PAT, Supabase PAT
+  - Payment: Square access token
+  - SaaS / Dev tools: Mapbox, Sentry (user + org tokens), Atlassian, Linear, Postman
+
+### Fixes
+
+- Fix My Number checksum: when the weighted-sum remainder is 0 or 1, the check digit is 0 (not invalid). Valid My Numbers ending in 0 were previously rejected.
+- Correct spec source abbreviation: JIPTEC → J-LIS (地方公共団体情報システム機構)
+- Harden `compileRule`: force `g` flag on regex, validate `regex` field, warn on unknown validator name
+- Pass `secretValue` (not full match) to validator so `secretGroup` + `validate` works in user rules
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Changelog
 
-## v0.6.0 (2026-08-02)
+## v0.7.0 (2026-08-04)
 
 ### Features
 
-- Add `SENSITIVE_CANARY_CATEGORIES` environment variable to limit which rule categories are active
-  - Accepts `secret`, `pii`, `secret,pii`, or `all` (comma-separated, case-insensitive); unset/empty/invalid means all categories
-  - Useful for reducing PII false positives (e.g. credit card or phone number rules firing on test fixtures) by scanning secrets only
-  - The name-based `.env`/`.env.*` block is a secret guard and is disabled when the `secret` category is not enabled
 - Add multi-region PII detection rules (25 PII rules, up from 7)
   - National IDs with checksum validation: Japanese My Number, French NIR, Italian Codice Fiscale, German Steuer-IdNr., Spanish DNI/NIE, Korean RRN and BRN, Chinese Resident Identity Card
   - Phone numbers for JP, US, FR, IT, DE, ES, KR, CN
@@ -36,6 +32,21 @@
 - Harden `compileRule`: force `g` flag on regex, validate `regex` field, warn on unknown validator name
 - Add strict schema validation for user-defined rules (required fields, optional field types, cross-field constraints)
 - Pass `secretValue` (not full match) to validator so `secretGroup` + `validate` works in user rules
+
+### Dependencies
+
+- Update pnpm to v11.19.0 and refresh the lockfile
+
+---
+
+## v0.6.0 (2026-08-02)
+
+### Features
+
+- Add `SENSITIVE_CANARY_CATEGORIES` environment variable to limit which rule categories are active
+  - Accepts `secret`, `pii`, `secret,pii`, or `all` (comma-separated, case-insensitive); unset/empty/invalid means all categories
+  - Useful for reducing PII false positives (e.g. credit card or phone number rules firing on test fixtures) by scanning secrets only
+  - The name-based `.env`/`.env.*` block is a secret guard and is disabled when the `secret` category is not enabled
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - Postal codes for JP, US/EU/KR (5/9-digit), and CN (6-digit)
   - Public IPv4 and IPv6 addresses (reserved ranges excluded)
 - Add context gating for noisy rules
-  - Rules with `requireContext` only fire when a nearby context word (phone, ZIP, IP, etc.) is found within ~2 sentences of the match
+  - Rules with `requireContext` only fire when a nearby context word (phone, ZIP, IP, etc.) is found within a small window around the match (default: 3 tokens ≈ 24 characters)
   - Reduces false positives on bare digit sequences without sacrificing detection when labels are present
 - Move all rule definitions to JSON (`src/lib/default-config.json`)
   - Rules are now data, not code — the full set can be inspected and modified without editing TypeScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix My Number checksum: when the weighted-sum remainder is 0 or 1, the check digit is 0 (not invalid). Valid My Numbers ending in 0 were previously rejected.
 - Correct spec source abbreviation: JIPTEC → J-LIS (地方公共団体情報システム機構)
 - Harden `compileRule`: force `g` flag on regex, validate `regex` field, warn on unknown validator name
+- Add strict schema validation for user-defined rules (required fields, optional field types, cross-field constraints)
 - Pass `secretValue` (not full match) to validator so `secretGroup` + `validate` works in user rules
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@
   - Accepts `secret`, `pii`, `secret,pii`, or `all` (comma-separated, case-insensitive); unset/empty/invalid means all categories
   - Useful for reducing PII false positives (e.g. credit card or phone number rules firing on test fixtures) by scanning secrets only
   - The name-based `.env`/`.env.*` block is a secret guard and is disabled when the `secret` category is not enabled
+- Add multi-region PII detection rules (25 PII rules, up from 7)
+  - National IDs with checksum validation: Japanese My Number, French NIR, Italian Codice Fiscale, German Steuer-IdNr., Spanish DNI/NIE, Korean RRN and BRN, Chinese Resident Identity Card
+  - Phone numbers for JP, US, FR, IT, DE, ES, KR, CN
+  - Postal codes for JP, US/EU/KR (5/9-digit), and CN (6-digit)
+  - Public IPv4 and IPv6 addresses (reserved ranges excluded)
+- Add context gating for noisy rules
+  - Rules with `requireContext` only fire when a nearby context word (phone, ZIP, IP, etc.) is found within ~2 sentences of the match
+  - Reduces false positives on bare digit sequences without sacrificing detection when labels are present
+- Move all rule definitions to JSON (`src/lib/default-config.json`)
+  - Rules are now data, not code — the full set can be inspected and modified without editing TypeScript
+  - Checksum validators remain in code and are referenced by name from the config
+- Add user-defined custom rules via config file
+  - Create `~/.config/sensitive-canary/config.json` or set `SENSITIVE_CANARY_CONFIG` to a custom path
+  - Add new rules, override built-in rules by id, and set a custom `contextWindow`
+  - Invalid rules are skipped with a warning; the rest of the config loads normally
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **49 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **64 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE)
 - **Context gating** — postal codes and FIGS phone numbers require a nearby label, reducing false positives on bare digit sequences
 - **Entropy filtering** — reduces false positives on low-entropy values

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
 
-National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, GB 11643-1999 for the Chinese Resident Identity Card, and the NTS (Hometax) standard algorithm for the Korean BRN (official spec not directly verified).
+National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, GB 11643-1999 for the Chinese Resident Identity Card, and the NTS (Hometax) standard algorithm for the Korean BRN.
 
 ### Context gating
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Set `contextWindow` at the top level to change how many tokens of surrounding te
 }
 ```
 
-Invalid rules (bad regex, missing fields) are skipped with a warning on stderr. The rest of the config still loads.
+Invalid rules (bad regex, wrong types, missing required fields) are skipped with a warning on stderr. The rest of the config still loads. Each rule is validated against a strict schema before compilation — `requireContext: true` without `contextWords` is also rejected, since such a rule would never fire.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,89 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 
 ---
 
+## Custom Rules
+
+All detection rules are defined in `src/lib/default-config.json` as data, not code. You can add your own rules or override built-in ones by creating a config file.
+
+### Config file location
+
+Create `~/.config/sensitive-canary/config.json`, or point to a custom path with the `SENSITIVE_CANARY_CONFIG` environment variable:
+
+```json
+{
+  "env": {
+    "SENSITIVE_CANARY_CONFIG": "/path/to/my-rules.json"
+  }
+}
+```
+
+### Adding a rule
+
+Each rule is a JSON object with an `id`, `description`, `regex` (source string), and `category` (`"secret"` or `"pii"`):
+
+```json
+{
+  "rules": [
+    {
+      "id": "custom-api-key",
+      "description": "My Service API Key",
+      "regex": "MYSVC-[A-Za-z0-9]{32}",
+      "category": "secret"
+    }
+  ]
+}
+```
+
+### Overriding a built-in rule
+
+A user rule with the same `id` as a built-in rule replaces it. For example, to tighten the email regex:
+
+```json
+{
+  "rules": [
+    {
+      "id": "pii-email",
+      "description": "Internal Email",
+      "regex": "[A-Za-z0-9]+@internal\\.corp\\.(com|org)",
+      "category": "pii"
+    }
+  ]
+}
+```
+
+### Context gating and validators
+
+User rules support the same fields as built-in rules:
+
+| Field | Type | Description |
+|---|---|---|
+| `requireContext` | boolean | Only fire when a nearby context word is found |
+| `contextWords` | string[] | Words that satisfy the context requirement |
+| `contextWindow` | number | Override the global context window (default: 3 tokens) |
+| `entropyThreshold` | number | Skip matches below this Shannon entropy |
+| `secretGroup` | number | Capture group index containing the secret (default: 0 = full match) |
+| `validate` | string | Name of a built-in checksum validator (see below) |
+| `flags` | string | Regex flags (default: `"g"`) |
+
+Available validators (referenced by name in the `validate` field):
+
+`luhn`, `mynumber-jp`, `nir-fr`, `codice-fiscale-it`, `steuer-id-de`, `dni-nie-es`, `rrn-kr`, `brn-kr`, `resident-id-cn`, `public-ipv4`, `public-ipv6`
+
+### Overriding the context window globally
+
+Set `contextWindow` at the top level to change how many tokens of surrounding text are scanned for context words (default: 3):
+
+```json
+{
+  "contextWindow": 5,
+  "rules": []
+}
+```
+
+Invalid rules (bad regex, missing fields) are skipped with a warning on stderr. The rest of the config still loads.
+
+---
+
 ## Detection rules
 
 ### Secrets (24 rules)

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ All detection rules are defined in `src/lib/default-config.json` as data, not co
 
 ### Config file location
 
-Create `~/.config/sensitive-canary/config.json`, or point to a custom path with the `SENSITIVE_CANARY_CONFIG` environment variable:
+Create `~/.config/sensitive-canary/config.json`, or point to a custom path with the `SENSITIVE_CANARY_CONFIG` environment variable. Set it in the `env` block of your Claude Code `settings.json`:
 
 ```json
 {
@@ -269,6 +269,12 @@ Create `~/.config/sensitive-canary/config.json`, or point to a custom path with 
     "SENSITIVE_CANARY_CONFIG": "/path/to/my-rules.json"
   }
 }
+```
+
+or export it in your shell:
+
+```sh
+export SENSITIVE_CANARY_CONFIG=/path/to/my-rules.json
 ```
 
 ### Adding a rule
@@ -334,7 +340,7 @@ Set `contextWindow` at the top level to change how many tokens of surrounding te
 }
 ```
 
-Invalid rules (bad regex, wrong types, missing required fields) are skipped with a warning on stderr. The rest of the config still loads. Each rule is validated against a strict schema before compilation — `requireContext: true` without `contextWords` is also rejected, since such a rule would never fire.
+Invalid rules (bad regex, wrong types, missing required fields) are skipped with a warning on stderr. The rest of the config still loads. Each rule is validated against a strict schema before compilation — `requireContext: true` without `contextWords` is also rejected, since empty `contextWords` would silently disable context gating and make the rule fire on every match.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **41 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **48 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE)
 - **Context gating** — postal codes and FIGS phone numbers require a nearby label, reducing false positives on bare digit sequences
 - **Entropy filtering** — reduces false positives on low-entropy values
@@ -286,7 +286,7 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 | `env-assignment` | `.env`-style secret assignment *(entropy ≥ 3.0)* |
 | `connection-string` | Database connection string with embedded credentials |
 
-### PII (17 rules)
+### PII (24 rules)
 
 | Rule ID | Description | Validation |
 |---|---|---|
@@ -306,11 +306,18 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 | `pii-phone-de` | German phone number | Context-gated |
 | `pii-phone-es` | Spanish phone number | Context-gated |
 | `pii-postal-jp` | Japanese postal code (`〒` prefix required) | — |
-| `pii-postal-code` | Postal code (US ZIP / EU 5-digit) | Context-gated |
+| `pii-postal-code` | Postal code (US ZIP / EU / KR) | Context-gated |
+| `pii-rrn-kr` | Korean Resident Registration Number | Checksum (weighted mod 11) |
+| `pii-resident-id-cn` | Chinese Resident Identity Card | Check digit (GB 11643 MOD 11-2) |
+| `pii-phone-kr` | Korean phone number | Context-gated |
+| `pii-phone-cn` | Chinese phone number | Context-gated |
+| `pii-postal-cn` | Chinese postal code (6-digit) | Context-gated |
+| `pii-ipv4-public` | Public IPv4 address | Context-gated, reserved ranges excluded |
+| `pii-ipv6` | IPv6 address | Context-gated, reserved ranges excluded |
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
 
-National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., and the Ministerio del Interior for DNI/NIE.
+National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, and GB 11643-1999 for the Chinese Resident Identity Card.
 
 ### Context gating
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **31 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **41 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE)
+- **Context gating** — postal codes and FIGS phone numbers require a nearby label, reducing false positives on bare digit sequences
 - **Entropy filtering** — reduces false positives on low-entropy values
-- **Luhn validation** — credit card numbers are validated, not just pattern-matched
 - **Local only** — all scanning runs in your terminal; nothing is sent anywhere
 
 ---
@@ -285,19 +286,35 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 | `env-assignment` | `.env`-style secret assignment *(entropy ≥ 3.0)* |
 | `connection-string` | Database connection string with embedded credentials |
 
-### PII (7 rules)
+### PII (17 rules)
 
 | Rule ID | Description | Validation |
 |---|---|---|
 | `pii-email` | Email address | — |
 | `pii-credit-card` | Credit card number | Luhn check |
+| `pii-ipv4` | IPv4 address (RFC 1918 private ranges only) | — |
 | `pii-ssn` | US Social Security Number | Invalid prefix exclusion |
+| `pii-mynumber-jp` | Japanese Individual Number (My Number) | Checksum (weighted mod 11) |
+| `pii-nir-fr` | French NIR / Social Security Number | Check key (mod 97) |
+| `pii-codice-fiscale-it` | Italian Codice Fiscale | Control character (mod 26) |
+| `pii-steuer-id-de` | German Steuer-Identifikationsnummer | MOD 11,10 |
+| `pii-dni-nie-es` | Spanish DNI / NIE | Control letter (mod 23) |
 | `pii-phone-us` | US phone number | — |
 | `pii-phone-jp` | Japanese phone number | — |
+| `pii-phone-fr` | French phone number | Context-gated |
+| `pii-phone-it` | Italian phone number | Context-gated |
+| `pii-phone-de` | German phone number | Context-gated |
+| `pii-phone-es` | Spanish phone number | Context-gated |
 | `pii-postal-jp` | Japanese postal code (`〒` prefix required) | — |
-| `pii-ipv4` | IPv4 address (RFC 1918 private ranges only) | — |
+| `pii-postal-code` | Postal code (US ZIP / EU 5-digit) | Context-gated |
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
+
+National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., and the Ministerio del Interior for DNI/NIE.
+
+### Context gating
+
+Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of context words (phone, ZIP, PLZ, CAP, etc. in the relevant languages) and only fire when one of those words appears near the match. National ID numbers rely on their checksums instead and do not need context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **48 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **49 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE)
 - **Context gating** — postal codes and FIGS phone numbers require a nearby label, reducing false positives on bare digit sequences
 - **Entropy filtering** — reduces false positives on low-entropy values
@@ -286,7 +286,7 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 | `env-assignment` | `.env`-style secret assignment *(entropy ≥ 3.0)* |
 | `connection-string` | Database connection string with embedded credentials |
 
-### PII (24 rules)
+### PII (25 rules)
 
 | Rule ID | Description | Validation |
 |---|---|---|
@@ -308,6 +308,7 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 | `pii-postal-jp` | Japanese postal code (`〒` prefix required) | — |
 | `pii-postal-code` | Postal code (US ZIP / EU / KR) | Context-gated |
 | `pii-rrn-kr` | Korean Resident Registration Number | Checksum (weighted mod 11) |
+| `pii-brn-kr` | Korean Business Registration Number | Checksum (NTS standard algorithm) |
 | `pii-resident-id-cn` | Chinese Resident Identity Card | Check digit (GB 11643 MOD 11-2) |
 | `pii-phone-kr` | Korean phone number | Context-gated |
 | `pii-phone-cn` | Chinese phone number | Context-gated |
@@ -317,7 +318,7 @@ This is a persistent filter, unlike allow tags which apply per prompt. The categ
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
 
-National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, and GB 11643-1999 for the Chinese Resident Identity Card.
+National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, GB 11643-1999 for the Chinese Resident Identity Card, and the NTS (Hometax) standard algorithm for the Korean BRN (official spec not directly verified).
 
 ### Context gating
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Claude Code is a powerful development tool, but file reads and command execution
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
 - **64 detection rules** — sourced from gitleaks and TruffleHog detector definitions
-- **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE)
-- **Context gating** — postal codes and FIGS phone numbers require a nearby label, reducing false positives on bare digit sequences
+- **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE, KR RRN/BRN, CN Resident ID)
+- **Context gating** — phone numbers, postal codes, and public IP addresses require a nearby label, reducing false positives on bare digit sequences
 - **Entropy filtering** — reduces false positives on low-entropy values
 - **Local only** — all scanning runs in your terminal; nothing is sent anywhere
 
@@ -426,7 +426,7 @@ National ID checksum algorithms follow the official specs from each issuing auth
 
 ### Context gating
 
-Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of context words (phone, ZIP, PLZ, CAP, etc. in the relevant languages) and only fire when one of those words appears near the match. National ID numbers rely on their checksums instead and do not need context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
+Phone numbers (IT, DE, FR, ES, KR, CN), bare 5/9-digit and Chinese 6-digit postal codes, and public IP addresses produce too many false positives on digit-only patterns. These rules carry a list of context words (phone, ZIP, PLZ, CAP, IP, etc. in the relevant languages) and only fire when one of those words appears near the match. National ID numbers rely on their checksums instead and do not need context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Invalid rules (bad regex, missing fields) are skipped with a warning on stderr. 
 
 ## Detection rules
 
-### Secrets (24 rules)
+### Secrets (39 rules)
 
 | Rule ID | Description |
 |---|---|
@@ -364,6 +364,21 @@ Invalid rules (bad regex, missing fields) are skipped with a warning on stderr. 
 | `openai-key` | OpenAI API Key (legacy format) |
 | `openai-project-key` | OpenAI Project API Key (`sk-proj-` prefix) *(entropy ≥ 3.5)* |
 | `anthropic-key` | Anthropic API Key |
+| `replicate-token` | Replicate API Token |
+| `huggingface-token` | Hugging Face Access Token |
+| `groq-key` | Groq API Key |
+| `openrouter-key` | OpenRouter API Key |
+| `xai-key` | xAI (Grok) API Key |
+| `perplexity-key` | Perplexity API Key |
+| `digitalocean-pat` | DigitalOcean Personal Access Token |
+| `square-access-token` | Square Access Token |
+| `mapbox-token` | Mapbox Token |
+| `sentry-user-token` | Sentry User Auth Token |
+| `sentry-org-token` | Sentry Organization Auth Token |
+| `atlassian-token` | Atlassian API Token |
+| `linear-key` | Linear API Key |
+| `postman-key` | Postman API Key |
+| `supabase-key` | Supabase Personal Access Token |
 | `jwt` | JSON Web Token (JWT) |
 | `generic-secret` | Generic API key / secret assignment *(entropy ≥ 3.5)* |
 | `env-assignment` | `.env`-style secret assignment *(entropy ≥ 3.0)* |
@@ -401,7 +416,7 @@ Invalid rules (bad regex, missing fields) are skipped with a warning on stderr. 
 
 Detection patterns are based on rule definitions from [gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog).
 
-National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (JIPTEC) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, GB 11643-1999 for the Chinese Resident Identity Card, and the NTS (Hometax) standard algorithm for the Korean BRN.
+National ID checksum algorithms follow the official specs from each issuing authority: 地方公共団体情報システム機構 (J-LIS) for My Number, INSEE for NIR, Agenzia delle Entrate for Codice Fiscale, Bundeszentralamt für Steuern for Steuer-IdNr., the Ministerio del Interior for DNI/NIE, the Ministry of the Interior and Safety for the Korean RRN, GB 11643-1999 for the Chinese Resident Identity Card, and the NTS (Hometax) standard algorithm for the Korean BRN.
 
 ### Context gating
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,8 @@ Tags apply only to the message they appear in. They do not persist across turns.
 
 ## Configuration
 
+### Category filtering
+
 Set `SENSITIVE_CANARY_CATEGORIES` in the `env` block of your Claude Code `settings.json` to limit which rule categories are active:
 
 ```json
@@ -58,7 +60,32 @@ Set `SENSITIVE_CANARY_CATEGORIES` in the `env` block of your Claude Code `settin
 
 This persistent filter is applied before allow tags. A typical use is setting `secret` when PII rules are too noisy against test fixtures.
 
+### Custom rules
+
+All 64 detection rules are defined in JSON. You can add your own or override built-in ones by creating a config file:
+
+```bash
+mkdir -p ~/.config/sensitive-canary
+```
+
+Then create `~/.config/sensitive-canary/config.json`:
+
+```json
+{
+  "rules": [
+    {
+      "id": "custom-api-key",
+      "description": "My Service API Key",
+      "regex": "MYSVC-[A-Za-z0-9]{32}",
+      "category": "secret"
+    }
+  ]
+}
+```
+
+The plugin reads this file at startup. Rules with the same `id` as a built-in rule replace it; new ids are appended. See [Detection Rules → Custom Rules](/rules#custom-rules) for the full field reference and examples.
+
 ## Next Steps
 
 - [Installation](/install) — alternative installation methods
-- [Detection Rules](/rules) — all 31 detection rules explained
+- [Detection Rules](/rules) — all 64 detection rules explained

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,10 @@ hero:
 features:
   - icon: 🔑
     title: Secret Detection
-    details: Catches AWS keys, GitHub PATs, Stripe keys, JWTs, Anthropic/OpenAI API keys, database connection strings, and 15+ more credential types.
+    details: Catches AWS keys, GitHub PATs, Stripe keys, JWTs, Anthropic/OpenAI API keys, database connection strings, Replicate/Hugging Face/Groq/xAI tokens, DigitalOcean/Square/Sentry/Linear tokens, and 20+ more credential types.
   - icon: 🕵️
     title: PII Detection
-    details: Detects email addresses, credit card numbers, US SSNs, phone numbers, Japanese postal codes, and private IPv4 addresses.
+    details: Detects email addresses, credit card numbers (Luhn-validated), US SSNs, phone numbers (JP/US/FR/IT/DE/ES/KR/CN), national IDs with checksum validation (My Number, NIR, Codice Fiscale, Steuer-IdNr., DNI/NIE, RRN, BRN, Chinese Resident ID), postal codes, and public/private IP addresses.
   - icon: 🛡️
     title: Pre-Tool-Use Hook
     details: Scans files before Claude reads them. Blocks .env files by name and any file whose contents contain secrets or PII.
@@ -37,7 +37,7 @@ features:
     details: Need to share a key intentionally? Add [allow-secret], [allow-pii], or [allow-all] to your prompt to bypass specific checks.
   - icon: 🐦
     title: Zero Config
-    details: Install once as a Claude Code plugin. No API keys, no servers, no configuration files needed.
+    details: Install once as a Claude Code plugin. No API keys, no servers. Optionally add custom rules via a JSON config file.
 ---
 
 ## Why Sensitive Canary?
@@ -54,7 +54,8 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **31 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **64 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **Context gating** — noisy PII rules (phone, postal, IP) only fire when a relevant label is nearby
 - **Entropy filtering** — reduces false positives on low-entropy values
 - **Luhn validation** — credit card numbers are validated, not just pattern-matched
 - **Local only** — all scanning runs in your terminal; nothing is sent anywhere
@@ -65,11 +66,13 @@ Claude Code is a powerful development tool, but file reads and command execution
 |----------|---------|
 | **Cloud credentials** | AWS Access Key, GCP service account key |
 | **Source control** | GitHub PAT, GitHub fine-grained token, GitLab PAT |
-| **AI services** | Anthropic API key, OpenAI API key / project key |
+| **AI services** | Anthropic API key, OpenAI API key / project key, Replicate, Hugging Face, Groq, OpenRouter, xAI, Perplexity |
 | **Communication** | Slack token, Slack webhook, Discord webhook, Telegram bot token |
-| **Payment** | Stripe secret/restricted key, credit card numbers (Luhn-validated) |
+| **Payment** | Stripe secret/restricted key, Square access token, credit card numbers (Luhn-validated) |
 | **Email services** | SendGrid API key, Mailgun key, Mailchimp key |
+| **Cloud / IaaS** | DigitalOcean PAT, Supabase PAT |
+| **SaaS / Dev tools** | Mapbox, Sentry, Atlassian, Linear, Postman |
 | **Auth tokens** | JWT, database connection strings |
-| **PII** | Email address, US SSN, US/JP phone, Japanese postal code, private IPv4 |
+| **PII** | Email, US SSN, phone (8 countries), national IDs (7 countries), postal codes, IP addresses |
 
 [View all detection rules →](/rules)

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 
 | Category | Examples |
 |----------|---------|
-| **Cloud credentials** | AWS Access Key, GCP service account key |
+| **Cloud credentials** | AWS Access Key, GCP API key |
 | **Source control** | GitHub PAT, GitHub fine-grained token, GitLab PAT |
 | **AI services** | Anthropic API key, OpenAI API key / project key, Replicate, Hugging Face, Groq, OpenRouter, xAI, Perplexity |
 | **Communication** | Slack token, Slack webhook, Discord webhook, Telegram bot token |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -95,7 +95,14 @@ The entropy threshold filters out low-entropy values (e.g. `API_KEY=placeholder`
 | `pii-phone-de` | German Phone Number | Context-gated |
 | `pii-phone-es` | Spanish Phone Number | Context-gated |
 | `pii-postal-jp` | Japanese Postal Code | Requires `〒` prefix to avoid false positives |
-| `pii-postal-code` | Postal Code (US ZIP / EU 5-digit) | Context-gated (requires nearby postal label) |
+| `pii-postal-code` | Postal Code (US ZIP / EU / KR) | Context-gated (requires nearby postal label) |
+| `pii-rrn-kr` | Korean Resident Registration Number | 13 digits, validated with weighted checksum (mod 11) |
+| `pii-resident-id-cn` | Chinese Resident Identity Card | 18 chars (17 digits + check), validated with GB 11643 MOD 11-2 |
+| `pii-phone-kr` | Korean Phone Number | Context-gated |
+| `pii-phone-cn` | Chinese Phone Number | Context-gated |
+| `pii-postal-cn` | Chinese Postal Code (6-digit) | Context-gated |
+| `pii-ipv4-public` | Public IPv4 Address | Context-gated; reserved/private ranges excluded |
+| `pii-ipv6` | IPv6 Address | Context-gated; loopback, link-local, ULA, multicast excluded |
 
 ### National ID Validation
 
@@ -106,12 +113,16 @@ National ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., E
 - **Codice Fiscale**: Agenzia delle Entrate, DM 12 giugno 2007 (mod 26)
 - **Steuer-IdNr.**: Bundeszentralamt für Steuern (ISO/IEC 7064 MOD 11,10)
 - **DNI/NIE**: Ministerio del Interior, Orden INT/2058/2008 (mod 23)
+- **Korean RRN**: 주민등록 사무편람, Ministry of the Interior and Safety (weighted mod 11)
+- **Chinese Resident ID**: GB 11643-1999 (ISO 7064 MOD 11-2)
 
 ### Context Gating
 
 Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of nearby context words (`phone`, `tel`, `ZIP`, `PLZ`, `CAP`, `code postal`, … in each relevant language) and only fire when one of those words appears within a small window of the match. If no context word is nearby, the match is dropped.
 
 National ID numbers rely on their checksums instead and do not require context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
+
+Public IPv4 and IPv6 addresses are also context-gated, and additionally exclude reserved ranges (private, loopback, link-local, TEST-NET, multicast, documentation, etc.) so that example IPs like `8.8.8.8` and tutorials do not fire unless a label such as `ip` or `address` is nearby. The existing `pii-ipv4` rule still flags RFC 1918 private ranges without context.
 
 ### Credit Card Validation
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,6 +32,19 @@ Sensitive Canary scans text against the following rules. Patterns are sourced fr
 | `openai-key` | OpenAI API Key — legacy format (`sk-` + 48 chars) |
 | `openai-project-key` | OpenAI Project API Key (`sk-proj-` prefix, entropy-filtered) |
 | `anthropic-key` | Anthropic API Key (`sk-ant-` prefix) |
+| `replicate-token` | Replicate API Token (`r8_` prefix) |
+| `huggingface-token` | Hugging Face Access Token (`hf_` prefix) |
+| `groq-key` | Groq API Key (`gsk_` prefix) |
+| `openrouter-key` | OpenRouter API Key (`sk-or-v1-` prefix) |
+| `xai-key` | xAI (Grok) API Key (`xai-` prefix) |
+| `perplexity-key` | Perplexity API Key (`pplx-` prefix) |
+
+### Cloud / IaaS
+
+| Rule ID | Description |
+|---------|-------------|
+| `digitalocean-pat` | DigitalOcean Personal Access Token (`dop_v1_` prefix) |
+| `supabase-key` | Supabase Personal Access Token (`sbp_` prefix) |
 
 ### Communication
 
@@ -49,6 +62,7 @@ Sensitive Canary scans text against the following rules. Patterns are sourced fr
 |---------|-------------|
 | `stripe-secret-key` | Stripe Secret Key (`sk_live_` / `sk_test_` prefix) |
 | `stripe-restricted-key` | Stripe Restricted Key (`rk_live_` / `rk_test_` prefix) |
+| `square-access-token` | Square Access Token (`EAAA` prefix) |
 
 ### Email Services
 
@@ -65,6 +79,17 @@ Sensitive Canary scans text against the following rules. Patterns are sourced fr
 | `jwt` | JSON Web Token (three Base64URL segments separated by `.`) |
 | `private-key` | PEM Private Key header (`-----BEGIN … PRIVATE KEY-----`) |
 | `connection-string` | Database connection string with embedded credentials |
+
+### SaaS / Developer Tools
+
+| Rule ID | Description |
+|---------|-------------|
+| `mapbox-token` | Mapbox Token (`pk.` / `sk.` JWT prefix) |
+| `sentry-user-token` | Sentry User Auth Token (`sntryu_` prefix) |
+| `sentry-org-token` | Sentry Organization Auth Token (`sntrys_` JWT prefix) |
+| `atlassian-token` | Atlassian (Jira/Confluence) API Token (`ATATT3` prefix) |
+| `linear-key` | Linear API Key (`lin_api_` prefix) |
+| `postman-key` | Postman API Key (`PMAK-` prefix) |
 
 ### Generic / Env-based
 
@@ -109,7 +134,7 @@ The entropy threshold filters out low-entropy values (e.g. `API_KEY=placeholder`
 
 National ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE) are matched by pattern **and** validated against their official checksum algorithm. A digit sequence that looks right but fails the checksum is not flagged. The algorithms follow each issuing authority's published spec:
 
-- **My Number**: 地方公共団体情報システム機構 (JIPTEC)
+- **My Number**: 地方公共団体情報システム機構 (J-LIS)
 - **NIR**: INSEE / décret n°82-103 (97 − N mod 97)
 - **Codice Fiscale**: Agenzia delle Entrate, DM 12 giugno 2007 (mod 26)
 - **Steuer-IdNr.**: Bundeszentralamt für Steuern (ISO/IEC 7064 MOD 11,10)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -116,7 +116,7 @@ National ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., E
 - **DNI/NIE**: Ministerio del Interior, Orden INT/2058/2008 (mod 23)
 - **Korean RRN**: 주민등록 사무편람, Ministry of the Interior and Safety (weighted mod 11)
 - **Chinese Resident ID**: GB 11643-1999 (ISO 7064 MOD 11-2)
-- **Korean BRN**: NTS (Hometax) standard algorithm (official spec not directly verified)
+- **Korean BRN**: NTS (Hometax) standard algorithm
 
 ### Context Gating
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -195,3 +195,106 @@ When Claude uses the `Bash` tool, sensitive-canary checks three things:
 1. **Environment variables** — any `$VAR` or `${VAR}` references in the command are looked up in the current environment; if their values contain secrets or PII, the command is blocked.
 2. **Command string** — the raw command is scanned (catches inline secrets like `echo AKIAIOSFODNN7EXAMPLE`).
 3. **File-reading commands** — for `cat`, `head`, `tail`, `less`, `more`, `bat`, `nl`, the target files are read and scanned before the command runs. Compound commands using `|`, `;`, `&&`, `||` are split and each segment is checked independently.
+
+## Custom Rules
+
+All built-in rules are defined in `src/lib/default-config.json` as JSON data. You can add your own rules or override built-in ones without modifying the plugin source.
+
+### Config file
+
+Create `~/.config/sensitive-canary/config.json`, or set the `SENSITIVE_CANARY_CONFIG` environment variable to a custom path (e.g. in the `env` block of your Claude Code `settings.json`).
+
+### Rule fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique identifier. Matching a built-in id overrides it. |
+| `description` | string | yes | Human-readable label shown in block messages. |
+| `regex` | string | yes | Regex source (not a `/literal/`). |
+| `category` | `"secret"` \| `"pii"` | yes | Which category the rule belongs to. |
+| `flags` | string | no | Regex flags. Default `"g"`. |
+| `secretGroup` | number | no | Capture group containing the secret. Default 0 (full match). |
+| `entropyThreshold` | number | no | Skip matches below this Shannon entropy (bits/char). |
+| `requireContext` | boolean | no | Only fire when a context word is nearby. |
+| `contextWords` | string[] | no | Words that satisfy `requireContext`. |
+| `contextWindow` | number | no | Per-rule override for context scan width (tokens). |
+| `validate` | string | no | Name of a built-in checksum validator. |
+
+### Available validators
+
+| Name | Algorithm |
+|------|-----------|
+| `luhn` | Luhn checksum (credit cards) |
+| `mynumber-jp` | Japanese Individual Number (My Number) |
+| `nir-fr` | French NIR / Social Security Number |
+| `codice-fiscale-it` | Italian Codice Fiscale |
+| `steuer-id-de` | German Steuer-Identifikationsnummer |
+| `dni-nie-es` | Spanish DNI / NIE |
+| `rrn-kr` | Korean Resident Registration Number |
+| `brn-kr` | Korean Business Registration Number |
+| `resident-id-cn` | Chinese Resident Identity Card |
+| `public-ipv4` | Rejects reserved IPv4 ranges |
+| `public-ipv6` | Rejects reserved IPv6 ranges |
+
+### Global context window
+
+Set `contextWindow` at the top level to override the default (3 tokens ≈ 24 characters):
+
+```json
+{
+  "contextWindow": 5,
+  "rules": []
+}
+```
+
+### Examples
+
+Add a custom secret pattern:
+
+```json
+{
+  "rules": [
+    {
+      "id": "custom-api-key",
+      "description": "My Service API Key",
+      "regex": "MYSVC-[A-Za-z0-9]{32}",
+      "category": "secret",
+      "entropyThreshold": 3.5
+    }
+  ]
+}
+```
+
+Add a context-gated PII rule:
+
+```json
+{
+  "rules": [
+    {
+      "id": "employee-id",
+      "description": "Employee ID",
+      "regex": "EMP\\d{6}",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["employee", "staff", "社員"]
+    }
+  ]
+}
+```
+
+Override a built-in rule (same `id` replaces the original):
+
+```json
+{
+  "rules": [
+    {
+      "id": "pii-email",
+      "description": "Internal Email Only",
+      "regex": "[A-Za-z0-9]+@internal\\.corp\\.(com|org)",
+      "category": "pii"
+    }
+  ]
+}
+```
+
+Invalid rules (bad regex, etc.) are skipped with a warning on stderr. The rest of the config loads normally.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -97,6 +97,7 @@ The entropy threshold filters out low-entropy values (e.g. `API_KEY=placeholder`
 | `pii-postal-jp` | Japanese Postal Code | Requires `〒` prefix to avoid false positives |
 | `pii-postal-code` | Postal Code (US ZIP / EU / KR) | Context-gated (requires nearby postal label) |
 | `pii-rrn-kr` | Korean Resident Registration Number | 13 digits, validated with weighted checksum (mod 11) |
+| `pii-brn-kr` | Korean Business Registration Number | 10 digits, validated with NTS standard checksum |
 | `pii-resident-id-cn` | Chinese Resident Identity Card | 18 chars (17 digits + check), validated with GB 11643 MOD 11-2 |
 | `pii-phone-kr` | Korean Phone Number | Context-gated |
 | `pii-phone-cn` | Chinese Phone Number | Context-gated |
@@ -115,10 +116,11 @@ National ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., E
 - **DNI/NIE**: Ministerio del Interior, Orden INT/2058/2008 (mod 23)
 - **Korean RRN**: 주민등록 사무편람, Ministry of the Interior and Safety (weighted mod 11)
 - **Chinese Resident ID**: GB 11643-1999 (ISO 7064 MOD 11-2)
+- **Korean BRN**: NTS (Hometax) standard algorithm (official spec not directly verified)
 
 ### Context Gating
 
-Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of nearby context words (`phone`, `tel`, `ZIP`, `PLZ`, `CAP`, `code postal`, … in each relevant language) and only fire when one of those words appears within a small window of the match. If no context word is nearby, the match is dropped.
+Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of nearby context words (`phone`, `tel`, `ZIP`, `PLZ`, `CAP`, `postal`, … in each relevant language) and only fire when one of those words appears within a small window of the match. Only words that **directly indicate the PII type** are included; generic words such as `contact`, `host`, `server`, or `code` are excluded because they cause false positives. If no decisive context word is nearby, the match is dropped.
 
 National ID numbers rely on their checksums instead and do not require context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -145,7 +145,7 @@ National ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., E
 
 ### Context Gating
 
-Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of nearby context words (`phone`, `tel`, `ZIP`, `PLZ`, `CAP`, `postal`, … in each relevant language) and only fire when one of those words appears within a small window of the match. Only words that **directly indicate the PII type** are included; generic words such as `contact`, `host`, `server`, or `code` are excluded because they cause false positives. If no decisive context word is nearby, the match is dropped.
+Phone numbers (IT, DE, FR, ES, KR, CN) and bare postal codes (5/9-digit and Chinese 6-digit) produce too many false positives on digit-only patterns. These rules carry a list of nearby context words (`phone`, `tel`, `ZIP`, `PLZ`, `CAP`, `postal`, … in each relevant language) and only fire when one of those words appears within a small window of the match. Only words that **directly indicate the PII type** are included; generic words such as `contact`, `host`, `server`, or `code` are excluded because they cause false positives. If no decisive context word is nearby, the match is dropped.
 
 National ID numbers rely on their checksums instead and do not require context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -81,11 +81,37 @@ The entropy threshold filters out low-entropy values (e.g. `API_KEY=placeholder`
 |---------|-------------|-------|
 | `pii-email` | Email Address | Standard RFC 5322-like pattern |
 | `pii-credit-card` | Credit Card Number | Visa, Mastercard, Amex, Discover; validated with Luhn algorithm |
+| `pii-ipv4` | Private IPv4 Address | RFC 1918 ranges only: `10.x`, `172.16–31.x`, `192.168.x` |
 | `pii-ssn` | US Social Security Number | Excludes invalid area (000, 666, 9xx), group (00), and serial (0000) numbers |
+| `pii-mynumber-jp` | Japanese Individual Number (My Number) | 12 digits, validated with weighted checksum (mod 11) |
+| `pii-nir-fr` | French NIR / Social Security Number | 15 digits, validated with check key (mod 97); Corsica 2A/2B supported |
+| `pii-codice-fiscale-it` | Italian Codice Fiscale | 16 alphanumeric chars, validated with control character (mod 26) |
+| `pii-steuer-id-de` | German Steuer-Identifikationsnummer | 11 digits, validated with MOD 11,10 (ISO/IEC 7064) |
+| `pii-dni-nie-es` | Spanish DNI / NIE | 8 digits + letter (DNI) or X/Y/Z + 7 digits + letter (NIE); validated with mod 23 |
 | `pii-phone-us` | US Phone Number | With or without country code |
 | `pii-phone-jp` | Japanese Phone Number | Area code + subscriber number format |
+| `pii-phone-fr` | French Phone Number | Context-gated (requires nearby phone label) |
+| `pii-phone-it` | Italian Phone Number | Context-gated |
+| `pii-phone-de` | German Phone Number | Context-gated |
+| `pii-phone-es` | Spanish Phone Number | Context-gated |
 | `pii-postal-jp` | Japanese Postal Code | Requires `〒` prefix to avoid false positives |
-| `pii-ipv4` | Private IPv4 Address | RFC 1918 ranges only: `10.x`, `172.16–31.x`, `192.168.x` |
+| `pii-postal-code` | Postal Code (US ZIP / EU 5-digit) | Context-gated (requires nearby postal label) |
+
+### National ID Validation
+
+National ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE) are matched by pattern **and** validated against their official checksum algorithm. A digit sequence that looks right but fails the checksum is not flagged. The algorithms follow each issuing authority's published spec:
+
+- **My Number**: 地方公共団体情報システム機構 (JIPTEC)
+- **NIR**: INSEE / décret n°82-103 (97 − N mod 97)
+- **Codice Fiscale**: Agenzia delle Entrate, DM 12 giugno 2007 (mod 26)
+- **Steuer-IdNr.**: Bundeszentralamt für Steuern (ISO/IEC 7064 MOD 11,10)
+- **DNI/NIE**: Ministerio del Interior, Orden INT/2058/2008 (mod 23)
+
+### Context Gating
+
+Variable-length Italian and German phone numbers, and bare 5/9-digit postal codes, produce too many false positives on digit-only patterns. These rules carry a list of nearby context words (`phone`, `tel`, `ZIP`, `PLZ`, `CAP`, `code postal`, … in each relevant language) and only fire when one of those words appears within a small window of the match. If no context word is nearby, the match is dropped.
+
+National ID numbers rely on their checksums instead and do not require context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 
 ### Credit Card Validation
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -149,7 +149,7 @@ Variable-length Italian and German phone numbers, and bare 5/9-digit postal code
 
 National ID numbers rely on their checksums instead and do not require context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 
-Public IPv4 and IPv6 addresses are also context-gated, and additionally exclude reserved ranges (private, loopback, link-local, TEST-NET, multicast, documentation, etc.) so that example IPs like `8.8.8.8` and tutorials do not fire unless a label such as `ip` or `address` is nearby. The existing `pii-ipv4` rule still flags RFC 1918 private ranges without context.
+Public IPv4 and IPv6 addresses are also context-gated, and additionally exclude reserved ranges (private, loopback, link-local, TEST-NET, multicast, documentation, etc.) so that example IPs like `8.8.8.8` and tutorials do not fire unless a label such as `ip`, `ipv4`, or `ipv6` is nearby. The existing `pii-ipv4` rule still flags RFC 1918 private ranges without context.
 
 ### Credit Card Validation
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -322,4 +322,8 @@ Override a built-in rule (same `id` replaces the original):
 }
 ```
 
-Invalid rules (bad regex, etc.) are skipped with a warning on stderr. The rest of the config loads normally.
+Invalid rules (bad regex, wrong types, missing required fields) are skipped with a warning on stderr. The rest of the config loads normally. Each rule is validated against a strict schema before compilation:
+
+- **Required**: `id`, `description`, `regex` (non-empty strings), `category` (`"secret"` or `"pii"`)
+- **Type-checked**: `flags` (string), `secretGroup` (non-negative integer), `entropyThreshold` (non-negative number), `validate` (string), `contextWords` (array of non-empty strings), `requireContext` (boolean), `contextWindow` (positive integer)
+- **Cross-field**: `requireContext: true` without `contextWords` is rejected (the rule would never fire)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -326,4 +326,4 @@ Invalid rules (bad regex, wrong types, missing required fields) are skipped with
 
 - **Required**: `id`, `description`, `regex` (non-empty strings), `category` (`"secret"` or `"pii"`)
 - **Type-checked**: `flags` (string), `secretGroup` (non-negative integer), `entropyThreshold` (non-negative number), `validate` (string), `contextWords` (array of non-empty strings), `requireContext` (boolean), `contextWindow` (positive integer)
-- **Cross-field**: `requireContext: true` without `contextWords` is rejected (the rule would never fire)
+- **Cross-field**: `requireContext: true` without `contextWords` is rejected (empty `contextWords` would disable context gating, making the rule fire on every match)

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "vitepress": "2.0.0-alpha.18",
     "vitest": "4.1.10"
   },
-  "packageManager": "pnpm@11.18.0"
+  "packageManager": "pnpm@11.19.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coo-quack/sensitive-canary",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
   "homepage": "https://coo-quack.github.io/sensitive-canary/",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 7.0.2
       vitepress:
         specifier: 2.0.0-alpha.18
-        version: 2.0.0-alpha.18(@types/node@25.9.5)(postcss@8.5.24)(typescript@7.0.2)
+        version: 2.0.0-alpha.18(@types/node@25.9.5)(postcss@8.5.25)(typescript@7.0.2)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5))
+        version: 4.1.10(@types/node@25.9.5)(vite@8.2.0(@types/node@25.9.5))
 
 packages:
 
@@ -37,13 +37,13 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.5.6':
@@ -103,26 +103,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@docsearch/css@4.6.3':
-    resolution: {integrity: sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==}
+  '@docsearch/css@4.7.0':
+    resolution: {integrity: sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==}
 
-  '@docsearch/js@4.6.3':
-    resolution: {integrity: sha512-qUIX2b4Apew3tv4F0qhmgShsl/Lfw4m6mqv/5/5dWNxwTcDdLMp2s3YwZ+NMGh3IKCg0pBaXm7Q5VdyU5Rj+cQ==}
+  '@docsearch/js@4.7.0':
+    resolution: {integrity: sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==}
 
-  '@docsearch/sidepanel-js@4.6.3':
-    resolution: {integrity: sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==}
+  '@docsearch/sidepanel-js@4.7.0':
+    resolution: {integrity: sha512-A8r34jCU8kcIk2viECEn2msA28ojUF1BLi/3v5OWWc5G2N3jOuuumBXoeYjfr8dA0UxgFSy5R2bt12dnFJQSyA==}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+  '@emnapi/core@2.0.0-alpha.3':
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
 
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+  '@emnapi/runtime@2.0.0-alpha.3':
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
 
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@emnapi/wasi-threads@2.0.1':
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
 
-  '@iconify-json/simple-icons@1.2.91':
-    resolution: {integrity: sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==}
+  '@iconify-json/simple-icons@1.2.92':
+    resolution: {integrity: sha512-hR0ozxR97t1dzWw+esoxFijZ15gagt7EIgF3CNifu2yICXhS7gnun4Y+j+odJQtNSl7wvqMdoLbViIShwe/fdw==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -130,106 +130,106 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@oxc-project/types@0.139.0':
-    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.1':
+    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.1':
+    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.1':
+    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.1':
+    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
+    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
+    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.1':
+    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.1':
+    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+  '@rolldown/binding-wasm32-wasi@1.2.1':
+    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
+    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -237,36 +237,36 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@shikijs/core@4.3.1':
-    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+  '@shikijs/core@4.4.1':
+    resolution: {integrity: sha512-VeR2CY6Nn9/WbisoYLOQZ7HZOnwTrpBuOw4wExjqLnBCi62BNWynBUO6K2uPIASPFJwAv7cX1fUu+LrPlSstcw==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-javascript@4.3.1':
-    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
+  '@shikijs/engine-javascript@4.4.1':
+    resolution: {integrity: sha512-6U4lJBh8LTvIkEVqRHv/rr3ruwtO6IweFQt1ME1ntHJMGHS+6N86vfYGO1o8c/DtOCTia2lfhdQBtBrps1sDfQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+  '@shikijs/engine-oniguruma@4.4.1':
+    resolution: {integrity: sha512-p23RugMKss0r5DAtRJW1yAXUDl60JvhQYV20yuxei//26JyDSJefV3umyWzzwep2weblMnJGDYahuti6XkcMgA==}
     engines: {node: '>=20'}
 
-  '@shikijs/langs@4.3.1':
-    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
+  '@shikijs/langs@4.4.1':
+    resolution: {integrity: sha512-xb2kCMloBCIraIy2fS5MW0t/BxVY3q2nDyQKBoeSeq6KNrQbShHetCFlw2n35fGIJ6t3+hXDLQogP5ir9O9bvA==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.3.1':
-    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+  '@shikijs/primitive@4.4.1':
+    resolution: {integrity: sha512-ko2OfDoG89YuQ7xL5LtcQiWKb7NIv1Ephb7g48TVU198OzAMLC8lXVEwaJGHK4sUMYrfAGJDqYmNLOLiW/Kz8w==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@4.3.1':
-    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+  '@shikijs/themes@4.4.1':
+    resolution: {integrity: sha512-wudOaoFro+/Zl9gQv2W1Ur5XlVduqvTuYLI483Xi0wgc1A+cy1hfB2r6ac6ufBgF+ID7KJEW7L41MHrzQ4wH+w==}
     engines: {node: '>=20'}
 
-  '@shikijs/transformers@4.3.1':
-    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
+  '@shikijs/transformers@4.4.1':
+    resolution: {integrity: sha512-Sb9Eehas+5EhClpFgNuklwY3aWf354FLaKRCiAWmjdNbHAjoQUpv6WmSj+N19eTXO6GLIWh1dIOH9dxyauhVWw==}
     engines: {node: '>=20'}
 
-  '@shikijs/types@4.3.1':
-    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+  '@shikijs/types@4.4.1':
+    resolution: {integrity: sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -506,13 +506,13 @@ packages:
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
-  '@vueuse/core@14.3.0':
-    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+  '@vueuse/core@14.4.0':
+    resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
     peerDependencies:
       vue: ^3.5.0
 
-  '@vueuse/integrations@14.3.0':
-    resolution: {integrity: sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==}
+  '@vueuse/integrations@14.4.0':
+    resolution: {integrity: sha512-oJz9qTgczvA7L1nXQFRU7h8tQbOCoiceqvMMhT9XYMyOGTqLJ2rEa09PON+nD2t48sZUfeOmg4eaWJXV4sZb/w==}
     peerDependencies:
       async-validator: ^4
       axios: ^1
@@ -553,11 +553,11 @@ packages:
       universal-cookie:
         optional: true
 
-  '@vueuse/metadata@14.3.0':
-    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+  '@vueuse/metadata@14.4.0':
+    resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
 
-  '@vueuse/shared@14.3.0':
-    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -792,13 +792,13 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.1:
+    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  shiki@4.3.1:
-    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
+  shiki@4.4.1:
+    resolution: {integrity: sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==}
     engines: {node: '>=20'}
 
   siginfo@2.0.0:
@@ -826,16 +826,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
@@ -873,13 +873,13 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@8.1.5:
-    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
+      '@vitejs/devtools': ^0.4.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -921,7 +921,7 @@ packages:
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
-      postcss: 8.5.24
+      postcss: 8.5.25
     peerDependenciesMeta:
       markdown-it-mathjax3:
         optional: true
@@ -991,11 +991,11 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.29.7':
+  '@babel/parser@7.29.8':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
-  '@babel/types@7.29.7':
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -1035,29 +1035,29 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.6':
     optional: true
 
-  '@docsearch/css@4.6.3': {}
+  '@docsearch/css@4.7.0': {}
 
-  '@docsearch/js@4.6.3': {}
+  '@docsearch/js@4.7.0': {}
 
-  '@docsearch/sidepanel-js@4.6.3': {}
+  '@docsearch/sidepanel-js@4.7.0': {}
 
-  '@emnapi/core@1.11.1':
+  '@emnapi/core@2.0.0-alpha.3':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.2
+      '@emnapi/wasi-threads': 2.0.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.2':
+  '@emnapi/runtime@2.0.0-alpha.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@iconify-json/simple-icons@1.2.91':
+  '@emnapi/wasi-threads@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@iconify-json/simple-icons@1.2.92':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -1065,105 +1065,105 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@oxc-project/types@0.139.0': {}
+  '@oxc-project/types@0.142.0': {}
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-freebsd-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
+  '@rolldown/binding-openharmony-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
+  '@rolldown/binding-wasm32-wasi@1.2.1':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@shikijs/core@4.3.1':
+  '@shikijs/core@4.4.1':
     dependencies:
-      '@shikijs/primitive': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/primitive': 4.4.1
+      '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@4.3.1':
+  '@shikijs/engine-javascript@4.4.1':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@4.3.1':
+  '@shikijs/engine-oniguruma@4.4.1':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@4.3.1':
+  '@shikijs/langs@4.4.1':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.1
 
-  '@shikijs/primitive@4.3.1':
+  '@shikijs/primitive@4.4.1':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
-  '@shikijs/themes@4.3.1':
+  '@shikijs/themes@4.4.1':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.1
 
-  '@shikijs/transformers@4.3.1':
+  '@shikijs/transformers@4.4.1':
     dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/core': 4.4.1
+      '@shikijs/types': 4.4.1
 
-  '@shikijs/types@4.3.1':
+  '@shikijs/types@4.4.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
@@ -1273,10 +1273,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@25.9.5))(vue@3.5.40(typescript@7.0.2))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.0(@types/node@25.9.5))(vue@3.5.40(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(@types/node@25.9.5)
+      vite: 8.2.0(@types/node@25.9.5)
       vue: 3.5.40(typescript@7.0.2)
 
   '@vitest/expect@4.1.10':
@@ -1286,19 +1286,19 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@25.9.5))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@25.9.5))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@25.9.5)
+      vite: 8.2.0(@types/node@25.9.5)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@vitest/runner@4.1.10':
     dependencies:
@@ -1318,11 +1318,11 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@vue/compiler-core@3.5.40':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/shared': 3.5.40
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -1335,7 +1335,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.40':
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@vue/compiler-core': 3.5.40
       '@vue/compiler-dom': 3.5.40
       '@vue/compiler-ssr': 3.5.40
@@ -1387,24 +1387,24 @@ snapshots:
 
   '@vue/shared@3.5.40': {}
 
-  '@vueuse/core@14.3.0(vue@3.5.40(typescript@7.0.2))':
+  '@vueuse/core@14.4.0(vue@3.5.40(typescript@7.0.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@7.0.2))
+      '@vueuse/metadata': 14.4.0
+      '@vueuse/shared': 14.4.0(vue@3.5.40(typescript@7.0.2))
       vue: 3.5.40(typescript@7.0.2)
 
-  '@vueuse/integrations@14.3.0(focus-trap@8.2.2)(vue@3.5.40(typescript@7.0.2))':
+  '@vueuse/integrations@14.4.0(focus-trap@8.2.2)(vue@3.5.40(typescript@7.0.2))':
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@7.0.2))
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@7.0.2))
+      '@vueuse/core': 14.4.0(vue@3.5.40(typescript@7.0.2))
+      '@vueuse/shared': 14.4.0(vue@3.5.40(typescript@7.0.2))
       vue: 3.5.40(typescript@7.0.2)
     optionalDependencies:
       focus-trap: 8.2.2
 
-  '@vueuse/metadata@14.3.0': {}
+  '@vueuse/metadata@14.4.0': {}
 
-  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@7.0.2))':
+  '@vueuse/shared@14.4.0(vue@3.5.40(typescript@7.0.2))':
     dependencies:
       vue: 3.5.40(typescript@7.0.2)
 
@@ -1603,35 +1603,35 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  rolldown@1.1.5:
+  rolldown@1.2.1:
     dependencies:
-      '@oxc-project/types': 0.139.0
+      '@oxc-project/types': 0.142.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.5
-      '@rolldown/binding-darwin-arm64': 1.1.5
-      '@rolldown/binding-darwin-x64': 1.1.5
-      '@rolldown/binding-freebsd-x64': 1.1.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
-      '@rolldown/binding-linux-arm64-gnu': 1.1.5
-      '@rolldown/binding-linux-arm64-musl': 1.1.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
-      '@rolldown/binding-linux-s390x-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-musl': 1.1.5
-      '@rolldown/binding-openharmony-arm64': 1.1.5
-      '@rolldown/binding-wasm32-wasi': 1.1.5
-      '@rolldown/binding-win32-arm64-msvc': 1.1.5
-      '@rolldown/binding-win32-x64-msvc': 1.1.5
+      '@rolldown/binding-android-arm64': 1.2.1
+      '@rolldown/binding-darwin-arm64': 1.2.1
+      '@rolldown/binding-darwin-x64': 1.2.1
+      '@rolldown/binding-freebsd-x64': 1.2.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
+      '@rolldown/binding-linux-arm64-gnu': 1.2.1
+      '@rolldown/binding-linux-arm64-musl': 1.2.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
+      '@rolldown/binding-linux-s390x-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-musl': 1.2.1
+      '@rolldown/binding-openharmony-arm64': 1.2.1
+      '@rolldown/binding-wasm32-wasi': 1.2.1
+      '@rolldown/binding-win32-arm64-msvc': 1.2.1
+      '@rolldown/binding-win32-x64-msvc': 1.2.1
 
-  shiki@4.3.1:
+  shiki@4.4.1:
     dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/engine-javascript': 4.3.1
-      '@shikijs/engine-oniguruma': 4.3.1
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/core': 4.4.1
+      '@shikijs/engine-javascript': 4.4.1
+      '@shikijs/engine-oniguruma': 4.4.1
+      '@shikijs/langs': 4.4.1
+      '@shikijs/themes': 4.4.1
+      '@shikijs/types': 4.4.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
@@ -1654,14 +1654,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.1.1: {}
 
   trim-lines@3.0.1: {}
 
@@ -1726,37 +1726,37 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.1.5(@types/node@25.9.5):
+  vite@8.2.0(@types/node@25.9.5):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.25
-      rolldown: 1.1.5
+      rolldown: 1.2.1
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.5
       fsevents: 2.3.3
 
-  vitepress@2.0.0-alpha.18(@types/node@25.9.5)(postcss@8.5.24)(typescript@7.0.2):
+  vitepress@2.0.0-alpha.18(@types/node@25.9.5)(postcss@8.5.25)(typescript@7.0.2):
     dependencies:
-      '@docsearch/css': 4.6.3
-      '@docsearch/js': 4.6.3
-      '@docsearch/sidepanel-js': 4.6.3
-      '@iconify-json/simple-icons': 1.2.91
-      '@shikijs/core': 4.3.1
-      '@shikijs/transformers': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@docsearch/css': 4.7.0
+      '@docsearch/js': 4.7.0
+      '@docsearch/sidepanel-js': 4.7.0
+      '@iconify-json/simple-icons': 1.2.92
+      '@shikijs/core': 4.4.1
+      '@shikijs/transformers': 4.4.1
+      '@shikijs/types': 4.4.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@25.9.5))(vue@3.5.40(typescript@7.0.2))
+      '@vitejs/plugin-vue': 6.0.8(vite@8.2.0(@types/node@25.9.5))(vue@3.5.40(typescript@7.0.2))
       '@vue/devtools-api': 8.2.1
       '@vue/shared': 3.5.40
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@7.0.2))
-      '@vueuse/integrations': 14.3.0(focus-trap@8.2.2)(vue@3.5.40(typescript@7.0.2))
+      '@vueuse/core': 14.4.0(vue@3.5.40(typescript@7.0.2))
+      '@vueuse/integrations': 14.4.0(focus-trap@8.2.2)(vue@3.5.40(typescript@7.0.2))
       focus-trap: 8.2.2
       mark.js: 8.11.1
       minisearch: 7.2.0
-      shiki: 4.3.1
-      vite: 8.1.5(@types/node@25.9.5)
+      shiki: 4.4.1
+      vite: 8.2.0(@types/node@25.9.5)
       vue: 3.5.40(typescript@7.0.2)
     optionalDependencies:
       postcss: 8.5.25
@@ -1786,10 +1786,10 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)):
+  vitest@4.1.10(@types/node@25.9.5)(vite@8.2.0(@types/node@25.9.5)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.9.5))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@25.9.5))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1803,10 +1803,10 @@ snapshots:
       picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@25.9.5)
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@25.9.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.5

--- a/src/lib/__tests__/inspector.test.ts
+++ b/src/lib/__tests__/inspector.test.ts
@@ -162,6 +162,7 @@ describe("applyAllowTags", () => {
       category: "secret",
       matchRedacted: "AKIA****",
       secretValue: "AKIATEST",
+      score: 1,
     },
     {
       ruleId: "pii-email",
@@ -169,6 +170,7 @@ describe("applyAllowTags", () => {
       category: "pii",
       matchRedacted: "user****",
       secretValue: "user@example.com",
+      score: 1,
     },
   ];
 
@@ -213,6 +215,7 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST",
+        score: 1,
       },
       {
         ruleId: "aws-access-key",
@@ -220,6 +223,7 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST",
+        score: 1,
       },
     ];
     expect(dedupeFindings(findings)).toHaveLength(1);
@@ -233,6 +237,7 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST1",
+        score: 1,
       },
       {
         ruleId: "aws-access-key",
@@ -240,6 +245,7 @@ describe("dedupeFindings", () => {
         category: "secret",
         matchRedacted: "AKIA****",
         secretValue: "AKIATEST2",
+        score: 1,
       },
     ];
     expect(dedupeFindings(findings)).toHaveLength(2);
@@ -257,6 +263,7 @@ describe("findingsToLines", () => {
         category: "secret",
         matchRedacted: "AKIA****MPLE",
         secretValue: "AKIAIOSFODNN7EXAMPLE",
+        score: 1,
       },
     ];
     const lines = findingsToLines(findings);
@@ -273,6 +280,7 @@ describe("findingsToLines", () => {
         category: "pii",
         matchRedacted: "user****",
         secretValue: "user@example.com",
+        score: 1,
       },
     ];
     const lines = findingsToLines(findings);

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -856,8 +856,32 @@ describe("isReservedIpv6", () => {
     expect(isReservedIpv6("::1")).toBe(true);
   });
 
+  it("returns true for fully-expanded loopback", () => {
+    expect(isReservedIpv6("0:0:0:0:0:0:0:1")).toBe(true);
+  });
+
+  it("returns true for fully-expanded unspecified", () => {
+    expect(isReservedIpv6("0:0:0:0:0:0:0:0")).toBe(true);
+  });
+
+  it("returns true for compressed unspecified", () => {
+    expect(isReservedIpv6("::")).toBe(true);
+  });
+
   it("returns true for link-local", () => {
     expect(isReservedIpv6("fe80::1")).toBe(true);
+  });
+
+  it("returns true for fully-expanded link-local", () => {
+    expect(isReservedIpv6("fe80:0:0:0:0:0:0:1")).toBe(true);
+  });
+
+  it("returns true for unique-local", () => {
+    expect(isReservedIpv6("fd00::1")).toBe(true);
+  });
+
+  it("returns true for multicast", () => {
+    expect(isReservedIpv6("ff02::1")).toBe(true);
   });
 
   it("returns true for documentation addresses", () => {

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -2,13 +2,17 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   enabledCategoriesFromEnv,
   entropy,
+  isReservedIpv4,
+  isReservedIpv6,
   luhn,
   parseCategories,
   redact,
   scan,
+  validateChineseID,
   validateCodiceFiscale,
   validateFrenchNIR,
   validateGermanIdNr,
+  validateKoreanRRN,
   validateMyNumber,
   validateSpanishNIF,
 } from "../rules.ts";
@@ -701,5 +705,173 @@ describe("scan — context scoring", () => {
     const findings = scan("contact: user@example.com");
     const email = findings.find((f) => f.ruleId === "pii-email");
     expect(email?.score).toBe(1.0);
+  });
+});
+
+// ── Korean / Chinese ID validators ────────────────────────────────────────────
+
+describe("validateKoreanRRN", () => {
+  it("passes a valid RRN", () => {
+    expect(validateKoreanRRN("8001011000008")).toBe(true);
+  });
+
+  it("fails an incorrect check digit", () => {
+    expect(validateKoreanRRN("8001011000009")).toBe(false);
+  });
+
+  it("fails a wrong length", () => {
+    expect(validateKoreanRRN("800101100000")).toBe(false);
+  });
+});
+
+describe("validateChineseID", () => {
+  it("passes a valid Resident Identity Card", () => {
+    expect(validateChineseID("110102199001010011")).toBe(true);
+  });
+
+  it("fails an incorrect check digit", () => {
+    expect(validateChineseID("110102199001010010")).toBe(false);
+  });
+
+  it("fails a wrong length", () => {
+    expect(validateChineseID("11010219900101001")).toBe(false);
+  });
+});
+
+// ── IP reserved-range checks ──────────────────────────────────────────────────
+
+describe("isReservedIpv4", () => {
+  it("returns false for a public IP", () => {
+    expect(isReservedIpv4("8.8.8.8")).toBe(false);
+  });
+
+  it("returns true for private ranges", () => {
+    expect(isReservedIpv4("192.168.1.1")).toBe(true);
+    expect(isReservedIpv4("10.0.0.1")).toBe(true);
+    expect(isReservedIpv4("172.16.0.1")).toBe(true);
+  });
+
+  it("returns true for TEST-NET addresses", () => {
+    expect(isReservedIpv4("192.0.2.1")).toBe(true);
+    expect(isReservedIpv4("203.0.113.1")).toBe(true);
+  });
+
+  it("returns true for loopback and link-local", () => {
+    expect(isReservedIpv4("127.0.0.1")).toBe(true);
+    expect(isReservedIpv4("169.254.1.1")).toBe(true);
+  });
+});
+
+describe("isReservedIpv6", () => {
+  it("returns false for a public IPv6", () => {
+    expect(isReservedIpv6("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("returns true for loopback", () => {
+    expect(isReservedIpv6("::1")).toBe(true);
+  });
+
+  it("returns true for link-local", () => {
+    expect(isReservedIpv6("fe80::1")).toBe(true);
+  });
+
+  it("returns true for documentation addresses", () => {
+    expect(isReservedIpv6("2001:db8::1")).toBe(true);
+  });
+});
+
+// ── scan: Korean / Chinese IDs ────────────────────────────────────────────────
+
+describe("scan — Korean / Chinese IDs", () => {
+  it("detects a valid Korean RRN", () => {
+    const findings = scan("rrn: 800101-1000008");
+    expect(findings.some((f) => f.ruleId === "pii-rrn-kr")).toBe(true);
+  });
+
+  it("does not flag an RRN with a bad check digit", () => {
+    const findings = scan("rrn: 800101-1000009");
+    expect(findings.some((f) => f.ruleId === "pii-rrn-kr")).toBe(false);
+  });
+
+  it("detects a valid Chinese Resident ID", () => {
+    const findings = scan("id: 110102199001010011");
+    expect(findings.some((f) => f.ruleId === "pii-resident-id-cn")).toBe(true);
+  });
+
+  it("does not flag a Chinese ID with a bad check digit", () => {
+    const findings = scan("id: 110102199001010010");
+    expect(findings.some((f) => f.ruleId === "pii-resident-id-cn")).toBe(false);
+  });
+});
+
+// ── scan: Korean / Chinese phone numbers ──────────────────────────────────────
+
+describe("scan — Korean / Chinese phones", () => {
+  it("detects a Korean phone with context", () => {
+    const findings = scan("전화: 010-1234-5678");
+    expect(findings.some((f) => f.ruleId === "pii-phone-kr")).toBe(true);
+  });
+
+  it("does not flag a bare Korean number without context", () => {
+    const findings = scan("ref 010-1234-5678 end");
+    expect(findings.some((f) => f.ruleId === "pii-phone-kr")).toBe(false);
+  });
+
+  it("detects a Chinese phone with context", () => {
+    const findings = scan("电话: 13812345678");
+    expect(findings.some((f) => f.ruleId === "pii-phone-cn")).toBe(true);
+  });
+
+  it("does not flag a bare Chinese number without context", () => {
+    const findings = scan("id 13812345678 end");
+    expect(findings.some((f) => f.ruleId === "pii-phone-cn")).toBe(false);
+  });
+});
+
+// ── scan: Chinese postal code ─────────────────────────────────────────────────
+
+describe("scan — Chinese postal code", () => {
+  it("detects a Chinese postal code with context", () => {
+    const findings = scan("邮编: 100000");
+    expect(findings.some((f) => f.ruleId === "pii-postal-cn")).toBe(true);
+  });
+
+  it("does not flag a bare 6-digit number", () => {
+    const findings = scan("count 123456 done");
+    expect(findings.some((f) => f.ruleId === "pii-postal-cn")).toBe(false);
+  });
+});
+
+// ── scan: public IP addresses ─────────────────────────────────────────────────
+
+describe("scan — public IPs", () => {
+  it("detects a public IPv4 with context", () => {
+    const findings = scan("ip: 8.8.8.8");
+    expect(findings.some((f) => f.ruleId === "pii-ipv4-public")).toBe(true);
+  });
+
+  it("does not flag a public IPv4 without context", () => {
+    const findings = scan("ping 8.8.8.8 now");
+    expect(findings.some((f) => f.ruleId === "pii-ipv4-public")).toBe(false);
+  });
+
+  it("does not flag a private IPv4 as public", () => {
+    const findings = scan("ip: 192.168.1.1");
+    expect(findings.some((f) => f.ruleId === "pii-ipv4-public")).toBe(false);
+  });
+
+  it("still flags a private IPv4 via the private-range rule", () => {
+    const findings = scan("server: 192.168.1.1");
+    expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(true);
+  });
+
+  it("detects an IPv6 with context", () => {
+    const findings = scan("ipv6: 2001:4860:4860::8888");
+    expect(findings.some((f) => f.ruleId === "pii-ipv6")).toBe(true);
+  });
+
+  it("does not flag a link-local IPv6", () => {
+    const findings = scan("ipv6: fe80::1");
+    expect(findings.some((f) => f.ruleId === "pii-ipv6")).toBe(false);
   });
 });

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -1022,6 +1022,79 @@ describe("compileRule", () => {
   });
 });
 
+// ── compileRule: schema validation ───────────────────────────────────────────
+
+describe("compileRule — schema validation", () => {
+  const valid = {
+    id: "test",
+    description: "Test",
+    regex: "\\d+",
+    category: "pii" as const,
+  };
+
+  it("rejects missing id", () => {
+    expect(() => compileRule({ ...valid, id: "" } as never)).toThrow('"id"');
+  });
+
+  it("rejects missing description", () => {
+    expect(() => compileRule({ ...valid, description: "" } as never)).toThrow(
+      '"description"',
+    );
+  });
+
+  it("rejects missing regex", () => {
+    expect(() => compileRule({ ...valid, regex: "" } as never)).toThrow(
+      '"regex"',
+    );
+  });
+
+  it("rejects invalid category", () => {
+    expect(() => compileRule({ ...valid, category: "other" as never })).toThrow(
+      '"category"',
+    );
+  });
+
+  it("rejects non-integer secretGroup", () => {
+    expect(() => compileRule({ ...valid, secretGroup: 1.5 } as never)).toThrow(
+      '"secretGroup"',
+    );
+  });
+
+  it("rejects negative entropyThreshold", () => {
+    expect(() =>
+      compileRule({ ...valid, entropyThreshold: -1 } as never),
+    ).toThrow('"entropyThreshold"');
+  });
+
+  it("rejects contextWords with empty string", () => {
+    expect(() =>
+      compileRule({ ...valid, contextWords: ["ok", ""] } as never),
+    ).toThrow('"contextWords"');
+  });
+
+  it("rejects non-integer contextWindow", () => {
+    expect(() => compileRule({ ...valid, contextWindow: 0 } as never)).toThrow(
+      '"contextWindow"',
+    );
+  });
+
+  it("rejects requireContext without contextWords", () => {
+    expect(() =>
+      compileRule({ ...valid, requireContext: true } as never),
+    ).toThrow("requireContext");
+  });
+
+  it("rejects requireContext with empty contextWords array", () => {
+    expect(() =>
+      compileRule({
+        ...valid,
+        requireContext: true,
+        contextWords: [],
+      } as never),
+    ).toThrow("requireContext");
+  });
+});
+
 // ── User config (custom rules) ────────────────────────────────────────────────
 
 describe("user config — custom rules", () => {

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -481,6 +481,14 @@ describe("validateFrenchNIR", () => {
   it("fails a wrong length", () => {
     expect(validateFrenchNIR("1234567890123")).toBe(false);
   });
+
+  it("passes a valid NIR with Corsica 2A", () => {
+    expect(validateFrenchNIR("188022A12345632")).toBe(true);
+  });
+
+  it("passes a valid NIR with Corsica 2B", () => {
+    expect(validateFrenchNIR("188022B12345659")).toBe(true);
+  });
 });
 
 describe("validateCodiceFiscale", () => {
@@ -568,6 +576,28 @@ describe("scan — national ID numbers", () => {
     const findings = scan("nie: X1234567L");
     expect(findings.some((f) => f.ruleId === "pii-dni-nie-es")).toBe(true);
   });
+
+  it("does not flag a French NIR with a bad check key", () => {
+    const findings = scan("secu: 1234567890123 99");
+    expect(findings.some((f) => f.ruleId === "pii-nir-fr")).toBe(false);
+  });
+
+  it("does not flag a Codice Fiscale with a bad control character", () => {
+    const findings = scan("cf: RSSMRA85M01H501Z");
+    expect(findings.some((f) => f.ruleId === "pii-codice-fiscale-it")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag a Steuer-IdNr. with a bad check digit", () => {
+    const findings = scan("idnr: 12345678900");
+    expect(findings.some((f) => f.ruleId === "pii-steuer-id-de")).toBe(false);
+  });
+
+  it("does not flag a DNI with a bad control letter", () => {
+    const findings = scan("dni: 12345678Y");
+    expect(findings.some((f) => f.ruleId === "pii-dni-nie-es")).toBe(false);
+  });
 });
 
 // ── scan: FIGS phone numbers (context-gated) ──────────────────────────────────
@@ -645,6 +675,16 @@ describe("scan — postal code", () => {
   it("does not flag a ZIP without a context label", () => {
     const findings = scan("order 90210 confirmed");
     expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(false);
+  });
+
+  it("detects a French postal code with context", () => {
+    const findings = scan("postal: 75001");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
+  });
+
+  it("detects a Spanish postal code with context", () => {
+    const findings = scan("código: 28013");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
   });
 });
 

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -626,7 +626,7 @@ describe("scan — national ID numbers", () => {
   });
 
   it("detects a valid French NIR", () => {
-    const findings = scan("secu: 1234567890123 11");
+    const findings = scan("secu: 1850175056001 49");
     expect(findings.some((f) => f.ruleId === "pii-nir-fr")).toBe(true);
   });
 
@@ -653,7 +653,7 @@ describe("scan — national ID numbers", () => {
   });
 
   it("does not flag a French NIR with a bad check key", () => {
-    const findings = scan("secu: 1234567890123 99");
+    const findings = scan("secu: 1850175056001 99");
     expect(findings.some((f) => f.ruleId === "pii-nir-fr")).toBe(false);
   });
 

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -6,6 +6,11 @@ import {
   parseCategories,
   redact,
   scan,
+  validateCodiceFiscale,
+  validateFrenchNIR,
+  validateGermanIdNr,
+  validateMyNumber,
+  validateSpanishNIF,
 } from "../rules.ts";
 
 // ── luhn ──────────────────────────────────────────────────────────────────────
@@ -444,5 +449,217 @@ describe("enabledCategoriesFromEnv", () => {
   it("returns the parsed categories when the env var is set", () => {
     process.env[ENV_KEY] = "pii";
     expect(enabledCategoriesFromEnv()).toEqual(new Set(["pii"]));
+  });
+});
+
+// ── National ID checksum validators ───────────────────────────────────────────
+
+describe("validateMyNumber", () => {
+  it("passes a valid My Number", () => {
+    expect(validateMyNumber("123456789018")).toBe(true);
+  });
+
+  it("fails an incorrect check digit", () => {
+    expect(validateMyNumber("123456789019")).toBe(false);
+  });
+
+  it("fails a wrong length", () => {
+    expect(validateMyNumber("12345678901")).toBe(false);
+    expect(validateMyNumber("1234567890123")).toBe(false);
+  });
+});
+
+describe("validateFrenchNIR", () => {
+  it("passes a valid NIR", () => {
+    expect(validateFrenchNIR("123456789012311")).toBe(true);
+  });
+
+  it("fails an incorrect check key", () => {
+    expect(validateFrenchNIR("123456789012399")).toBe(false);
+  });
+
+  it("fails a wrong length", () => {
+    expect(validateFrenchNIR("1234567890123")).toBe(false);
+  });
+});
+
+describe("validateCodiceFiscale", () => {
+  it("passes a valid Codice Fiscale", () => {
+    expect(validateCodiceFiscale("RSSMRA85M01H501Q")).toBe(true);
+  });
+
+  it("fails an incorrect control character", () => {
+    expect(validateCodiceFiscale("RSSMRA85M01H501Z")).toBe(false);
+  });
+
+  it("fails a wrong shape", () => {
+    expect(validateCodiceFiscale("RSSMRA85M01H501")).toBe(false);
+  });
+});
+
+describe("validateGermanIdNr", () => {
+  it("passes a valid Steuer-IdNr.", () => {
+    expect(validateGermanIdNr("12345678903")).toBe(true);
+  });
+
+  it("fails an incorrect check digit", () => {
+    expect(validateGermanIdNr("12345678900")).toBe(false);
+  });
+
+  it("fails when the first digit is 0", () => {
+    expect(validateGermanIdNr("02345678903")).toBe(false);
+  });
+});
+
+describe("validateSpanishNIF", () => {
+  it("passes a valid DNI", () => {
+    expect(validateSpanishNIF("12345678Z")).toBe(true);
+  });
+
+  it("fails an incorrect DNI control letter", () => {
+    expect(validateSpanishNIF("12345678Y")).toBe(false);
+  });
+
+  it("passes a valid NIE", () => {
+    expect(validateSpanishNIF("X1234567L")).toBe(true);
+  });
+
+  it("fails an incorrect NIE control letter", () => {
+    expect(validateSpanishNIF("X1234567M")).toBe(false);
+  });
+});
+
+// ── scan: national ID numbers ─────────────────────────────────────────────────
+
+describe("scan — national ID numbers", () => {
+  it("detects a valid My Number", () => {
+    const findings = scan("number: 123456789018");
+    expect(findings.some((f) => f.ruleId === "pii-mynumber-jp")).toBe(true);
+  });
+
+  it("does not flag a My Number with a bad check digit", () => {
+    const findings = scan("number: 123456789019");
+    expect(findings.some((f) => f.ruleId === "pii-mynumber-jp")).toBe(false);
+  });
+
+  it("detects a valid French NIR", () => {
+    const findings = scan("secu: 1234567890123 11");
+    expect(findings.some((f) => f.ruleId === "pii-nir-fr")).toBe(true);
+  });
+
+  it("detects a valid Italian Codice Fiscale", () => {
+    const findings = scan("cf: RSSMRA85M01H501Q");
+    expect(findings.some((f) => f.ruleId === "pii-codice-fiscale-it")).toBe(
+      true,
+    );
+  });
+
+  it("detects a valid German Steuer-IdNr.", () => {
+    const findings = scan("idnr: 12345678903");
+    expect(findings.some((f) => f.ruleId === "pii-steuer-id-de")).toBe(true);
+  });
+
+  it("detects a valid Spanish DNI", () => {
+    const findings = scan("dni: 12345678Z");
+    expect(findings.some((f) => f.ruleId === "pii-dni-nie-es")).toBe(true);
+  });
+
+  it("detects a valid Spanish NIE", () => {
+    const findings = scan("nie: X1234567L");
+    expect(findings.some((f) => f.ruleId === "pii-dni-nie-es")).toBe(true);
+  });
+});
+
+// ── scan: FIGS phone numbers (context-gated) ──────────────────────────────────
+
+describe("scan — FIGS phone numbers", () => {
+  it("detects a French phone number with context", () => {
+    const findings = scan("tél: 01 23 45 67 89");
+    expect(findings.some((f) => f.ruleId === "pii-phone-fr")).toBe(true);
+  });
+
+  it("does not flag a bare French number without context", () => {
+    const findings = scan("ref 01 23 45 67 89 done");
+    expect(findings.some((f) => f.ruleId === "pii-phone-fr")).toBe(false);
+  });
+
+  it("detects an Italian phone number with context", () => {
+    const findings = scan("telefono: 0212345678");
+    expect(findings.some((f) => f.ruleId === "pii-phone-it")).toBe(true);
+  });
+
+  it("does not flag a bare Italian number without context", () => {
+    const findings = scan("id 0212345678 end");
+    expect(findings.some((f) => f.ruleId === "pii-phone-it")).toBe(false);
+  });
+
+  it("detects a German phone number with context", () => {
+    const findings = scan("Telefon: 0301234567");
+    expect(findings.some((f) => f.ruleId === "pii-phone-de")).toBe(true);
+  });
+
+  it("does not flag a bare German number without context", () => {
+    const findings = scan("code 0301234567 end");
+    expect(findings.some((f) => f.ruleId === "pii-phone-de")).toBe(false);
+  });
+
+  it("detects a Spanish phone number with context", () => {
+    const findings = scan("teléfono: 612345678");
+    expect(findings.some((f) => f.ruleId === "pii-phone-es")).toBe(true);
+  });
+
+  it("does not flag a bare Spanish number without context", () => {
+    const findings = scan("num 612345678 end");
+    expect(findings.some((f) => f.ruleId === "pii-phone-es")).toBe(false);
+  });
+});
+
+// ── scan: postal code (context-gated) ─────────────────────────────────────────
+
+describe("scan — postal code", () => {
+  it("detects a US ZIP with context", () => {
+    const findings = scan("ZIP: 90210");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
+  });
+
+  it("detects a US ZIP+4 with context", () => {
+    const findings = scan("postal: 90210-1234");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
+  });
+
+  it("detects a German PLZ with context", () => {
+    const findings = scan("PLZ: 10115");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
+  });
+
+  it("detects an Italian CAP with context", () => {
+    const findings = scan("CAP: 00184");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
+  });
+
+  it("does not flag a bare 5-digit number", () => {
+    const findings = scan("count: 12345 items");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(false);
+  });
+
+  it("does not flag a ZIP without a context label", () => {
+    const findings = scan("order 90210 confirmed");
+    expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(false);
+  });
+});
+
+// ── scan: context scoring ─────────────────────────────────────────────────────
+
+describe("scan — context scoring", () => {
+  it("assigns score 1.0 to a context-gated match", () => {
+    const findings = scan("ZIP: 90210");
+    const postal = findings.find((f) => f.ruleId === "pii-postal-code");
+    expect(postal?.score).toBe(1.0);
+  });
+
+  it("assigns score 1.0 to rules without context requirements", () => {
+    const findings = scan("contact: user@example.com");
+    const email = findings.find((f) => f.ruleId === "pii-email");
+    expect(email?.score).toBe(1.0);
   });
 });

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -249,6 +249,75 @@ describe("scan — secrets", () => {
   });
 });
 
+// ── scan: expanded secrets ───────────────────────────────────────────────────
+
+describe("scan — expanded secrets (AI, cloud, SaaS)", () => {
+  it("detects a Replicate token", () => {
+    const findings = scan(`r8_${"A".repeat(37)}`);
+    expect(findings.some((f) => f.ruleId === "replicate-token")).toBe(true);
+  });
+
+  it("detects a Hugging Face token", () => {
+    const findings = scan(`hf_${"a".repeat(34)}`);
+    expect(findings.some((f) => f.ruleId === "huggingface-token")).toBe(true);
+  });
+
+  it("detects a Groq API key", () => {
+    const findings = scan(`gsk_${"A".repeat(52)}`);
+    expect(findings.some((f) => f.ruleId === "groq-key")).toBe(true);
+  });
+
+  it("detects an OpenRouter API key", () => {
+    const findings = scan(`sk-or-v1-${"a".repeat(64)}`);
+    expect(findings.some((f) => f.ruleId === "openrouter-key")).toBe(true);
+  });
+
+  it("detects an xAI (Grok) API key", () => {
+    const findings = scan(`xai-${"A".repeat(80)}`);
+    expect(findings.some((f) => f.ruleId === "xai-key")).toBe(true);
+  });
+
+  it("detects a Perplexity API key", () => {
+    const findings = scan(`pplx-${"a".repeat(48)}`);
+    expect(findings.some((f) => f.ruleId === "perplexity-key")).toBe(true);
+  });
+
+  it("detects a DigitalOcean PAT", () => {
+    const findings = scan(`dop_v1_${"a".repeat(64)}`);
+    expect(findings.some((f) => f.ruleId === "digitalocean-pat")).toBe(true);
+  });
+
+  it("detects a Square access token", () => {
+    const findings = scan(`EAAA${"A".repeat(60)}`);
+    expect(findings.some((f) => f.ruleId === "square-access-token")).toBe(true);
+  });
+
+  it("detects a Sentry user auth token", () => {
+    const findings = scan(`sntryu_${"a".repeat(64)}`);
+    expect(findings.some((f) => f.ruleId === "sentry-user-token")).toBe(true);
+  });
+
+  it("detects an Atlassian API token", () => {
+    const findings = scan(`ATATT3${"A".repeat(180)}`);
+    expect(findings.some((f) => f.ruleId === "atlassian-token")).toBe(true);
+  });
+
+  it("detects a Linear API key", () => {
+    const findings = scan(`lin_api_${"a".repeat(40)}`);
+    expect(findings.some((f) => f.ruleId === "linear-key")).toBe(true);
+  });
+
+  it("detects a Postman API key", () => {
+    const findings = scan(`PMAK-${"a".repeat(24)}-${"b".repeat(34)}`);
+    expect(findings.some((f) => f.ruleId === "postman-key")).toBe(true);
+  });
+
+  it("detects a Supabase PAT", () => {
+    const findings = scan(`sbp_${"a".repeat(40)}`);
+    expect(findings.some((f) => f.ruleId === "supabase-key")).toBe(true);
+  });
+});
+
 // ── scan: PII ─────────────────────────────────────────────────────────────────
 
 describe("scan — PII", () => {

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -38,6 +38,11 @@ describe("luhn", () => {
     expect(luhn("4111 1111 1111 1111")).toBe(true);
     expect(luhn("4111-1111-1111-1111")).toBe(true);
   });
+
+  it("fails empty or digit-less input", () => {
+    expect(luhn("")).toBe(false);
+    expect(luhn("no-digits-here")).toBe(false);
+  });
 });
 
 // ── entropy ───────────────────────────────────────────────────────────────────
@@ -845,6 +850,17 @@ describe("isReservedIpv4", () => {
     expect(isReservedIpv4("127.0.0.1")).toBe(true);
     expect(isReservedIpv4("169.254.1.1")).toBe(true);
   });
+
+  it("returns true for partially-numeric octets", () => {
+    expect(isReservedIpv4("1a.2.3.4")).toBe(true);
+    expect(isReservedIpv4("8.8.8.8x")).toBe(true);
+    expect(isReservedIpv4("1.2.3.4 ")).toBe(true);
+  });
+
+  it("returns true for other RFC 6890 special-purpose ranges", () => {
+    expect(isReservedIpv4("192.0.0.1")).toBe(true); // IETF protocol assignments
+    expect(isReservedIpv4("192.88.99.1")).toBe(true); // 6to4 relay anycast
+  });
 });
 
 describe("isReservedIpv6", () => {
@@ -886,6 +902,20 @@ describe("isReservedIpv6", () => {
 
   it("returns true for documentation addresses", () => {
     expect(isReservedIpv6("2001:db8::1")).toBe(true);
+  });
+
+  it("returns true for groups with non-hex trailing characters", () => {
+    expect(isReservedIpv6("abcdZ::1")).toBe(true);
+    expect(isReservedIpv6("2001:4860:4860::8888g")).toBe(true);
+  });
+
+  it("returns true for groups longer than 4 hex digits", () => {
+    expect(isReservedIpv6("12345::1")).toBe(true);
+  });
+
+  it("returns true when :: compresses zero groups", () => {
+    // RFC 4291 §2.2: "::" must compress at least one 16-bit group.
+    expect(isReservedIpv6("1:2:3:4:5:6:7::8")).toBe(true);
   });
 });
 
@@ -1289,5 +1319,52 @@ describe("user config — custom rules", () => {
     const { RULES } = await import("../rules.ts");
     expect(RULES.some((r) => r.id === "bad-regex")).toBe(false);
     expect(RULES.some((r) => r.id === "good-regex")).toBe(true);
+  });
+
+  it("skips null or non-object rule entries without crashing", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({
+        rules: [
+          null,
+          {
+            id: "good-rule",
+            description: "Good",
+            regex: "GOODKEY-\\d+",
+            category: "secret",
+          },
+        ],
+      }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    const { RULES } = await import("../rules.ts");
+    expect(RULES.some((r) => r.id === "good-rule")).toBe(true);
+  });
+
+  it("ignores a non-array rules field without crashing", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ rules: { id: "not-an-array" } }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    // Built-in defaults still load (spot-check a well-known rule).
+    const { RULES } = await import("../rules.ts");
+    expect(RULES.some((r) => r.id === "pii-email")).toBe(true);
   });
 });

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  compileRule,
   enabledCategoriesFromEnv,
   entropy,
   isReservedIpv4,
@@ -898,5 +899,189 @@ describe("scan — public IPs", () => {
   it("does not flag a link-local IPv6", () => {
     const findings = scan("ipv6: fe80::1");
     expect(findings.some((f) => f.ruleId === "pii-ipv6")).toBe(false);
+  });
+});
+
+// ── compileRule ───────────────────────────────────────────────────────────────
+
+describe("compileRule", () => {
+  it("compiles regex source with default g flag", () => {
+    const rule = compileRule({
+      id: "test",
+      description: "Test",
+      regex: "\\d{4}",
+      category: "pii",
+    });
+    expect(rule.regex.flags).toBe("g");
+    expect("1234".match(rule.regex)).not.toBeNull();
+  });
+
+  it("compiles with custom flags", () => {
+    const rule = compileRule({
+      id: "test",
+      description: "Test",
+      regex: "\\d{4}",
+      flags: "gi",
+      category: "pii",
+    });
+    expect(rule.regex.flags).toBe("gi");
+  });
+
+  it("resolves a validator by name", () => {
+    const rule = compileRule({
+      id: "test",
+      description: "Test",
+      regex: "\\d{12}",
+      category: "pii",
+      validate: "mynumber-jp",
+    });
+    expect(rule.validate).toBeDefined();
+    expect(rule.validate?.("123456789018")).toBe(true);
+  });
+
+  it("preserves secretGroup and entropyThreshold", () => {
+    const rule = compileRule({
+      id: "test",
+      description: "Test",
+      regex: "key=(\\S+)",
+      category: "secret",
+      secretGroup: 1,
+      entropyThreshold: 3.5,
+    });
+    expect(rule.secretGroup).toBe(1);
+    expect(rule.entropyThreshold).toBe(3.5);
+  });
+});
+
+// ── User config (custom rules) ────────────────────────────────────────────────
+
+describe("user config — custom rules", () => {
+  const ENV_KEY = "SENSITIVE_CANARY_CONFIG";
+  const envBackup = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (envBackup === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = envBackup;
+    }
+    vi.resetModules();
+  });
+
+  it("adds a custom rule from a user config file", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({
+        rules: [
+          {
+            id: "custom-token",
+            description: "Custom Service Token",
+            regex: "MYSVC-[A-Za-z0-9]{20}",
+            category: "secret",
+          },
+        ],
+      }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    const { RULES, scan } = await import("../rules.ts");
+    expect(RULES.some((r) => r.id === "custom-token")).toBe(true);
+
+    const findings = scan("token: MYSVC-abcdefghijklmnopqrst");
+    expect(findings.some((f) => f.ruleId === "custom-token")).toBe(true);
+  });
+
+  it("overrides a built-in rule by id", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({
+        rules: [
+          {
+            id: "pii-email",
+            description: "Replaced Email Rule",
+            regex: "NEVERMATCH[a-z]+",
+            category: "pii",
+          },
+        ],
+      }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    const { RULES, scan } = await import("../rules.ts");
+    const emailRules = RULES.filter((r) => r.id === "pii-email");
+    expect(emailRules).toHaveLength(1);
+    expect(emailRules[0]?.description).toBe("Replaced Email Rule");
+
+    const findings = scan("contact: user@example.com");
+    expect(findings.some((f) => f.ruleId === "pii-email")).toBe(false);
+  });
+
+  it("respects a custom contextWindow", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({
+        contextWindow: 1,
+        rules: [],
+      }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    const { getDefaultContextWindow: getWindow } = await import("../rules.ts");
+    expect(getWindow()).toBe(1);
+  });
+
+  it("skips rules with invalid regex", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({
+        rules: [
+          {
+            id: "bad-regex",
+            description: "Bad",
+            regex: "[invalid(",
+            category: "secret",
+          },
+          {
+            id: "good-regex",
+            description: "Good",
+            regex: "GOODKEY-\\d+",
+            category: "secret",
+          },
+        ],
+      }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    const { RULES } = await import("../rules.ts");
+    expect(RULES.some((r) => r.id === "bad-regex")).toBe(false);
+    expect(RULES.some((r) => r.id === "good-regex")).toBe(true);
   });
 });

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -1196,6 +1196,46 @@ describe("user config — custom rules", () => {
     expect(findings.some((f) => f.ruleId === "pii-email")).toBe(false);
   });
 
+  it("de-duplicates duplicate user rule ids (last definition wins)", async () => {
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = mkdtempSync(join(tmpdir(), "canary-"));
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({
+        rules: [
+          {
+            id: "custom-token",
+            description: "First Definition",
+            regex: "MYSVC-[A-Za-z0-9]{20}",
+            category: "secret",
+          },
+          {
+            id: "custom-token",
+            description: "Last Definition",
+            regex: "MYSVC2-[A-Za-z0-9]{20}",
+            category: "secret",
+          },
+        ],
+      }),
+    );
+
+    process.env[ENV_KEY] = join(dir, "config.json");
+    vi.resetModules();
+
+    const { RULES, scan } = await import("../rules.ts");
+    const dupes = RULES.filter((r) => r.id === "custom-token");
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]?.description).toBe("Last Definition");
+
+    // Only the last regex is active, and a match produces a single finding.
+    expect(scan("token: MYSVC-abcdefghijklmnopqrst")).toHaveLength(0);
+    const findings = scan("token: MYSVC2-abcdefghijklmnopqrst");
+    expect(findings.filter((f) => f.ruleId === "custom-token")).toHaveLength(1);
+  });
+
   it("respects a custom contextWindow", async () => {
     const { mkdtempSync, writeFileSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -12,6 +12,7 @@ import {
   validateCodiceFiscale,
   validateFrenchNIR,
   validateGermanIdNr,
+  validateKoreanBRN,
   validateKoreanRRN,
   validateMyNumber,
   validateSpanishNIF,
@@ -687,7 +688,7 @@ describe("scan — postal code", () => {
   });
 
   it("detects a Spanish postal code with context", () => {
-    const findings = scan("código: 28013");
+    const findings = scan("postal: 28013");
     expect(findings.some((f) => f.ruleId === "pii-postal-code")).toBe(true);
   });
 });
@@ -721,6 +722,20 @@ describe("validateKoreanRRN", () => {
 
   it("fails a wrong length", () => {
     expect(validateKoreanRRN("800101100000")).toBe(false);
+  });
+});
+
+describe("validateKoreanBRN", () => {
+  it("passes a valid BRN", () => {
+    expect(validateKoreanBRN("1348672612")).toBe(true);
+  });
+
+  it("fails an incorrect check digit", () => {
+    expect(validateKoreanBRN("1348672610")).toBe(false);
+  });
+
+  it("fails a wrong length", () => {
+    expect(validateKoreanBRN("134867261")).toBe(false);
   });
 });
 
@@ -801,6 +816,16 @@ describe("scan — Korean / Chinese IDs", () => {
   it("does not flag a Chinese ID with a bad check digit", () => {
     const findings = scan("id: 110102199001010010");
     expect(findings.some((f) => f.ruleId === "pii-resident-id-cn")).toBe(false);
+  });
+
+  it("detects a valid Korean BRN", () => {
+    const findings = scan("brn: 134-86-72612");
+    expect(findings.some((f) => f.ruleId === "pii-brn-kr")).toBe(true);
+  });
+
+  it("does not flag a BRN with a bad check digit", () => {
+    const findings = scan("brn: 134-86-72610");
+    expect(findings.some((f) => f.ruleId === "pii-brn-kr")).toBe(false);
   });
 });
 

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -1,0 +1,371 @@
+{
+  "contextWindow": 3,
+  "rules": [
+    {
+      "id": "aws-access-key",
+      "description": "AWS Access Key ID",
+      "regex": "\\b(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}\\b",
+      "category": "secret"
+    },
+    {
+      "id": "gcp-api-key",
+      "description": "Google Cloud API Key",
+      "regex": "AIza[0-9A-Za-z_-]{35}",
+      "category": "secret"
+    },
+    {
+      "id": "private-key",
+      "description": "PEM Private Key",
+      "regex": "-----BEGIN (RSA |EC |DSA |PGP |OPENSSH )?PRIVATE KEY",
+      "category": "secret"
+    },
+    {
+      "id": "github-pat",
+      "description": "GitHub Personal Access Token",
+      "regex": "gh[pousr]_[A-Za-z0-9]{36,255}",
+      "category": "secret"
+    },
+    {
+      "id": "github-fine-grained",
+      "description": "GitHub Fine-Grained Token",
+      "regex": "github_pat_[A-Za-z0-9_]{82}",
+      "category": "secret"
+    },
+    {
+      "id": "gitlab-pat",
+      "description": "GitLab Personal Access Token",
+      "regex": "glpat-[A-Za-z0-9_=-]{20,22}",
+      "category": "secret"
+    },
+    {
+      "id": "npm-token",
+      "description": "npm Access Token",
+      "regex": "npm_[A-Za-z0-9]{36}",
+      "category": "secret"
+    },
+    {
+      "id": "slack-token",
+      "description": "Slack Token",
+      "regex": "xox[baprs]-[0-9a-zA-Z-]{10,72}",
+      "category": "secret"
+    },
+    {
+      "id": "slack-webhook",
+      "description": "Slack Webhook URL",
+      "regex": "https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Za-z0-9_]{8,10}\\/B[A-Za-z0-9_]{8,12}\\/[A-Za-z0-9_]{23,24}",
+      "category": "secret"
+    },
+    {
+      "id": "discord-webhook",
+      "description": "Discord Webhook URL",
+      "regex": "https:\\/\\/discord(?:app)?\\.com\\/api\\/webhooks\\/[0-9]{17,20}\\/[A-Za-z0-9_-]{68}",
+      "category": "secret"
+    },
+    {
+      "id": "telegram-bot-token",
+      "description": "Telegram Bot Token",
+      "regex": "[0-9]{8,10}:AA[0-9A-Za-z_-]{33}",
+      "category": "secret"
+    },
+    {
+      "id": "twilio-sid",
+      "description": "Twilio Account SID",
+      "regex": "AC[0-9a-f]{32}",
+      "category": "secret"
+    },
+    {
+      "id": "sendgrid-key",
+      "description": "SendGrid API Key",
+      "regex": "SG\\.[A-Za-z0-9_-]{20,24}\\.[A-Za-z0-9_-]{39,50}",
+      "category": "secret"
+    },
+    {
+      "id": "mailgun-key",
+      "description": "Mailgun API Key",
+      "regex": "key-[0-9a-zA-Z]{32}",
+      "category": "secret"
+    },
+    {
+      "id": "mailchimp-key",
+      "description": "Mailchimp API Key",
+      "regex": "[0-9a-f]{32}-us[0-9]{1,2}",
+      "category": "secret"
+    },
+    {
+      "id": "stripe-secret-key",
+      "description": "Stripe Secret Key",
+      "regex": "sk_(live|test)_[0-9a-zA-Z]{24}",
+      "category": "secret"
+    },
+    {
+      "id": "stripe-restricted-key",
+      "description": "Stripe Restricted Key",
+      "regex": "rk_(live|test)_[0-9a-zA-Z]{24}",
+      "category": "secret"
+    },
+    {
+      "id": "openai-key",
+      "description": "OpenAI API Key (legacy)",
+      "regex": "sk-(?!proj-|ant-)[A-Za-z0-9]{48}",
+      "category": "secret"
+    },
+    {
+      "id": "openai-project-key",
+      "description": "OpenAI Project API Key",
+      "regex": "sk-proj-[A-Za-z0-9_-]{40,}",
+      "category": "secret",
+      "entropyThreshold": 3.5
+    },
+    {
+      "id": "anthropic-key",
+      "description": "Anthropic API Key",
+      "regex": "sk-ant-[A-Za-z0-9_-]{95}",
+      "category": "secret"
+    },
+    {
+      "id": "jwt",
+      "description": "JSON Web Token (JWT)",
+      "regex": "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "generic-secret",
+      "description": "Generic API Key / Secret",
+      "regex": "(api[_-]?key|secret[_-]?key|access[_-]?token|api[_-]?secret)\\s*[:=]\\s*['\"]?([A-Za-z0-9\\-_.]{20,})",
+      "category": "secret",
+      "flags": "gi",
+      "secretGroup": 2,
+      "entropyThreshold": 3.5
+    },
+    {
+      "id": "env-assignment",
+      "description": ".env style secret assignment",
+      "regex": "\\b[A-Z_]*(SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|PRIVATE_KEY)[A-Z_0-9]*\\s*=\\s*(\\S{8,})",
+      "category": "secret",
+      "secretGroup": 2,
+      "entropyThreshold": 3
+    },
+    {
+      "id": "connection-string",
+      "description": "Database Connection String with credentials",
+      "regex": "(mongodb|mysql|postgres|postgresql|redis):\\/\\/[^:\\s]+:[^@\\s]+@",
+      "category": "secret"
+    },
+    {
+      "id": "pii-email",
+      "description": "Email Address",
+      "regex": "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+      "category": "pii"
+    },
+    {
+      "id": "pii-credit-card",
+      "description": "Credit Card Number",
+      "regex": "\\b(?:4[0-9]{3}(?:[\\s-]?[0-9]{4}){3}|5[1-5][0-9]{2}(?:[\\s-]?[0-9]{4}){3}|3[47][0-9]{2}[\\s-]?[0-9]{6}[\\s-]?[0-9]{5}|6(?:011|5[0-9]{2})[0-9](?:[\\s-]?[0-9]{4}){3})\\b",
+      "category": "pii",
+      "validate": "luhn"
+    },
+    {
+      "id": "pii-ssn",
+      "description": "US Social Security Number",
+      "regex": "\\b(?!000|666|9\\d{2})\\d{3}[- ](?!00)\\d{2}[- ](?!0000)\\d{4}\\b",
+      "category": "pii"
+    },
+    {
+      "id": "pii-phone-us",
+      "description": "US Phone Number",
+      "regex": "\\b(\\+1[\\s.-]?)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}\\b",
+      "category": "pii"
+    },
+    {
+      "id": "pii-phone-jp",
+      "description": "Japanese Phone Number",
+      "regex": "\\b0\\d{1,4}[\\s-]\\d{1,4}[\\s-]\\d{4}\\b",
+      "category": "pii"
+    },
+    {
+      "id": "pii-postal-jp",
+      "description": "Japanese Postal Code",
+      "regex": "〒\\d{3}[\\s-]\\d{4}",
+      "category": "pii"
+    },
+    {
+      "id": "pii-ipv4",
+      "description": "IPv4 Address (private range)",
+      "regex": "\\b(10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.(1[6-9]|2\\d|3[01])\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3})\\b",
+      "category": "pii"
+    },
+    {
+      "id": "pii-mynumber-jp",
+      "description": "Japanese Individual Number (My Number)",
+      "regex": "\\b\\d{12}\\b",
+      "category": "pii",
+      "validate": "mynumber-jp"
+    },
+    {
+      "id": "pii-nir-fr",
+      "description": "French NIR / Social Security Number",
+      "regex": "\\b[12]\\d{2}(?:0[1-9]|1[0-9]|2[0-9]|[3-9]\\d)(?:\\d{5}|2[AB]\\d{3})\\d{3}\\s?\\d{2}\\b",
+      "category": "pii",
+      "flags": "gi",
+      "validate": "nir-fr"
+    },
+    {
+      "id": "pii-codice-fiscale-it",
+      "description": "Italian Codice Fiscale",
+      "regex": "\\b[A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z]\\b",
+      "category": "pii",
+      "validate": "codice-fiscale-it"
+    },
+    {
+      "id": "pii-steuer-id-de",
+      "description": "German Steuer-Identifikationsnummer",
+      "regex": "\\b[1-9]\\d{10}\\b",
+      "category": "pii",
+      "validate": "steuer-id-de"
+    },
+    {
+      "id": "pii-dni-nie-es",
+      "description": "Spanish DNI / NIE",
+      "regex": "\\b(?:\\d{8}[A-Z]|[XYZ]\\d{7}[A-Z])\\b",
+      "category": "pii",
+      "validate": "dni-nie-es"
+    },
+    {
+      "id": "pii-phone-fr",
+      "description": "French Phone Number",
+      "regex": "\\b0[1-9](?:[\\s.-]?\\d{2}){4}\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": [
+        "tél",
+        "tel",
+        "téléphone",
+        "telephone",
+        "phone",
+        "mobile",
+        "portable",
+        "fax"
+      ]
+    },
+    {
+      "id": "pii-phone-it",
+      "description": "Italian Phone Number",
+      "regex": "\\b(?:0\\d{8,9}|3\\d{8,9})\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["telefono", "tel", "cellulare", "mobile", "phone", "fax"]
+    },
+    {
+      "id": "pii-phone-de",
+      "description": "German Phone Number",
+      "regex": "\\b0[1-9]\\d{6,11}\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["telefon", "tel", "handy", "mobil", "phone", "fax"]
+    },
+    {
+      "id": "pii-phone-es",
+      "description": "Spanish Phone Number",
+      "regex": "\\b[67]\\d{8}\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": [
+        "teléfono",
+        "telefono",
+        "tel",
+        "móvil",
+        "movil",
+        "phone",
+        "fax"
+      ]
+    },
+    {
+      "id": "pii-postal-code",
+      "description": "Postal Code (US ZIP / EU / KR)",
+      "regex": "\\b\\d{5}(?:-\\d{4})?\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": [
+        "zip",
+        "postal",
+        "postale",
+        "postcode",
+        "plz",
+        "postleitzahl",
+        "cap",
+        "우편번호"
+      ]
+    },
+    {
+      "id": "pii-rrn-kr",
+      "description": "Korean Resident Registration Number",
+      "regex": "\\b\\d{6}[-\\s]?\\d{7}\\b",
+      "category": "pii",
+      "validate": "rrn-kr"
+    },
+    {
+      "id": "pii-brn-kr",
+      "description": "Korean Business Registration Number",
+      "regex": "\\b\\d{3}[-\\s]?\\d{2}[-\\s]?\\d{5}\\b",
+      "category": "pii",
+      "validate": "brn-kr"
+    },
+    {
+      "id": "pii-resident-id-cn",
+      "description": "Chinese Resident Identity Card",
+      "regex": "\\b\\d{17}[\\dXx]\\b",
+      "category": "pii",
+      "validate": "resident-id-cn"
+    },
+    {
+      "id": "pii-phone-kr",
+      "description": "Korean Phone Number",
+      "regex": "(?:\\+82[-\\s]?)?(?:01[016789]|0\\d{1,2})[-\\s]?\\d{3,4}[-\\s]?\\d{4}",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": [
+        "전화",
+        "핸드폰",
+        "휴대",
+        "tel",
+        "phone",
+        "mobile",
+        "fax"
+      ]
+    },
+    {
+      "id": "pii-phone-cn",
+      "description": "Chinese Phone Number",
+      "regex": "(?:\\+86[-\\s]?)?(?:1[3-9]\\d{9}|0\\d{2,3}[-\\s]?\\d{7,8})",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["电话", "手机", "tel", "phone", "mobile", "fax"]
+    },
+    {
+      "id": "pii-postal-cn",
+      "description": "Chinese Postal Code",
+      "regex": "\\b[1-9]\\d{5}\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["邮编", "邮政编码", "postal", "postcode", "zip"]
+    },
+    {
+      "id": "pii-ipv4-public",
+      "description": "Public IPv4 Address",
+      "regex": "\\b\\d{1,3}(?:\\.\\d{1,3}){3}\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["ip", "ipv4"],
+      "validate": "public-ipv4"
+    },
+    {
+      "id": "pii-ipv6",
+      "description": "IPv6 Address",
+      "regex": "\\b[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{0,4}){2,7}\\b",
+      "category": "pii",
+      "requireContext": true,
+      "contextWords": ["ipv6", "ip"],
+      "validate": "public-ipv6"
+    }
+  ]
+}

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -123,6 +123,96 @@
       "category": "secret"
     },
     {
+      "id": "replicate-token",
+      "description": "Replicate API Token",
+      "regex": "r8_[0-9A-Za-z_]{37}",
+      "category": "secret"
+    },
+    {
+      "id": "huggingface-token",
+      "description": "Hugging Face Access Token",
+      "regex": "hf_[a-zA-Z0-9]{34}",
+      "category": "secret"
+    },
+    {
+      "id": "groq-key",
+      "description": "Groq API Key",
+      "regex": "gsk_[A-Za-z0-9]{52}",
+      "category": "secret"
+    },
+    {
+      "id": "openrouter-key",
+      "description": "OpenRouter API Key",
+      "regex": "sk-or-v1-[0-9a-f]{64}",
+      "category": "secret"
+    },
+    {
+      "id": "xai-key",
+      "description": "xAI (Grok) API Key",
+      "regex": "xai-[0-9A-Za-z_]{80}",
+      "category": "secret"
+    },
+    {
+      "id": "perplexity-key",
+      "description": "Perplexity API Key",
+      "regex": "pplx-[a-zA-Z0-9]{48}",
+      "category": "secret"
+    },
+    {
+      "id": "digitalocean-pat",
+      "description": "DigitalOcean Personal Access Token",
+      "regex": "dop_v1_[a-f0-9]{64}",
+      "category": "secret"
+    },
+    {
+      "id": "square-access-token",
+      "description": "Square Access Token",
+      "regex": "EAAA[a-zA-Z0-9\\-_+=]{60}",
+      "category": "secret"
+    },
+    {
+      "id": "mapbox-token",
+      "description": "Mapbox Token",
+      "regex": "(?:pk|sk)\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "sentry-user-token",
+      "description": "Sentry User Auth Token",
+      "regex": "sntryu_[a-f0-9]{64}",
+      "category": "secret"
+    },
+    {
+      "id": "sentry-org-token",
+      "description": "Sentry Organization Auth Token",
+      "regex": "sntrys_eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "atlassian-token",
+      "description": "Atlassian API Token",
+      "regex": "ATATT3[A-Za-z0-9_\\-=]{180,}",
+      "category": "secret"
+    },
+    {
+      "id": "linear-key",
+      "description": "Linear API Key",
+      "regex": "lin_api_[a-z0-9]{40}",
+      "category": "secret"
+    },
+    {
+      "id": "postman-key",
+      "description": "Postman API Key",
+      "regex": "PMAK-[a-f0-9]{24}-[a-f0-9]{34}",
+      "category": "secret"
+    },
+    {
+      "id": "supabase-key",
+      "description": "Supabase Personal Access Token",
+      "regex": "sbp_[a-z0-9]{40}",
+      "category": "secret"
+    },
+    {
       "id": "jwt",
       "description": "JSON Web Token (JWT)",
       "regex": "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -215,7 +215,7 @@
     {
       "id": "jwt",
       "description": "JSON Web Token (JWT)",
-      "regex": "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "regex": "(?<!sntrys_|pk\\.|sk\\.)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
       "category": "secret"
     },
     {
@@ -294,7 +294,7 @@
     {
       "id": "pii-nir-fr",
       "description": "French NIR / Social Security Number",
-      "regex": "\\b[12]\\d{2}(?:0[1-9]|1[0-9]|2[0-9]|[3-9]\\d)(?:\\d{5}|2[AB]\\d{3})\\d{3}\\s?\\d{2}\\b",
+      "regex": "\\b[12]\\d{2}(?:0[1-9]|1[0-2]|20)(?:\\d{5}|2[AB]\\d{3})\\d{3}\\s?\\d{2}\\b",
       "category": "pii",
       "flags": "gi",
       "validate": "nir-fr"

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -538,7 +538,7 @@ function validateRuleConfig(rc: unknown): asserts rc is RuleConfig {
     (!Array.isArray(contextWords) || contextWords.length === 0)
   ) {
     throw new Error(
-      '"requireContext" is true but "contextWords" is empty — the rule would never fire',
+      '"requireContext" is true but "contextWords" is empty — context gating would be disabled and the rule would always fire',
     );
   }
 }

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -232,6 +232,23 @@ export function validateKoreanRRN(input: string): boolean {
   return check === parseInt(s[12] ?? "", 10);
 }
 
+// Korean Business Registration Number (사업자등록번호): 10 digits. Uses the
+// standard algorithm employed by Korea's NTS (Hometax) and widely implemented:
+// weights 1,3,7,1,3,7,1,3,5 over digits 1-9, plus floor(digit9 × 5 / 10), and
+// the check digit is (10 - (sum mod 10)) mod 10. Note: the official NTS spec
+// was not directly accessible; this follows the de-facto standard algorithm.
+export function validateKoreanBRN(input: string): boolean {
+  const s = input.replace(/[-\s]/g, "");
+  if (!/^\d{10}$/.test(s)) return false;
+  const weights = [1, 3, 7, 1, 3, 7, 1, 3, 5];
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += parseInt(s[i] ?? "", 10) * (weights[i] ?? 0);
+  }
+  sum += Math.floor((parseInt(s[8] ?? "", 10) * 5) / 10);
+  return (10 - (sum % 10)) % 10 === parseInt(s[9] ?? "", 10);
+}
+
 // Chinese Resident Identity Card (居民身份证): 18 chars (17 digits + check).
 // ISO 7064 MOD 11-2 per GB 11643-1999. Weights
 // 7,9,10,5,8,4,2,1,6,3,7,9,10,5,8,4,2; remainder maps to "10X98765432".
@@ -630,8 +647,6 @@ const PII_RULES: Rule[] = [
       "phone",
       "mobile",
       "portable",
-      "contact",
-      "appel",
       "fax",
     ],
   },
@@ -641,16 +656,7 @@ const PII_RULES: Rule[] = [
     regex: /\b(?:0\d{8,9}|3\d{8,9})\b/g,
     category: "pii",
     requireContext: true,
-    contextWords: [
-      "telefono",
-      "tel",
-      "cellulare",
-      "mobile",
-      "phone",
-      "contatto",
-      "chiamata",
-      "fax",
-    ],
+    contextWords: ["telefono", "tel", "cellulare", "mobile", "phone", "fax"],
   },
   {
     id: "pii-phone-de",
@@ -658,16 +664,7 @@ const PII_RULES: Rule[] = [
     regex: /\b0[1-9]\d{6,11}\b/g,
     category: "pii",
     requireContext: true,
-    contextWords: [
-      "telefon",
-      "tel",
-      "handy",
-      "mobil",
-      "phone",
-      "anruf",
-      "nummer",
-      "fax",
-    ],
+    contextWords: ["telefon", "tel", "handy", "mobil", "phone", "fax"],
   },
   {
     id: "pii-phone-es",
@@ -682,8 +679,6 @@ const PII_RULES: Rule[] = [
       "móvil",
       "movil",
       "phone",
-      "contacto",
-      "llamada",
       "fax",
     ],
   },
@@ -705,8 +700,6 @@ const PII_RULES: Rule[] = [
       "plz",
       "postleitzahl",
       "cap",
-      "código",
-      "codigo",
       "우편번호",
     ],
   },
@@ -717,6 +710,13 @@ const PII_RULES: Rule[] = [
     description: "Korean Resident Registration Number",
     regex: /\b\d{6}[-\s]?\d{7}\b/g,
     validate: validateKoreanRRN,
+    category: "pii",
+  },
+  {
+    id: "pii-brn-kr",
+    description: "Korean Business Registration Number",
+    regex: /\b\d{3}[-\s]?\d{2}[-\s]?\d{5}\b/g,
+    validate: validateKoreanBRN,
     category: "pii",
   },
   {
@@ -734,17 +734,7 @@ const PII_RULES: Rule[] = [
     regex: /(?:\+82[-\s]?)?(?:01[016789]|0\d{1,2})[-\s]?\d{3,4}[-\s]?\d{4}/g,
     category: "pii",
     requireContext: true,
-    contextWords: [
-      "전화",
-      "연락처",
-      "핸드폰",
-      "휴대",
-      "tel",
-      "phone",
-      "mobile",
-      "call",
-      "fax",
-    ],
+    contextWords: ["전화", "핸드폰", "휴대", "tel", "phone", "mobile", "fax"],
   },
   {
     id: "pii-phone-cn",
@@ -752,16 +742,7 @@ const PII_RULES: Rule[] = [
     regex: /(?:\+86[-\s]?)?(?:1[3-9]\d{9}|0\d{2,3}[-\s]?\d{7,8})/g,
     category: "pii",
     requireContext: true,
-    contextWords: [
-      "电话",
-      "手机",
-      "联系方式",
-      "tel",
-      "phone",
-      "mobile",
-      "call",
-      "fax",
-    ],
+    contextWords: ["电话", "手机", "tel", "phone", "mobile", "fax"],
   },
 
   // ── Chinese postal code (6-digit, context-gated) ─────────────────────────────
@@ -785,15 +766,7 @@ const PII_RULES: Rule[] = [
     validate: (ip) => !isReservedIpv4(ip),
     category: "pii",
     requireContext: true,
-    contextWords: [
-      "ip",
-      "ipv4",
-      "address",
-      "addr",
-      "host",
-      "server",
-      "endpoint",
-    ],
+    contextWords: ["ip", "ipv4"],
   },
   {
     id: "pii-ipv6",
@@ -802,15 +775,7 @@ const PII_RULES: Rule[] = [
     validate: (ip) => !isReservedIpv6(ip),
     category: "pii",
     requireContext: true,
-    contextWords: [
-      "ipv6",
-      "ip",
-      "address",
-      "addr",
-      "host",
-      "server",
-      "endpoint",
-    ],
+    contextWords: ["ipv6", "ip"],
   },
 ];
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -426,14 +426,98 @@ function readJsonFile(filePath: string): unknown {
   return JSON.parse(readFileSync(filePath, "utf-8"));
 }
 
+// Validate a raw JSON object against the RuleConfig schema. Throws with a
+// descriptive message when a required field is missing, a type is wrong, or a
+// cross-field constraint is violated.
+function validateRuleConfig(rc: unknown): asserts rc is RuleConfig {
+  if (typeof rc !== "object" || rc === null) {
+    throw new Error("rule must be an object");
+  }
+  const {
+    id,
+    description,
+    regex: source,
+    category,
+    flags,
+    secretGroup,
+    entropyThreshold,
+    validate: validateName,
+    contextWords,
+    requireContext,
+    contextWindow,
+  } = rc as Record<string, unknown>;
+
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error('missing or empty "id" field');
+  }
+  if (typeof description !== "string" || description.length === 0) {
+    throw new Error('missing or empty "description" field');
+  }
+  if (typeof source !== "string" || source.length === 0) {
+    throw new Error('missing or empty "regex" field');
+  }
+  if (category !== "secret" && category !== "pii") {
+    throw new Error(
+      `invalid "category" ${JSON.stringify(category)} (must be "secret" or "pii")`,
+    );
+  }
+  if (flags != null && typeof flags !== "string") {
+    throw new Error('"flags" must be a string');
+  }
+  if (
+    secretGroup != null &&
+    (typeof secretGroup !== "number" ||
+      !Number.isInteger(secretGroup) ||
+      secretGroup < 0)
+  ) {
+    throw new Error('"secretGroup" must be a non-negative integer');
+  }
+  if (
+    entropyThreshold != null &&
+    (typeof entropyThreshold !== "number" || entropyThreshold < 0)
+  ) {
+    throw new Error('"entropyThreshold" must be a non-negative number');
+  }
+  if (validateName != null && typeof validateName !== "string") {
+    throw new Error('"validate" must be a string');
+  }
+  if (contextWords != null) {
+    if (
+      !Array.isArray(contextWords) ||
+      contextWords.some((w) => typeof w !== "string" || w.length === 0)
+    ) {
+      throw new Error('"contextWords" must be an array of non-empty strings');
+    }
+  }
+  if (requireContext != null && typeof requireContext !== "boolean") {
+    throw new Error('"requireContext" must be a boolean');
+  }
+  if (
+    contextWindow != null &&
+    (typeof contextWindow !== "number" ||
+      !Number.isInteger(contextWindow) ||
+      contextWindow < 1)
+  ) {
+    throw new Error('"contextWindow" must be a positive integer');
+  }
+
+  // Cross-field: requireContext is meaningless without contextWords
+  if (
+    requireContext === true &&
+    (!Array.isArray(contextWords) || contextWords.length === 0)
+  ) {
+    throw new Error(
+      '"requireContext" is true but "contextWords" is empty — the rule would never fire',
+    );
+  }
+}
+
 // Compile a single RuleConfig (JSON) into a Rule (with compiled RegExp and
 // resolved validator function). Throws on invalid regex or missing required
 // fields so the caller (buildRules) can catch and warn per-rule.
 export function compileRule(rc: RuleConfig): Rule {
+  validateRuleConfig(rc);
   const { regex: source, flags, validate: validateName, ...rest } = rc;
-  if (typeof source !== "string" || source.length === 0) {
-    throw new Error('missing or empty "regex" field');
-  }
   // matchAll requires the global flag; ensure it is always present.
   const flagStr = flags ?? "g";
   const withG = flagStr.includes("g") ? flagStr : `${flagStr}g`;
@@ -487,8 +571,16 @@ function buildRules(): Rule[] {
 
   const userConfig = loadUserConfig();
   if (userConfig) {
-    if (userConfig.contextWindow != null) {
+    if (
+      typeof userConfig.contextWindow === "number" &&
+      Number.isInteger(userConfig.contextWindow) &&
+      userConfig.contextWindow >= 1
+    ) {
       effectiveContextWindow = userConfig.contextWindow;
+    } else if (userConfig.contextWindow != null) {
+      process.stderr.write(
+        `sensitive-canary: invalid contextWindow in user config, ignoring\n`,
+      );
     }
     if (userConfig.rules?.length) {
       const userRules: Rule[] = [];

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -214,6 +214,86 @@ export function validateSpanishNIF(input: string): boolean {
   return false;
 }
 
+// Korean Resident Registration Number (RRN, 주민등록번호): 13 digits.
+// Checksum is (11 - (weighted sum mod 11)) mod 10 with weights
+// 2,3,4,5,6,7,8,9,2,3,4,5 over the first 12 digits.
+// Note: numbers issued after Oct 2020 randomize digits 8-13, so the checksum
+// may not pass for valid recent numbers (false negatives possible).
+// Spec: 주민등록 사무편람 (Ministry of the Interior and Safety).
+export function validateKoreanRRN(input: string): boolean {
+  const s = input.replace(/[-\s]/g, "");
+  if (!/^\d{13}$/.test(s)) return false;
+  const weights = [2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5];
+  let sum = 0;
+  for (let i = 0; i < 12; i++) {
+    sum += parseInt(s[i] ?? "", 10) * (weights[i] ?? 0);
+  }
+  const check = (11 - (sum % 11)) % 10;
+  return check === parseInt(s[12] ?? "", 10);
+}
+
+// Chinese Resident Identity Card (居民身份证): 18 chars (17 digits + check).
+// ISO 7064 MOD 11-2 per GB 11643-1999. Weights
+// 7,9,10,5,8,4,2,1,6,3,7,9,10,5,8,4,2; remainder maps to "10X98765432".
+export function validateChineseID(input: string): boolean {
+  const s = input.toUpperCase().replace(/[-\s]/g, "");
+  if (!/^\d{17}[\dX]$/.test(s)) return false;
+  const weights = [7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
+  const code = "10X98765432";
+  let sum = 0;
+  for (let i = 0; i < 17; i++) {
+    sum += parseInt(s[i] ?? "", 10) * (weights[i] ?? 0);
+  }
+  return code[sum % 11] === s[17];
+}
+
+// IPv4 reserved / non-public ranges. Returns true for addresses that should
+// NOT be flagged as PII (loopback, private, link-local, TEST-NET, multicast,
+// reserved, CGN, benchmarking). Used by pii-ipv4-public to keep only public IPs.
+export function isReservedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => parseInt(p, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
+  ) {
+    return true;
+  }
+  const a = parts[0] ?? 0;
+  const b = parts[1] ?? 0;
+  const c = parts[2] ?? 0;
+  if (a === 0 || a === 10) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGN 100.64.0.0/10
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 0 && c === 2) return true; // TEST-NET-1
+  if (a === 192 && b === 168) return true; // private
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmark
+  if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true; // TEST-NET-3
+  if (a >= 224) return true; // multicast + reserved
+  return false;
+}
+
+// IPv6 reserved / non-public ranges. Returns true for addresses that should
+// NOT be flagged as PII (loopback, unspecified, link-local, unique-local,
+// multicast, documentation). Used by pii-ipv6.
+export function isReservedIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase().replace(/^:+|:+$/g, "");
+  if (lower === "1" || lower === "") return true; // ::1, ::
+  if (
+    lower.startsWith("fe8") ||
+    lower.startsWith("fe9") ||
+    lower.startsWith("fea") ||
+    lower.startsWith("feb")
+  )
+    return true; // fe80::/10
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7
+  if (lower.startsWith("ff")) return true; // ff00::/8 multicast
+  if (lower.startsWith("2001:db8")) return true; // documentation
+  return false;
+}
+
 // Shannon entropy (bits per character, 0–8 scale)
 export function entropy(str: string): number {
   if (str.length === 0) return 0;
@@ -613,7 +693,7 @@ const PII_RULES: Rule[] = [
   // Japanese postal codes keep their own rule (〒 prefix required).
   {
     id: "pii-postal-code",
-    description: "Postal Code (US ZIP / EU)",
+    description: "Postal Code (US ZIP / EU / KR)",
     regex: /\b\d{5}(?:-\d{4})?\b/g,
     category: "pii",
     requireContext: true,
@@ -627,6 +707,109 @@ const PII_RULES: Rule[] = [
       "cap",
       "código",
       "codigo",
+      "우편번호",
+    ],
+  },
+
+  // ── Korean / Chinese national IDs (checksum-validated) ───────────────────────
+  {
+    id: "pii-rrn-kr",
+    description: "Korean Resident Registration Number",
+    regex: /\b\d{6}[-\s]?\d{7}\b/g,
+    validate: validateKoreanRRN,
+    category: "pii",
+  },
+  {
+    id: "pii-resident-id-cn",
+    description: "Chinese Resident Identity Card",
+    regex: /\b\d{17}[\dXx]\b/g,
+    validate: validateChineseID,
+    category: "pii",
+  },
+
+  // ── Korean / Chinese phone numbers (context-gated) ───────────────────────────
+  {
+    id: "pii-phone-kr",
+    description: "Korean Phone Number",
+    regex: /(?:\+82[-\s]?)?(?:01[016789]|0\d{1,2})[-\s]?\d{3,4}[-\s]?\d{4}/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "전화",
+      "연락처",
+      "핸드폰",
+      "휴대",
+      "tel",
+      "phone",
+      "mobile",
+      "call",
+      "fax",
+    ],
+  },
+  {
+    id: "pii-phone-cn",
+    description: "Chinese Phone Number",
+    regex: /(?:\+86[-\s]?)?(?:1[3-9]\d{9}|0\d{2,3}[-\s]?\d{7,8})/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "电话",
+      "手机",
+      "联系方式",
+      "tel",
+      "phone",
+      "mobile",
+      "call",
+      "fax",
+    ],
+  },
+
+  // ── Chinese postal code (6-digit, context-gated) ─────────────────────────────
+  {
+    id: "pii-postal-cn",
+    description: "Chinese Postal Code",
+    regex: /\b[1-9]\d{5}\b/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: ["邮编", "邮政编码", "postal", "postcode", "zip"],
+  },
+
+  // ── Public IP addresses (context-gated, reserved ranges excluded) ───────────
+  // The existing pii-ipv4 rule keeps private-range detection without context.
+  // These flag public IPs only and require a nearby label, to avoid noise from
+  // example IPs (8.8.8.8) and unrelated dotted numbers.
+  {
+    id: "pii-ipv4-public",
+    description: "Public IPv4 Address",
+    regex: /\b\d{1,3}(?:\.\d{1,3}){3}\b/g,
+    validate: (ip) => !isReservedIpv4(ip),
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "ip",
+      "ipv4",
+      "address",
+      "addr",
+      "host",
+      "server",
+      "endpoint",
+    ],
+  },
+  {
+    id: "pii-ipv6",
+    description: "IPv6 Address",
+    regex: /\b[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{0,4}){2,7}\b/g,
+    validate: (ip) => !isReservedIpv6(ip),
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "ipv6",
+      "ip",
+      "address",
+      "addr",
+      "host",
+      "server",
+      "endpoint",
     ],
   },
 ];

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -233,10 +233,8 @@ export function validateKoreanRRN(input: string): boolean {
 }
 
 // Korean Business Registration Number (사업자등록번호): 10 digits. Uses the
-// standard algorithm employed by Korea's NTS (Hometax) and widely implemented:
-// weights 1,3,7,1,3,7,1,3,5 over digits 1-9, plus floor(digit9 × 5 / 10), and
-// the check digit is (10 - (sum mod 10)) mod 10. Note: the official NTS spec
-// was not directly accessible; this follows the de-facto standard algorithm.
+// NTS (Hometax) standard algorithm: weights 1,3,7,1,3,7,1,3,5 over digits 1-9,
+// plus floor(digit9 × 5 / 10), and the check digit is (10 - (sum mod 10)) mod 10.
 export function validateKoreanBRN(input: string): boolean {
   const s = input.replace(/[-\s]/g, "");
   if (!/^\d{10}$/.test(s)) return false;

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -567,7 +567,16 @@ function buildRules(): Rule[] {
   const defaultConfig = loadDefaultConfig();
   effectiveContextWindow = defaultConfig.contextWindow ?? 3;
 
-  const defaultRules = defaultConfig.rules.map(compileRule);
+  const defaultRules: Rule[] = [];
+  for (const rc of defaultConfig.rules) {
+    try {
+      defaultRules.push(compileRule(rc));
+    } catch (e) {
+      process.stderr.write(
+        `sensitive-canary: failed to compile built-in rule "${rc.id ?? "(unknown)"}": ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+    }
+  }
 
   const userConfig = loadUserConfig();
   if (userConfig) {

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -427,16 +427,29 @@ function readJsonFile(filePath: string): unknown {
 }
 
 // Compile a single RuleConfig (JSON) into a Rule (with compiled RegExp and
-// resolved validator function).
+// resolved validator function). Throws on invalid regex or missing required
+// fields so the caller (buildRules) can catch and warn per-rule.
 export function compileRule(rc: RuleConfig): Rule {
   const { regex: source, flags, validate: validateName, ...rest } = rc;
+  if (typeof source !== "string" || source.length === 0) {
+    throw new Error('missing or empty "regex" field');
+  }
+  // matchAll requires the global flag; ensure it is always present.
+  const flagStr = flags ?? "g";
+  const withG = flagStr.includes("g") ? flagStr : `${flagStr}g`;
   const rule: Rule = {
     ...rest,
-    regex: new RegExp(source, flags ?? "g"),
+    regex: new RegExp(source, withG),
   };
   if (validateName) {
     const fn = VALIDATORS[validateName];
-    if (fn) rule.validate = fn;
+    if (fn) {
+      rule.validate = fn;
+    } else {
+      process.stderr.write(
+        `sensitive-canary: unknown validator "${validateName}" in rule "${rc.id}" — validation disabled\n`,
+      );
+    }
   }
   return rule;
 }
@@ -446,12 +459,18 @@ function loadDefaultConfig(): CanaryConfig {
   return readJsonFile(DEFAULT_CONFIG_PATH) as CanaryConfig;
 }
 
-// Load user config if it exists. Returns null when the file is absent or
-// unreadable so that only built-in defaults are used.
+// Load user config if it exists. Returns null when the file is absent (the
+// common case). JSON parse errors and permission issues are reported on stderr
+// so that a broken config file is not silently ignored.
 function loadUserConfig(): CanaryConfig | null {
   try {
     return readJsonFile(USER_CONFIG_PATH) as CanaryConfig;
-  } catch {
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      process.stderr.write(
+        `sensitive-canary: could not read user config "${USER_CONFIG_PATH}": ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+    }
     return null;
   }
 }
@@ -516,7 +535,7 @@ export function scan(
         entropy(secretValue) < rule.entropyThreshold
       )
         continue;
-      if (rule.validate != null && !rule.validate(match[0])) continue;
+      if (rule.validate != null && !rule.validate(secretValue)) continue;
 
       const matchStart = match.index ?? 0;
       const matchEnd = matchStart + match[0].length;

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -322,19 +322,44 @@ export function isReservedIpv4(ip: string): boolean {
 // IPv6 reserved / non-public ranges. Returns true for addresses that should
 // NOT be flagged as PII (loopback, unspecified, link-local, unique-local,
 // multicast, documentation). Used by pii-ipv6.
+// IPv6 reserved / non-public ranges. Returns true for addresses that should
+// NOT be flagged as PII (loopback, unspecified, link-local, unique-local,
+// multicast, documentation). Properly handles both compressed (::) and
+// fully-expanded (0:0:0:0:0:0:0:1) forms.
 export function isReservedIpv6(ip: string): boolean {
-  const lower = ip.toLowerCase().replace(/^:+|:+$/g, "");
-  if (lower === "1" || lower === "") return true; // ::1, ::
-  if (
-    lower.startsWith("fe8") ||
-    lower.startsWith("fe9") ||
-    lower.startsWith("fea") ||
-    lower.startsWith("feb")
-  )
-    return true; // fe80::/10
-  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7
-  if (lower.startsWith("ff")) return true; // ff00::/8 multicast
-  if (lower.startsWith("2001:db8")) return true; // documentation
+  const lower = ip.toLowerCase();
+
+  // Split and expand :: notation into zero groups.
+  const halves = lower.split("::");
+  let groups: number[];
+  if (halves.length === 1) {
+    groups = lower.split(":").map((g) => Number.parseInt(g || "0", 16));
+  } else {
+    const left = halves[0]
+      ? halves[0].split(":").map((g) => Number.parseInt(g, 16))
+      : [];
+    const right = halves[1]
+      ? halves[1].split(":").map((g) => Number.parseInt(g, 16))
+      : [];
+    const zeros = Array(8 - left.length - right.length).fill(0);
+    groups = [...left, ...zeros, ...right];
+  }
+
+  if (groups.length !== 8) return true; // malformed — treat as reserved
+
+  // Unspecified (::)
+  if (groups.every((g) => g === 0)) return true;
+  // Loopback (::1)
+  if (groups.slice(0, 7).every((g) => g === 0) && groups[7] === 1) return true;
+  // Link-local fe80::/10
+  if ((groups[0] ?? 0) >= 0xfe80 && (groups[0] ?? 0) <= 0xfebf) return true;
+  // Unique-local fc00::/7
+  if (((groups[0] ?? 0) & 0xfe00) === 0xfc00) return true;
+  // Multicast ff00::/8
+  if (((groups[0] ?? 0) & 0xff00) === 0xff00) return true;
+  // Documentation 2001:db8::/32
+  if ((groups[0] ?? 0) === 0x2001 && (groups[1] ?? 0) === 0x0db8) return true;
+
   return false;
 }
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -633,8 +633,20 @@ function buildRules(): Rule[] {
           );
         }
       }
-      const userIds = new Set(userRules.map((r) => r.id));
-      return defaultRules.filter((r) => !userIds.has(r.id)).concat(userRules);
+      // De-duplicate by id (last definition wins) so duplicate ids in the
+      // user config don't produce duplicate rules and duplicate findings.
+      const byId = new Map<string, Rule>();
+      for (const rule of userRules) {
+        if (byId.has(rule.id)) {
+          process.stderr.write(
+            `sensitive-canary: duplicate user rule id "${rule.id}" — using the last definition\n`,
+          );
+        }
+        byId.set(rule.id, rule);
+      }
+      return defaultRules
+        .filter((r) => !byId.has(r.id))
+        .concat(...byId.values());
     }
   }
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -329,8 +329,11 @@ export function isReservedIpv4(ip: string): boolean {
 export function isReservedIpv6(ip: string): boolean {
   const lower = ip.toLowerCase();
 
-  // Split and expand :: notation into zero groups.
+  // Multiple :: is invalid — treat as reserved.
   const halves = lower.split("::");
+  if (halves.length > 2) return true;
+
+  // Split and expand :: notation into zero groups.
   let groups: number[];
   if (halves.length === 1) {
     groups = lower.split(":").map((g) => Number.parseInt(g || "0", 16));
@@ -341,11 +344,14 @@ export function isReservedIpv6(ip: string): boolean {
     const right = halves[1]
       ? halves[1].split(":").map((g) => Number.parseInt(g, 16))
       : [];
+    // Too many groups to fit in 128 bits — malformed.
+    if (left.length + right.length > 8) return true;
     const zeros = Array(8 - left.length - right.length).fill(0);
     groups = [...left, ...zeros, ...right];
   }
 
   if (groups.length !== 8) return true; // malformed — treat as reserved
+  if (groups.some((g) => Number.isNaN(g))) return true; // non-hex groups
 
   // Unspecified (::)
   if (groups.every((g) => g === 0)) return true;

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -325,7 +325,7 @@ export function entropy(str: string): number {
 
 // ── Context enhancement ──────────────────────────────────────────────────────
 
-const DEFAULT_CONTEXT_WINDOW = 10;
+const DEFAULT_CONTEXT_WINDOW = 3;
 
 // Split on whitespace and Unicode punctuation. A cheap tokenizer with no NLP
 // dependency, sufficient for matching context labels (phone, ZIP, etc.) in

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -591,7 +591,7 @@ function buildRules(): Rule[] {
         `sensitive-canary: invalid contextWindow in user config, ignoring\n`,
       );
     }
-    if (userConfig.rules?.length) {
+    if (Array.isArray(userConfig.rules) && userConfig.rules.length) {
       const userRules: Rule[] = [];
       for (const rc of userConfig.rules) {
         try {

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -1,3 +1,8 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 export type Category = "secret" | "pii";
 
 export interface Finding {
@@ -20,6 +25,30 @@ interface Rule {
   contextWords?: string[];
   requireContext?: boolean;
   contextWindow?: number;
+}
+
+// JSON representation of a rule, as written in config files. The `regex` is a
+// source string (not a RegExp literal), compiled at load time. `validate` is a
+// name into the VALIDATORS registry.
+export interface RuleConfig {
+  id: string;
+  description: string;
+  regex: string;
+  flags?: string;
+  secretGroup?: number;
+  entropyThreshold?: number;
+  validate?: string;
+  category: Category;
+  contextWords?: string[];
+  requireContext?: boolean;
+  contextWindow?: number;
+}
+
+// Top-level config file: a context window override plus a list of rules.
+// User config files use the same shape and can override built-in rules by id.
+export interface CanaryConfig {
+  contextWindow?: number;
+  rules: RuleConfig[];
 }
 
 const ALL_CATEGORIES: ReadonlySet<Category> = new Set(["secret", "pii"]);
@@ -325,7 +354,12 @@ export function entropy(str: string): number {
 
 // ── Context enhancement ──────────────────────────────────────────────────────
 
-const DEFAULT_CONTEXT_WINDOW = 3;
+// Set from the default config during module initialisation (see buildRules).
+let effectiveContextWindow = 3;
+
+export function getDefaultContextWindow(): number {
+  return effectiveContextWindow;
+}
 
 // Split on whitespace and Unicode punctuation. A cheap tokenizer with no NLP
 // dependency, sufficient for matching context labels (phone, ZIP, etc.) in
@@ -354,430 +388,109 @@ function hasNearbyContextWord(
   return contextWords.some((word) => nearby.has(word.toLowerCase()));
 }
 
-// Patterns sourced from gitleaks and TruffleHog detector definitions.
-// Each rule:
-//   regex        — must have /g flag
-//   secretGroup  — capture group containing the secret (default: 0 = full match)
-//   entropyThreshold — skip match if entropy(secretValue) is below threshold
+// ── Validator registry ───────────────────────────────────────────────────────
+// Validators are code (checksum algorithms), not data. They live here and are
+// referenced by name from the JSON config. User-defined rules can use any of
+// these validators or omit `validate` entirely.
 
-// ── Secrets ───────────────────────────────────────────────────────────────────
+const VALIDATORS: Readonly<Record<string, (str: string) => boolean>> = {
+  luhn,
+  "mynumber-jp": validateMyNumber,
+  "nir-fr": validateFrenchNIR,
+  "codice-fiscale-it": validateCodiceFiscale,
+  "steuer-id-de": validateGermanIdNr,
+  "dni-nie-es": validateSpanishNIF,
+  "rrn-kr": validateKoreanRRN,
+  "brn-kr": validateKoreanBRN,
+  "resident-id-cn": validateChineseID,
+  "public-ipv4": (ip: string) => !isReservedIpv4(ip),
+  "public-ipv6": (ip: string) => !isReservedIpv6(ip),
+};
 
-const SECRET_RULES: Rule[] = [
-  // Cloud
-  {
-    id: "aws-access-key",
-    description: "AWS Access Key ID",
-    regex:
-      /\b(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}\b/g,
-    category: "secret",
-  },
-  {
-    id: "gcp-api-key",
-    description: "Google Cloud API Key",
-    regex: /AIza[0-9A-Za-z_-]{35}/g,
-    category: "secret",
-  },
-  {
-    id: "private-key",
-    description: "PEM Private Key",
-    // Covers RSA, EC, DSA, PGP, and OpenSSH private keys
-    regex: /-----BEGIN (RSA |EC |DSA |PGP |OPENSSH )?PRIVATE KEY/g,
-    category: "secret",
-  },
+export function getValidator(
+  name: string,
+): ((str: string) => boolean) | undefined {
+  return VALIDATORS[name];
+}
 
-  // Source control
-  {
-    id: "github-pat",
-    description: "GitHub Personal Access Token",
-    regex: /gh[pousr]_[A-Za-z0-9]{36,255}/g,
-    category: "secret",
-  },
-  {
-    id: "github-fine-grained",
-    description: "GitHub Fine-Grained Token",
-    regex: /github_pat_[A-Za-z0-9_]{82}/g,
-    category: "secret",
-  },
-  {
-    id: "gitlab-pat",
-    description: "GitLab Personal Access Token",
-    regex: /glpat-[A-Za-z0-9_=-]{20,22}/g,
-    category: "secret",
-  },
+// ── Config loading ───────────────────────────────────────────────────────────
 
-  // Package registries
-  {
-    id: "npm-token",
-    description: "npm Access Token",
-    regex: /npm_[A-Za-z0-9]{36}/g,
-    category: "secret",
-  },
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONFIG_PATH = join(MODULE_DIR, "default-config.json");
+const { SENSITIVE_CANARY_CONFIG: userConfigPath } = process.env;
+const USER_CONFIG_PATH =
+  userConfigPath ??
+  join(homedir(), ".config", "sensitive-canary", "config.json");
 
-  // Communication
-  {
-    id: "slack-token",
-    description: "Slack Token",
-    regex: /xox[baprs]-[0-9a-zA-Z-]{10,72}/g,
-    category: "secret",
-  },
-  {
-    id: "slack-webhook",
-    description: "Slack Webhook URL",
-    regex:
-      /https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9_]{8,10}\/B[A-Za-z0-9_]{8,12}\/[A-Za-z0-9_]{23,24}/g,
-    category: "secret",
-  },
-  {
-    id: "discord-webhook",
-    description: "Discord Webhook URL",
-    regex:
-      /https:\/\/discord(?:app)?\.com\/api\/webhooks\/[0-9]{17,20}\/[A-Za-z0-9_-]{68}/g,
-    category: "secret",
-  },
-  {
-    id: "telegram-bot-token",
-    description: "Telegram Bot Token",
-    regex: /[0-9]{8,10}:AA[0-9A-Za-z_-]{33}/g,
-    category: "secret",
-  },
-  {
-    id: "twilio-sid",
-    description: "Twilio Account SID",
-    regex: /AC[0-9a-f]{32}/g,
-    category: "secret",
-  },
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
 
-  // Email services
-  {
-    id: "sendgrid-key",
-    description: "SendGrid API Key",
-    regex: /SG\.[A-Za-z0-9_-]{20,24}\.[A-Za-z0-9_-]{39,50}/g,
-    category: "secret",
-  },
-  {
-    id: "mailgun-key",
-    description: "Mailgun API Key",
-    regex: /key-[0-9a-zA-Z]{32}/g,
-    category: "secret",
-  },
-  {
-    id: "mailchimp-key",
-    description: "Mailchimp API Key",
-    regex: /[0-9a-f]{32}-us[0-9]{1,2}/g,
-    category: "secret",
-  },
+// Compile a single RuleConfig (JSON) into a Rule (with compiled RegExp and
+// resolved validator function).
+export function compileRule(rc: RuleConfig): Rule {
+  const { regex: source, flags, validate: validateName, ...rest } = rc;
+  const rule: Rule = {
+    ...rest,
+    regex: new RegExp(source, flags ?? "g"),
+  };
+  if (validateName) {
+    const fn = VALIDATORS[validateName];
+    if (fn) rule.validate = fn;
+  }
+  return rule;
+}
 
-  // Payment
-  {
-    id: "stripe-secret-key",
-    description: "Stripe Secret Key",
-    regex: /sk_(live|test)_[0-9a-zA-Z]{24}/g,
-    category: "secret",
-  },
-  {
-    id: "stripe-restricted-key",
-    description: "Stripe Restricted Key",
-    regex: /rk_(live|test)_[0-9a-zA-Z]{24}/g,
-    category: "secret",
-  },
+// Load and compile the built-in default rules from default-config.json.
+function loadDefaultConfig(): CanaryConfig {
+  return readJsonFile(DEFAULT_CONFIG_PATH) as CanaryConfig;
+}
 
-  // AI services
-  {
-    id: "openai-key",
-    description: "OpenAI API Key (legacy)",
-    regex: /sk-(?!proj-|ant-)[A-Za-z0-9]{48}/g,
-    category: "secret",
-  },
-  {
-    id: "openai-project-key",
-    description: "OpenAI Project API Key",
-    regex: /sk-proj-[A-Za-z0-9_-]{40,}/g,
-    entropyThreshold: 3.5,
-    category: "secret",
-  },
-  {
-    id: "anthropic-key",
-    description: "Anthropic API Key",
-    regex: /sk-ant-[A-Za-z0-9_-]{95}/g,
-    category: "secret",
-  },
+// Load user config if it exists. Returns null when the file is absent or
+// unreadable so that only built-in defaults are used.
+function loadUserConfig(): CanaryConfig | null {
+  try {
+    return readJsonFile(USER_CONFIG_PATH) as CanaryConfig;
+  } catch {
+    return null;
+  }
+}
 
-  // Auth tokens
-  {
-    id: "jwt",
-    description: "JSON Web Token (JWT)",
-    regex: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
-    category: "secret",
-  },
+// Build the final rule list: default rules first, then user rules. A user rule
+// with the same id as a built-in rule replaces it; new ids are appended.
+// Invalid user rules (bad regex, etc.) are skipped with a warning so that one
+// bad entry does not break the entire hook.
+function buildRules(): Rule[] {
+  const defaultConfig = loadDefaultConfig();
+  effectiveContextWindow = defaultConfig.contextWindow ?? 3;
 
-  // Generic / env-based
-  {
-    id: "generic-secret",
-    description: "Generic API Key / Secret",
-    regex:
-      /(api[_-]?key|secret[_-]?key|access[_-]?token|api[_-]?secret)\s*[:=]\s*['"]?([A-Za-z0-9\-_.]{20,})/gi,
-    secretGroup: 2,
-    entropyThreshold: 3.5,
-    category: "secret",
-  },
-  {
-    id: "env-assignment",
-    description: ".env style secret assignment",
-    regex:
-      /\b[A-Z_]*(SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|PRIVATE_KEY)[A-Z_0-9]*\s*=\s*(\S{8,})/g,
-    secretGroup: 2,
-    entropyThreshold: 3.0,
-    category: "secret",
-  },
-  {
-    id: "connection-string",
-    description: "Database Connection String with credentials",
-    regex: /(mongodb|mysql|postgres|postgresql|redis):\/\/[^:\s]+:[^@\s]+@/g,
-    category: "secret",
-  },
-];
+  const defaultRules = defaultConfig.rules.map(compileRule);
 
-// ── PII ───────────────────────────────────────────────────────────────────────
+  const userConfig = loadUserConfig();
+  if (userConfig) {
+    if (userConfig.contextWindow != null) {
+      effectiveContextWindow = userConfig.contextWindow;
+    }
+    if (userConfig.rules?.length) {
+      const userRules: Rule[] = [];
+      for (const rc of userConfig.rules) {
+        try {
+          userRules.push(compileRule(rc));
+        } catch (e) {
+          process.stderr.write(
+            `sensitive-canary: skipping user rule "${rc.id ?? "(unknown)"}": ${e instanceof Error ? e.message : String(e)}\n`,
+          );
+        }
+      }
+      const userIds = new Set(userRules.map((r) => r.id));
+      return defaultRules.filter((r) => !userIds.has(r.id)).concat(userRules);
+    }
+  }
 
-const PII_RULES: Rule[] = [
-  {
-    id: "pii-email",
-    description: "Email Address",
-    regex: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
-    category: "pii",
-  },
-  {
-    id: "pii-credit-card",
-    description: "Credit Card Number",
-    // Visa (16d) | Mastercard (16d) | Amex (15d) | Discover (16d)
-    // Optional spaces or dashes between digit groups
-    regex:
-      /\b(?:4[0-9]{3}(?:[\s-]?[0-9]{4}){3}|5[1-5][0-9]{2}(?:[\s-]?[0-9]{4}){3}|3[47][0-9]{2}[\s-]?[0-9]{6}[\s-]?[0-9]{5}|6(?:011|5[0-9]{2})[0-9](?:[\s-]?[0-9]{4}){3})\b/g,
-    validate: luhn,
-    category: "pii",
-  },
-  {
-    id: "pii-ssn",
-    description: "US Social Security Number",
-    regex: /\b(?!000|666|9\d{2})\d{3}[- ](?!00)\d{2}[- ](?!0000)\d{4}\b/g,
-    category: "pii",
-  },
-  {
-    id: "pii-phone-us",
-    description: "US Phone Number",
-    regex: /\b(\+1[\s.-]?)?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}\b/g,
-    category: "pii",
-  },
-  {
-    id: "pii-phone-jp",
-    description: "Japanese Phone Number",
-    regex: /\b0\d{1,4}[\s-]\d{1,4}[\s-]\d{4}\b/g,
-    category: "pii",
-  },
-  {
-    id: "pii-postal-jp",
-    description: "Japanese Postal Code",
-    // Require 〒 prefix to avoid false positives (e.g. phone number fragments)
-    regex: /〒\d{3}[\s-]\d{4}/g,
-    category: "pii",
-  },
-  {
-    id: "pii-ipv4",
-    description: "IPv4 Address (private range)",
-    // Only flag RFC-1918 private addresses to reduce noise
-    regex:
-      /\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g,
-    category: "pii",
-  },
+  return defaultRules;
+}
 
-  // ── National ID numbers (checksum-validated) ────────────────────────────────
-  {
-    id: "pii-mynumber-jp",
-    description: "Japanese Individual Number (My Number)",
-    regex: /\b\d{12}\b/g,
-    validate: validateMyNumber,
-    category: "pii",
-  },
-  {
-    id: "pii-nir-fr",
-    description: "French NIR / Social Security Number",
-    regex:
-      /\b[12]\d{2}(?:0[1-9]|1[0-9]|2[0-9]|[3-9]\d)(?:\d{5}|2[AB]\d{3})\d{3}\s?\d{2}\b/gi,
-    validate: validateFrenchNIR,
-    category: "pii",
-  },
-  {
-    id: "pii-codice-fiscale-it",
-    description: "Italian Codice Fiscale",
-    regex: /\b[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]\b/g,
-    validate: validateCodiceFiscale,
-    category: "pii",
-  },
-  {
-    id: "pii-steuer-id-de",
-    description: "German Steuer-Identifikationsnummer",
-    regex: /\b[1-9]\d{10}\b/g,
-    validate: validateGermanIdNr,
-    category: "pii",
-  },
-  {
-    id: "pii-dni-nie-es",
-    description: "Spanish DNI / NIE",
-    regex: /\b(?:\d{8}[A-Z]|[XYZ]\d{7}[A-Z])\b/g,
-    validate: validateSpanishNIF,
-    category: "pii",
-  },
-
-  // ── Phone numbers (FIGS) ─────────────────────────────────────────────────────
-  // Variable-length Italian and German numbers are noisy on bare digits, so
-  // these require a nearby phone-related context word.
-  {
-    id: "pii-phone-fr",
-    description: "French Phone Number",
-    regex: /\b0[1-9](?:[\s.-]?\d{2}){4}\b/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: [
-      "tél",
-      "tel",
-      "téléphone",
-      "telephone",
-      "phone",
-      "mobile",
-      "portable",
-      "fax",
-    ],
-  },
-  {
-    id: "pii-phone-it",
-    description: "Italian Phone Number",
-    regex: /\b(?:0\d{8,9}|3\d{8,9})\b/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: ["telefono", "tel", "cellulare", "mobile", "phone", "fax"],
-  },
-  {
-    id: "pii-phone-de",
-    description: "German Phone Number",
-    regex: /\b0[1-9]\d{6,11}\b/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: ["telefon", "tel", "handy", "mobil", "phone", "fax"],
-  },
-  {
-    id: "pii-phone-es",
-    description: "Spanish Phone Number",
-    regex: /\b[67]\d{8}\b/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: [
-      "teléfono",
-      "telefono",
-      "tel",
-      "móvil",
-      "movil",
-      "phone",
-      "fax",
-    ],
-  },
-
-  // ── Postal codes (5/9-digit, context-gated) ─────────────────────────────────
-  // Bare 5/9-digit numbers are too generic to flag without a nearby label.
-  // Japanese postal codes keep their own rule (〒 prefix required).
-  {
-    id: "pii-postal-code",
-    description: "Postal Code (US ZIP / EU / KR)",
-    regex: /\b\d{5}(?:-\d{4})?\b/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: [
-      "zip",
-      "postal",
-      "postale",
-      "postcode",
-      "plz",
-      "postleitzahl",
-      "cap",
-      "우편번호",
-    ],
-  },
-
-  // ── Korean / Chinese national IDs (checksum-validated) ───────────────────────
-  {
-    id: "pii-rrn-kr",
-    description: "Korean Resident Registration Number",
-    regex: /\b\d{6}[-\s]?\d{7}\b/g,
-    validate: validateKoreanRRN,
-    category: "pii",
-  },
-  {
-    id: "pii-brn-kr",
-    description: "Korean Business Registration Number",
-    regex: /\b\d{3}[-\s]?\d{2}[-\s]?\d{5}\b/g,
-    validate: validateKoreanBRN,
-    category: "pii",
-  },
-  {
-    id: "pii-resident-id-cn",
-    description: "Chinese Resident Identity Card",
-    regex: /\b\d{17}[\dXx]\b/g,
-    validate: validateChineseID,
-    category: "pii",
-  },
-
-  // ── Korean / Chinese phone numbers (context-gated) ───────────────────────────
-  {
-    id: "pii-phone-kr",
-    description: "Korean Phone Number",
-    regex: /(?:\+82[-\s]?)?(?:01[016789]|0\d{1,2})[-\s]?\d{3,4}[-\s]?\d{4}/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: ["전화", "핸드폰", "휴대", "tel", "phone", "mobile", "fax"],
-  },
-  {
-    id: "pii-phone-cn",
-    description: "Chinese Phone Number",
-    regex: /(?:\+86[-\s]?)?(?:1[3-9]\d{9}|0\d{2,3}[-\s]?\d{7,8})/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: ["电话", "手机", "tel", "phone", "mobile", "fax"],
-  },
-
-  // ── Chinese postal code (6-digit, context-gated) ─────────────────────────────
-  {
-    id: "pii-postal-cn",
-    description: "Chinese Postal Code",
-    regex: /\b[1-9]\d{5}\b/g,
-    category: "pii",
-    requireContext: true,
-    contextWords: ["邮编", "邮政编码", "postal", "postcode", "zip"],
-  },
-
-  // ── Public IP addresses (context-gated, reserved ranges excluded) ───────────
-  // The existing pii-ipv4 rule keeps private-range detection without context.
-  // These flag public IPs only and require a nearby label, to avoid noise from
-  // example IPs (8.8.8.8) and unrelated dotted numbers.
-  {
-    id: "pii-ipv4-public",
-    description: "Public IPv4 Address",
-    regex: /\b\d{1,3}(?:\.\d{1,3}){3}\b/g,
-    validate: (ip) => !isReservedIpv4(ip),
-    category: "pii",
-    requireContext: true,
-    contextWords: ["ip", "ipv4"],
-  },
-  {
-    id: "pii-ipv6",
-    description: "IPv6 Address",
-    regex: /\b[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{0,4}){2,7}\b/g,
-    validate: (ip) => !isReservedIpv6(ip),
-    category: "pii",
-    requireContext: true,
-    contextWords: ["ipv6", "ip"],
-  },
-];
-
-export const RULES: Rule[] = [...SECRET_RULES, ...PII_RULES];
+export const RULES: Rule[] = buildRules();
 
 // Show first 4 + **** + last 4 chars; fully mask strings of 8 chars or fewer
 export function redact(str: string): string {
@@ -815,7 +528,7 @@ export function scan(
               matchStart,
               matchEnd,
               rule.contextWords,
-              rule.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+              rule.contextWindow ?? effectiveContextWindow,
             );
 
       // Rules that require context (e.g. bare postal codes) are dropped when

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -11,7 +11,7 @@ export interface Finding {
   category: Category;
   matchRedacted: string;
   secretValue: string;
-  score: number;
+  score?: number;
 }
 
 interface Rule {

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -77,6 +77,7 @@ export function enabledCategoriesFromEnv(): Set<Category> {
 // Luhn algorithm checksum validation. Returns true if the number (digits only) passes.
 export function luhn(str: string): boolean {
   const digits = str.replace(/\D/g, "");
+  if (digits.length === 0) return false;
   let sum = 0;
   let double = false;
   for (let i = digits.length - 1; i >= 0; i--) {
@@ -295,11 +296,14 @@ export function validateChineseID(input: string): boolean {
 // NOT be flagged as PII (loopback, private, link-local, TEST-NET, multicast,
 // reserved, CGN, benchmarking). Used by pii-ipv4-public to keep only public IPs.
 export function isReservedIpv4(ip: string): boolean {
-  const parts = ip.split(".").map((p) => parseInt(p, 10));
-  if (
-    parts.length !== 4 ||
-    parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
-  ) {
+  const octets = ip.split(".");
+  // Require exactly 4 octets of 1–3 digits each, so partial parses
+  // (e.g. "1a" → 1 via parseInt) are treated as malformed, not public.
+  if (octets.length !== 4 || octets.some((o) => !/^\d{1,3}$/.test(o))) {
+    return true;
+  }
+  const parts = octets.map((o) => parseInt(o, 10));
+  if (parts.some((p) => p > 255)) {
     return true;
   }
   const a = parts[0] ?? 0;
@@ -310,7 +314,9 @@ export function isReservedIpv4(ip: string): boolean {
   if (a === 127) return true; // loopback
   if (a === 169 && b === 254) return true; // link-local
   if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 0 && c === 0) return true; // IETF protocol assignments
   if (a === 192 && b === 0 && c === 2) return true; // TEST-NET-1
+  if (a === 192 && b === 88 && c === 99) return true; // 6to4 relay anycast (deprecated)
   if (a === 192 && b === 168) return true; // private
   if (a === 198 && (b === 18 || b === 19)) return true; // benchmark
   if (a === 198 && b === 51 && c === 100) return true; // TEST-NET-2
@@ -321,11 +327,10 @@ export function isReservedIpv4(ip: string): boolean {
 
 // IPv6 reserved / non-public ranges. Returns true for addresses that should
 // NOT be flagged as PII (loopback, unspecified, link-local, unique-local,
-// multicast, documentation). Used by pii-ipv6.
-// IPv6 reserved / non-public ranges. Returns true for addresses that should
-// NOT be flagged as PII (loopback, unspecified, link-local, unique-local,
 // multicast, documentation). Properly handles both compressed (::) and
-// fully-expanded (0:0:0:0:0:0:0:1) forms.
+// fully-expanded (0:0:0:0:0:0:0:1) forms. Used by pii-ipv6.
+// Each group must be 1–4 hex digits; anything else is malformed.
+const isHexGroup = (g: string): boolean => /^[0-9a-f]{1,4}$/.test(g);
 export function isReservedIpv6(ip: string): boolean {
   const lower = ip.toLowerCase();
 
@@ -336,22 +341,28 @@ export function isReservedIpv6(ip: string): boolean {
   // Split and expand :: notation into zero groups.
   let groups: number[];
   if (halves.length === 1) {
-    groups = lower.split(":").map((g) => Number.parseInt(g || "0", 16));
+    const raw = lower.split(":");
+    if (raw.some((g) => !isHexGroup(g))) return true;
+    groups = raw.map((g) => Number.parseInt(g, 16));
   } else {
-    const left = halves[0]
-      ? halves[0].split(":").map((g) => Number.parseInt(g, 16))
-      : [];
-    const right = halves[1]
-      ? halves[1].split(":").map((g) => Number.parseInt(g, 16))
-      : [];
-    // Too many groups to fit in 128 bits — malformed.
-    if (left.length + right.length > 8) return true;
+    const leftRaw = halves[0] ? halves[0].split(":") : [];
+    const rightRaw = halves[1] ? halves[1].split(":") : [];
+    if (
+      leftRaw.some((g) => !isHexGroup(g)) ||
+      rightRaw.some((g) => !isHexGroup(g))
+    ) {
+      return true;
+    }
+    // Too many groups to fit in 128 bits — malformed. A "::" that compresses
+    // zero groups (left + right === 8) is also invalid per RFC 4291 §2.2.
+    if (leftRaw.length + rightRaw.length >= 8) return true;
+    const left = leftRaw.map((g) => Number.parseInt(g, 16));
+    const right = rightRaw.map((g) => Number.parseInt(g, 16));
     const zeros = Array(8 - left.length - right.length).fill(0);
     groups = [...left, ...zeros, ...right];
   }
 
   if (groups.length !== 8) return true; // malformed — treat as reserved
-  if (groups.some((g) => Number.isNaN(g))) return true; // non-hex groups
 
   // Unspecified (::)
   if (groups.every((g) => g === 0)) return true;
@@ -369,7 +380,7 @@ export function isReservedIpv6(ip: string): boolean {
   return false;
 }
 
-// Shannon entropy (bits per character, 0–8 scale)
+// Shannon entropy (bits per character; ≈0–8 for byte-sized alphabets)
 export function entropy(str: string): number {
   if (str.length === 0) return 0;
   const freq: Record<string, number> = {};
@@ -604,7 +615,7 @@ function buildRules(): Rule[] {
       defaultRules.push(compileRule(rc));
     } catch (e) {
       process.stderr.write(
-        `sensitive-canary: failed to compile built-in rule "${rc.id ?? "(unknown)"}": ${e instanceof Error ? e.message : String(e)}\n`,
+        `sensitive-canary: failed to compile built-in rule "${(rc as { id?: unknown })?.id ?? "(unknown)"}": ${e instanceof Error ? e.message : String(e)}\n`,
       );
     }
   }
@@ -622,6 +633,11 @@ function buildRules(): Rule[] {
         `sensitive-canary: invalid contextWindow in user config, ignoring\n`,
       );
     }
+    if (userConfig.rules != null && !Array.isArray(userConfig.rules)) {
+      process.stderr.write(
+        `sensitive-canary: "rules" in user config must be an array, ignoring\n`,
+      );
+    }
     if (Array.isArray(userConfig.rules) && userConfig.rules.length) {
       const userRules: Rule[] = [];
       for (const rc of userConfig.rules) {
@@ -629,7 +645,7 @@ function buildRules(): Rule[] {
           userRules.push(compileRule(rc));
         } catch (e) {
           process.stderr.write(
-            `sensitive-canary: skipping user rule "${rc.id ?? "(unknown)"}": ${e instanceof Error ? e.message : String(e)}\n`,
+            `sensitive-canary: skipping user rule "${(rc as { id?: unknown })?.id ?? "(unknown)"}": ${e instanceof Error ? e.message : String(e)}\n`,
           );
         }
       }

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -95,8 +95,8 @@ export function luhn(str: string): boolean {
 
 // Japanese Individual Number (My Number): 12 digits, weighted checksum over the
 // first 11 digits with weights 6,5,4,3,2,7,6,5,4,3,2. The 12th digit is
-// 11 - (sum mod 11); a remainder of 0 or 1 is an invalid number.
-// Spec: 地方公共団体情報システム機構 (JIPTEC).
+// 11 - (sum mod 11); when the remainder is 0 or 1, the check digit is 0.
+// Spec: 地方公共団体情報システム機構 (J-LIS).
 export function validateMyNumber(input: string): boolean {
   const digits = input.replace(/\D/g, "");
   if (digits.length !== 12) return false;
@@ -106,8 +106,8 @@ export function validateMyNumber(input: string): boolean {
     sum += parseInt(digits[i] ?? "", 10) * (weights[i] ?? 0);
   }
   const remainder = sum % 11;
-  if (remainder <= 1) return false;
-  return 11 - remainder === parseInt(digits[11] ?? "", 10);
+  const checkDigit = remainder <= 1 ? 0 : 11 - remainder;
+  return checkDigit === parseInt(digits[11] ?? "", 10);
 }
 
 // French NIR (Numéro de sécurité sociale / INSEE): 15 digits, 2-digit check key

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -6,6 +6,7 @@ export interface Finding {
   category: Category;
   matchRedacted: string;
   secretValue: string;
+  score: number;
 }
 
 interface Rule {
@@ -16,6 +17,9 @@ interface Rule {
   entropyThreshold?: number;
   validate?: (str: string) => boolean;
   category: Category;
+  contextWords?: string[];
+  requireContext?: boolean;
+  contextWindow?: number;
 }
 
 const ALL_CATEGORIES: ReadonlySet<Category> = new Set(["secret", "pii"]);
@@ -58,6 +62,158 @@ export function luhn(str: string): boolean {
   return sum % 10 === 0;
 }
 
+// ── National ID checksum validators ──────────────────────────────────────────
+
+// Japanese Individual Number (My Number): 12 digits, weighted checksum over the
+// first 11 digits with weights 6,5,4,3,2,7,6,5,4,3,2. The 12th digit is
+// 11 - (sum mod 11); a remainder of 0 or 1 is an invalid number.
+// Spec: 地方公共団体情報システム機構 (JIPTEC).
+export function validateMyNumber(input: string): boolean {
+  const digits = input.replace(/\D/g, "");
+  if (digits.length !== 12) return false;
+  const weights = [6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2];
+  let sum = 0;
+  for (let i = 0; i < 11; i++) {
+    sum += parseInt(digits[i] ?? "", 10) * (weights[i] ?? 0);
+  }
+  const remainder = sum % 11;
+  if (remainder <= 1) return false;
+  return 11 - remainder === parseInt(digits[11] ?? "", 10);
+}
+
+// French NIR (Numéro de sécurité sociale / INSEE): 15 digits, 2-digit check key
+// computed as 97 - (N mod 97) over the leading 13 digits. Corsica departements
+// use 2A/2B, substituted to 19/18 before the mod. The 13-digit value can exceed
+// Number.MAX_SAFE_INTEGER, so BigInt is used. Spec: INSEE / décret n°82-103.
+export function validateFrenchNIR(input: string): boolean {
+  const cleaned = input.replace(/\s/g, "");
+  let nir13: string;
+  let keyStr: string;
+
+  const standard = cleaned.match(/^([12]\d{12})(\d{2})$/);
+  const corseA = cleaned.match(/^([12]\d{4}2A\d{6})(\d{2})$/i);
+  const corseB = cleaned.match(/^([12]\d{4}2B\d{6})(\d{2})$/i);
+
+  if (standard) {
+    nir13 = standard[1] ?? "";
+    keyStr = standard[2] ?? "";
+  } else if (corseA) {
+    nir13 = (corseA[1] ?? "").replace(/2A/i, "19");
+    keyStr = corseA[2] ?? "";
+  } else if (corseB) {
+    nir13 = (corseB[1] ?? "").replace(/2B/i, "18");
+    keyStr = corseB[2] ?? "";
+  } else {
+    return false;
+  }
+
+  const num = BigInt(nir13);
+  const computedKey = 97 - Number(num % 97n);
+  return computedKey === parseInt(keyStr, 10);
+}
+
+// Italian Codice Fiscale: 16 alphanumeric chars. The last char is a control
+// character computed by summing odd/even position values (different maps) mod 26.
+// Spec: Agenzia delle Entrate, DM 12 giugno 2007.
+const CF_ODD_VALUES: Record<string, number> = {
+  "0": 1,
+  "1": 0,
+  "2": 5,
+  "3": 7,
+  "4": 9,
+  "5": 13,
+  "6": 15,
+  "7": 17,
+  "8": 19,
+  "9": 21,
+  A: 1,
+  B: 0,
+  C: 5,
+  D: 7,
+  E: 9,
+  F: 13,
+  G: 15,
+  H: 17,
+  I: 19,
+  J: 21,
+  K: 2,
+  L: 4,
+  M: 18,
+  N: 20,
+  O: 11,
+  P: 3,
+  Q: 6,
+  R: 8,
+  S: 12,
+  T: 14,
+  U: 16,
+  V: 10,
+  W: 22,
+  X: 25,
+  Y: 24,
+  Z: 23,
+};
+
+export function validateCodiceFiscale(input: string): boolean {
+  const cf = input.toUpperCase().replace(/\s/g, "");
+  if (!/^[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]$/.test(cf)) return false;
+
+  let sum = 0;
+  for (let i = 0; i < 15; i++) {
+    const ch = cf[i] ?? "";
+    if (i % 2 === 0) {
+      sum += CF_ODD_VALUES[ch] ?? -1;
+    } else if (/[0-9]/.test(ch)) {
+      sum += parseInt(ch, 10);
+    } else {
+      sum += ch.charCodeAt(0) - 65;
+    }
+  }
+  const expected = String.fromCharCode(65 + (sum % 26));
+  return expected === cf[15];
+}
+
+// German Steuer-Identifikationsnummer (IdNr.): 11 digits, first digit non-zero.
+// Uses ISO/IEC 7064 MOD 11,10. Spec: Bundeszentralamt für Steuern.
+export function validateGermanIdNr(input: string): boolean {
+  const cleaned = input.replace(/\s/g, "");
+  if (!/^[1-9]\d{10}$/.test(cleaned)) return false;
+
+  let produkt = 10;
+  for (let i = 0; i < 10; i++) {
+    let summe = (parseInt(cleaned[i] ?? "", 10) + produkt) % 10;
+    if (summe === 0) summe = 10;
+    produkt = (summe * 2) % 11;
+  }
+  let check = 11 - produkt;
+  if (check === 10) check = 0;
+  return check === parseInt(cleaned[10] ?? "", 10);
+}
+
+// Spanish DNI (8 digits + letter) and NIE (X/Y/Z + 7 digits + letter). The
+// control letter is selected from TRWAGMYFPDXBNJZSQVHLCKE by the number mod 23.
+// NIE leading letters map X→0, Y→1, Z→2 before the mod.
+// Spec: Ministerio del Interior, Orden INT/2058/2008.
+const NIF_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE";
+
+export function validateSpanishNIF(input: string): boolean {
+  const cleaned = input.toUpperCase().replace(/[\s-]/g, "");
+
+  const dni = cleaned.match(/^(\d{8})([A-Z])$/);
+  if (dni) {
+    return NIF_LETTERS[parseInt(dni[1] ?? "", 10) % 23] === dni[2];
+  }
+
+  const nie = cleaned.match(/^([XYZ])(\d{7})([A-Z])$/);
+  if (nie) {
+    const prefix = nie[1] === "X" ? "0" : nie[1] === "Y" ? "1" : "2";
+    const num = parseInt(prefix + (nie[2] ?? ""), 10);
+    return NIF_LETTERS[num % 23] === nie[3];
+  }
+
+  return false;
+}
+
 // Shannon entropy (bits per character, 0–8 scale)
 export function entropy(str: string): number {
   if (str.length === 0) return 0;
@@ -70,6 +226,37 @@ export function entropy(str: string): number {
     h -= p * Math.log2(p);
   }
   return h;
+}
+
+// ── Context enhancement ──────────────────────────────────────────────────────
+
+const DEFAULT_CONTEXT_WINDOW = 10;
+
+// Split on whitespace and Unicode punctuation. A cheap tokenizer with no NLP
+// dependency, sufficient for matching context labels (phone, ZIP, etc.) in
+// Latin-script text. Japanese PII rules rely on prefixes (〒) or required
+// separators rather than context words, so this tokenizer not needing to
+// handle Japanese word segmentation is acceptable.
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s\p{P}]+/u)
+    .filter(Boolean);
+}
+
+function hasNearbyContextWord(
+  text: string,
+  matchStart: number,
+  matchEnd: number,
+  contextWords: string[],
+  windowTokens: number,
+): boolean {
+  if (contextWords.length === 0) return true;
+  const charWindow = windowTokens * 8;
+  const before = text.slice(Math.max(0, matchStart - charWindow), matchStart);
+  const after = text.slice(matchEnd, matchEnd + charWindow);
+  const nearby = new Set(tokenize(`${before} ${after}`));
+  return contextWords.some((word) => nearby.has(word.toLowerCase()));
 }
 
 // Patterns sourced from gitleaks and TruffleHog detector definitions.
@@ -307,6 +494,141 @@ const PII_RULES: Rule[] = [
       /\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g,
     category: "pii",
   },
+
+  // ── National ID numbers (checksum-validated) ────────────────────────────────
+  {
+    id: "pii-mynumber-jp",
+    description: "Japanese Individual Number (My Number)",
+    regex: /\b\d{12}\b/g,
+    validate: validateMyNumber,
+    category: "pii",
+  },
+  {
+    id: "pii-nir-fr",
+    description: "French NIR / Social Security Number",
+    regex:
+      /\b[12]\d{2}(?:0[1-9]|1[0-9]|2[0-9]|[3-9]\d)(?:\d{5}|2[AB]\d{3})\d{3}\s?\d{2}\b/gi,
+    validate: validateFrenchNIR,
+    category: "pii",
+  },
+  {
+    id: "pii-codice-fiscale-it",
+    description: "Italian Codice Fiscale",
+    regex: /\b[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]\b/g,
+    validate: validateCodiceFiscale,
+    category: "pii",
+  },
+  {
+    id: "pii-steuer-id-de",
+    description: "German Steuer-Identifikationsnummer",
+    regex: /\b[1-9]\d{10}\b/g,
+    validate: validateGermanIdNr,
+    category: "pii",
+  },
+  {
+    id: "pii-dni-nie-es",
+    description: "Spanish DNI / NIE",
+    regex: /\b(?:\d{8}[A-Z]|[XYZ]\d{7}[A-Z])\b/g,
+    validate: validateSpanishNIF,
+    category: "pii",
+  },
+
+  // ── Phone numbers (FIGS) ─────────────────────────────────────────────────────
+  // Variable-length Italian and German numbers are noisy on bare digits, so
+  // these require a nearby phone-related context word.
+  {
+    id: "pii-phone-fr",
+    description: "French Phone Number",
+    regex: /\b0[1-9](?:[\s.-]?\d{2}){4}\b/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "tél",
+      "tel",
+      "téléphone",
+      "telephone",
+      "phone",
+      "mobile",
+      "portable",
+      "contact",
+      "appel",
+      "fax",
+    ],
+  },
+  {
+    id: "pii-phone-it",
+    description: "Italian Phone Number",
+    regex: /\b(?:0\d{8,9}|3\d{8,9})\b/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "telefono",
+      "tel",
+      "cellulare",
+      "mobile",
+      "phone",
+      "contatto",
+      "chiamata",
+      "fax",
+    ],
+  },
+  {
+    id: "pii-phone-de",
+    description: "German Phone Number",
+    regex: /\b0[1-9]\d{6,11}\b/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "telefon",
+      "tel",
+      "handy",
+      "mobil",
+      "phone",
+      "anruf",
+      "nummer",
+      "fax",
+    ],
+  },
+  {
+    id: "pii-phone-es",
+    description: "Spanish Phone Number",
+    regex: /\b[67]\d{8}\b/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "teléfono",
+      "telefono",
+      "tel",
+      "móvil",
+      "movil",
+      "phone",
+      "contacto",
+      "llamada",
+      "fax",
+    ],
+  },
+
+  // ── Postal codes (5/9-digit, context-gated) ─────────────────────────────────
+  // Bare 5/9-digit numbers are too generic to flag without a nearby label.
+  // Japanese postal codes keep their own rule (〒 prefix required).
+  {
+    id: "pii-postal-code",
+    description: "Postal Code (US ZIP / EU)",
+    regex: /\b\d{5}(?:-\d{4})?\b/g,
+    category: "pii",
+    requireContext: true,
+    contextWords: [
+      "zip",
+      "postal",
+      "postale",
+      "postcode",
+      "plz",
+      "postleitzahl",
+      "cap",
+      "código",
+      "codigo",
+    ],
+  },
 ];
 
 export const RULES: Rule[] = [...SECRET_RULES, ...PII_RULES];
@@ -337,12 +659,30 @@ export function scan(
         continue;
       if (rule.validate != null && !rule.validate(match[0])) continue;
 
+      const matchStart = match.index ?? 0;
+      const matchEnd = matchStart + match[0].length;
+      const hasContext =
+        !rule.contextWords || rule.contextWords.length === 0
+          ? true
+          : hasNearbyContextWord(
+              text,
+              matchStart,
+              matchEnd,
+              rule.contextWords,
+              rule.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+            );
+
+      // Rules that require context (e.g. bare postal codes) are dropped when
+      // no context label is nearby, to avoid flagging every 5-digit number.
+      if (rule.requireContext && !hasContext) continue;
+
       findings.push({
         ruleId: rule.id,
         description: rule.description,
         category: rule.category,
         matchRedacted: redact(secretValue),
         secretValue,
+        score: hasContext ? 1.0 : 0.4,
       });
     }
   }


### PR DESCRIPTION
Promote develop to main for v0.7.0.

## Highlights

- Multi-region PII detection rules (25 PII rules, up from 7): national IDs with checksum validation (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE, KR RRN/BRN, CN Resident Identity Card), phone numbers and postal codes for 8 regions, public IPv4/IPv6 detection
- Context gating (`requireContext`) to reduce false positives on bare digit sequences
- Rule definitions moved to JSON (`src/lib/default-config.json`) with user-defined custom rules via config file
- Secret detection coverage expanded (39 secret rules, up from 24)
- Fixes: My Number checksum edge case, strict schema validation for user rules, IPv6 reserved-range handling, and more

Merging this PR triggers the release workflow: npm publish, git tag `v0.7.0`, GitHub Release, and marketplace sync.