### PR TITLE
ci: replace deprecated app-id input with client-id

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BACKPORT_APP_ID }}
+          client-id: ${{ vars.BACKPORT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
 
       - name: Prepare sync branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         id: marketplace-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BACKPORT_APP_ID }}
+          client-id: ${{ vars.BACKPORT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
           owner: coo-quack
           repositories: claude-code-marketplace


### PR DESCRIPTION
Follow-up to the v0.7.0 release: the release workflow warned that the `app-id` input of `actions/create-github-app-token` is deprecated.

- Switch `release.yml` and `backport.yml` to the `client-id` input
- Add org variable `BACKPORT_APP_CLIENT_ID` (`Iv23li26XNNXPooiGZC4`, the client ID of coo-quack-backport-bot) with the same selected-repos visibility as `BACKPORT_APP_ID`

No release is triggered by this merge: the workflow's check job skips because the `v0.7.0` tag already exists.