### PR TITLE
feat: expand PreToolUse coverage to Grep, MCP tools and more Bash forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
   is now read as the whole word. A truncated delimiter never matched its closing
   line, so every following command was swallowed as heredoc body and a read
   placed after it went unscanned
+- Command and process substitutions are found by counting parentheses instead of
+  by regex, so a body carrying parentheses of its own is no longer cut short:
+  `echo $(python3 -c "print(open('.env').read())")` is scanned now. Substitutions
+  inside single quotes are correctly left alone
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 - `git difftool` and `git stash` are no longer treated as content-printing
   subcommands: one hands off to an external tool, the other prints no file
   contents, and classifying them pushed tokens like `pop` as paths
+- `env -S "cmd args"` is no longer treated as an environment dump, and the
+  split string is scanned as the command it runs: `env -S "cat secrets"`
+  blocks now
 - Heredoc bodies are no longer scanned as shell commands: writing a script
   that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
   limitation: a heredoc that feeds commands to a remote shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
     `expand`, `unexpand`, `iconv`, `zcat`, `gzcat`, `bzcat`, `xzcat`, `zstdcat`,
     `diff`, `comm`, `join`, `look`
   - Add pattern-first commands whose later arguments are files: `sed`, `awk`, `gawk`,
-    `grep`, `egrep`, `fgrep`, `rg`, `ag`, `jq`, `yq`, `perl`, `ruby`, `python`,
-    `python3`, `node`, `deno`, `bun` (`sed -i` is exempt: it writes no stdout)
+    `grep`, `egrep`, `fgrep`, `rg`, `ag`, `jq`, `yq`, `perl`, `ruby`
+    (`sed -i` is exempt: it writes no stdout)
   - Unwrap wrapper commands (`sudo`, `env`, `timeout`, `nice`) to scan underlying commands
   - Parse and scan inline scripts (`-c`, `-e`, `-pe` flags) and their shell code
   - Extract file paths from input redirections (`<file`), command substitutions (`$(...)`, `` `...` ``, `<(...)`), and chained commands (newlines, `&&`, `;`)
@@ -38,6 +38,11 @@
 - Only known wrappers are peeled when locating the command: an operand that
   happens to name a read command (`echo cat secrets`) no longer triggers a
   scan of a file nothing reads
+- `if=<file>` is treated as an input file only for `dd`; another command given
+  an `if=` argument (`echo if=secrets`) no longer triggers a scan
+- `python`, `python3`, `node`, `deno` and `bun` no longer have their arguments
+  scanned as printed files: running a script does not print the paths named
+  after it. Their inline code (`-c`, `-e`) is still scanned
 - Heredoc bodies are no longer scanned as shell commands: writing a script
   that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
   limitation: a heredoc that feeds commands to a remote shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@
 - The write-name exemption for MCP tools now matches only the tool component
   of `mcp__<server>__<tool>`: a server named "editor" or "readwrite" no longer
   exempts the read tools it offers
+- The write-name exemption requires the verb to lead the tool name rather than
+  appear anywhere in it. As a substring test it exempted reads: "update" sits
+  inside `get_updates` and "write" inside `read_and_write_file`, so a tool that
+  returns file contents was treated as one that only writes
 - `$'...'` (ANSI-C) and `$"..."` quoting no longer hide a path from the
   tokenizer
 - A heredoc delimiter carrying a hyphen or partial quoting (`<<EOF-1`, `<<E"O"F`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@
   subcommand and ruled the environment dump out
 - `printenv > out.txt` counts as a whole-environment dump: the redirection target
   was taken for a named variable
+- A subshell is tokenized as the command line it is, so `(cat secrets)` and
+  `echo hi && (cat secrets)` are scanned. The parens used to stay attached to
+  their neighbours, leaving a command called `(cat` and a path called `secrets)`
+- A segment led by a brace-group delimiter or a shell keyword no longer hides its
+  command: `{ cat secrets; }`, `if …; then cat secrets; fi` and
+  `for … do cat secrets; done` are scanned like a bare `cat`
 - `perl script.pl data.txt` and `ruby script.rb data.txt` no longer have their
   operands scanned as printed files, for the same reason `python` and `node` do
   not: with a program file the operands are argv, not output. A one-liner given

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Expand Bash command detection to additional read commands
+  - Add content-printing commands: `tac`, `rev`, `strings`, `xxd`, `od`, `hexdump`,
+    `base64`, `cut`, `sort`, `uniq`, `shuf`, `column`, `paste`, `fold`, `fmt`, `pr`,
+    `expand`, `unexpand`, `iconv`, `zcat`, `gzcat`, `bzcat`, `xzcat`, `zstdcat`,
+    `diff`, `comm`, `join`, `look`
+  - Add pattern-first commands whose later arguments are files: `sed`, `awk`, `gawk`,
+    `grep`, `egrep`, `fgrep`, `rg`, `ag`, `jq`, `yq`, `perl`, `ruby`, `python`,
+    `python3`, `node`, `deno`, `bun` (`sed -i` is exempt: it writes no stdout)
+  - Unwrap wrapper commands (`sudo`, `env`, `timeout`, `nice`) to scan underlying commands
+  - Parse and scan inline scripts (`-c`, `-e`, `-pe` flags) and their shell code
+  - Extract file paths from input redirections (`<file`), command substitutions (`$(...)`, `` `...` ``, `<(...)`), and chained commands (newlines, `&&`, `;`)
+  - Add git subcommands (`git diff`, `git show`, `git blame`) to read-command list
+  - Add `dd if=<file>` to read-command patterns
+- Add Grep tool detection
+  - Pre-tool-use hook now scans Grep tool input for secret file paths
+  - Known limitation: directory paths are not scanned
+- Add MCP tool detection
+  - Pre-tool-use hook now scans common MCP tool inputs (`path`, `file_path`, nested in `arguments`) for secrets
+- Exclude `wc` from read-command list
+  - `wc` outputs only line/word/byte counts, not file content, so it is not a read-level threat
+
+---
+
 ## v0.7.0 (2026-08-04)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
   `sha256sum`) as non-reads, whether the file is named or fed in over `<`
 - Skip tools whose name says they write, so an MCP `write_file` given a path is
   treated like the built-in `Write` rather than as a read
+- Add an opt-in integration test that runs the hook inside a real headless
+  Claude Code session and asserts both halves of the block contract: the read is
+  stopped, and the reason reaches Claude. Every other test spawns the hook and
+  reads its output itself, which says nothing about whether the runtime acts on
+  it. Set `SENSITIVE_CANARY_INTEGRATION=1` to run it; it needs credentials and
+  network, so CI skips it
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
   by regex, so a body carrying parentheses of its own is no longer cut short:
   `echo $(python3 -c "print(open('.env').read())")` is scanned now. Substitutions
   inside single quotes are correctly left alone
+- A file-descriptor prefix on a redirection (`env 2>err`) is read as part of the
+  operator rather than as a token of its own, where it passed for `env`'s
+  subcommand and ruled the environment dump out
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@
   exempts the read tools it offers
 - `$'...'` (ANSI-C) and `$"..."` quoting no longer hide a path from the
   tokenizer
+- A heredoc delimiter carrying a hyphen or partial quoting (`<<EOF-1`, `<<E"O"F`)
+  is now read as the whole word. A truncated delimiter never matched its closing
+  line, so every following command was swallowed as heredoc body and a read
+  placed after it went unscanned
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 - `python`, `python3`, `node`, `deno` and `bun` no longer have their arguments
   scanned as printed files: running a script does not print the paths named
   after it. Their inline code (`-c`, `-e`) is still scanned
+- Quoted literals with spaces inside inline code are no longer skipped:
+  `python3 -c "open('my secret.txt').read()"` is found now. Only literals with
+  line breaks or tabs are still treated as messages rather than paths
 - Heredoc bodies are no longer scanned as shell commands: writing a script
   that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
   limitation: a heredoc that feeds commands to a remote shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 - `env -S "cmd args"` is no longer treated as an environment dump, and the
   split string is scanned as the command it runs: `env -S "cat secrets"`
   blocks now
+- Wrapper flags and operands no longer hide an environment dump:
+  `sudo -u root printenv` and `timeout 5 env` are detected like bare
+  `printenv` / `env`
 - Heredoc bodies are no longer scanned as shell commands: writing a script
   that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
   limitation: a heredoc that feeds commands to a remote shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@
 - Quoted literals with spaces inside inline code are no longer skipped:
   `python3 -c "open('my secret.txt').read()"` is found now. Only literals with
   line breaks or tabs are still treated as messages rather than paths
+- Path fields nested as objects inside an array (`{ paths: [{ path: "…" }] }`)
+  are now found in Grep/MCP tool inputs; only plain string elements were
+  collected before
 - Heredoc bodies are no longer scanned as shell commands: writing a script
   that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
   limitation: a heredoc that feeds commands to a remote shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
     `expand`, `unexpand`, `iconv`, `zcat`, `gzcat`, `bzcat`, `xzcat`, `zstdcat`,
     `diff`, `comm`, `join`, `look`
   - Add pattern-first commands whose later arguments are files: `sed`, `awk`, `gawk`,
-    `grep`, `egrep`, `fgrep`, `rg`, `ag`, `jq`, `yq`, `perl`, `ruby`
+    `grep`, `egrep`, `fgrep`, `rg`, `ag`, `jq`, `yq`
     (`sed -i` is exempt: it writes no stdout)
+  - Add `perl` and `ruby` one-liners, whose operands are input once the program is
+    given inline (`perl -pe '…' f`)
   - Unwrap wrapper commands (`sudo`, `env`, `timeout`, `nice`) to scan underlying commands
   - Parse and scan inline scripts (`-c`, `-e`, `-pe` flags) and their shell code
   - Extract file paths from input redirections (`<file`), command substitutions (`$(...)`, `` `...` ``, `<(...)`), and chained commands (newlines, `&&`, `;`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@
 - Skip tools whose name says they write, so an MCP `write_file` given a path is
   treated like the built-in `Write` rather than as a read
 
+### Fixed
+
+- `env FOO=1` (assignments but no subcommand), `env -u FOO` and a redirected
+  `env > out` now count as whole-environment dumps; `env -i` no longer does,
+  since it prints only the assignments given
+- `>(...)` process substitution is recursed into, like `<(...)`
+- Only known wrappers are peeled when locating the command: an operand that
+  happens to name a read command (`echo cat secrets`) no longer triggers a
+  scan of a file nothing reads
+- Heredoc bodies are no longer scanned as shell commands: writing a script
+  that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
+  limitation: a heredoc that feeds commands to a remote shell
+  (`ssh host <<EOF`) is no longer caught
+- The write-name exemption for MCP tools now matches only the tool component
+  of `mcp__<server>__<tool>`: a server named "editor" or "readwrite" no longer
+  exempts the read tools it offers
+- `$'...'` (ANSI-C) and `$"..."` quoting no longer hide a path from the
+  tokenizer
+
 ---
 
 ## v0.7.0 (2026-08-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
 - Path fields nested as objects inside an array (`{ paths: [{ path: "…" }] }`)
   are now found in Grep/MCP tool inputs; only plain string elements were
   collected before
+- Global git flags with a separate value no longer hide the subcommand:
+  `git -C repo show f` and `git -c k=v show f` are scanned like `git show f`
+- `git difftool` and `git stash` are no longer treated as content-printing
+  subcommands: one hands off to an external tool, the other prints no file
+  contents, and classifying them pushed tokens like `pop` as paths
 - Heredoc bodies are no longer scanned as shell commands: writing a script
   that mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known
   limitation: a heredoc that feeds commands to a remote shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 - A file-descriptor prefix on a redirection (`env 2>err`) is read as part of the
   operator rather than as a token of its own, where it passed for `env`'s
   subcommand and ruled the environment dump out
+- `printenv > out.txt` counts as a whole-environment dump: the redirection target
+  was taken for a named variable
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@
   subcommand and ruled the environment dump out
 - `printenv > out.txt` counts as a whole-environment dump: the redirection target
   was taken for a named variable
+- `perl script.pl data.txt` and `ruby script.rb data.txt` no longer have their
+  operands scanned as printed files, for the same reason `python` and `node` do
+  not: with a program file the operands are argv, not output. A one-liner given
+  inline (`perl -pe '…' f`, `ruby -pe '…' f`) still reads its operands and is
+  still scanned
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,12 @@
   - Known limitation: directory paths are not scanned
 - Add MCP tool detection
   - Pre-tool-use hook now scans common MCP tool inputs (`path`, `file_path`, nested in `arguments`) for secrets
-- Exclude `wc` from read-command list
-  - `wc` outputs only line/word/byte counts, not file content, so it is not a read-level threat
+- Scan every environment variable when a bare `env` or `printenv` would print the
+  whole environment, including behind a wrapper (`sudo printenv`)
+- Treat commands that only measure a file (`wc`, `cksum`, `md5sum`, `sha1sum`,
+  `sha256sum`) as non-reads, whether the file is named or fed in over `<`
+- Skip tools whose name says they write, so an MCP `write_file` given a path is
+  treated like the built-in `Write` rather than as a read
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,18 +7,18 @@ Thanks for your interest in contributing to Sensitive Canary!
 ```bash
 git clone https://github.com/coo-quack/sensitive-canary.git
 cd sensitive-canary
-npm install
+pnpm install
 ```
 
 ## Commands
 
 ```bash
-npm test           # Run tests
-npm run test:watch # Run tests in watch mode
-npm run typecheck  # Type check with tsc
-npm run lint       # Check with Biome
-npm run fix        # Lint + auto-fix with Biome
-npm run ci         # typecheck + lint + tests (full CI check)
+pnpm test          # Run tests
+pnpm run test:watch # Run tests in watch mode
+pnpm run typecheck  # Type check with tsc
+pnpm run lint       # Check with Biome
+pnpm run fix        # Lint + auto-fix with Biome
+pnpm run ci         # typecheck + lint + tests (full CI check)
 ```
 
 ## Branching Strategy
@@ -70,6 +70,7 @@ When bumping a version, open a PR from `develop` → `main` with:
    - This content is automatically used as the GitHub Release notes by `release.yml`
 3. Review `docs/rules.md` — add/update any changed rules
 4. Review `README.md` — update rule counts and tables if needed
+5. Run the integration test (see below) — CI never does, and it is the only check that the block still reaches Claude
 
 After merging into `main`, `release.yml` automatically:
 - Creates a git tag `vX.Y.Z`
@@ -77,13 +78,25 @@ After merging into `main`, `release.yml` automatically:
 
 The documentation site is also redeployed automatically on merge to `main`.
 
+## Integration test
+
+`src/__tests__/pre-tool-use-hook.integration.test.ts` runs the hook inside a real headless Claude Code session. It is the only test that checks Claude Code acts on what the hook says — the rest spawn the hook and read its output themselves, which passes whether or not the runtime reads that channel.
+
+It needs credentials and network, so it is opt-in and CI skips it:
+
+```bash
+SENSITIVE_CANARY_INTEGRATION=1 pnpm test src/__tests__/pre-tool-use-hook.integration.test.ts
+```
+
+Run it by hand whenever the way a block is returned changes — the exit code, the channel the reason is written to, or the shape of the payload.
+
 ## Pull Requests
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `hotfix:`, etc.)
-- All tests must pass (`npm test`)
-- Lint must pass (`npm run lint`)
+- All tests must pass (`pnpm test`)
+- Lint must pass (`pnpm run lint`)
 - One approval required to merge
 
 ## Code Style
 
-Enforced by [Biome](https://biomejs.dev/). Run `npm run fix` before committing.
+Enforced by [Biome](https://biomejs.dev/). Run `pnpm run fix` before committing.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Then add to `~/.claude/settings.json`:
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -141,7 +141,7 @@ Then add to `~/.claude/settings.json`:
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -449,24 +449,47 @@ When blocked, the terminal shows what was detected and how to bypass it.
 
 ### ② PreToolUse hook
 
-Runs just before Claude calls the `Read` or `Bash` tool.
+Runs just before Claude calls the `Read`, `Bash`, `Grep`, or MCP tools.
 
 ```
-Claude calls Read / Bash tool
+Claude calls Read / Bash / Grep / MCP tool
       ↓
 PreToolUse hook
       ↓
       ── Read tool ─────────────────────────────────────────────────────
       │  1. filename is .env / .env.* → blocked (secret category only)
       │  2. file contents contain secret / PII → blocked
-      └─ Bash tool ─────────────────────────────────────────────────────
-         1. env var values referenced in the command contain secret / PII → blocked
-         2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
-         3. cat / head / tail / etc. targeting a file → file contents scanned
+      │
+      ├─ Bash tool ──────────────────────────────────────────────────────
+      │  1. env var values referenced in the command contain secret / PII → blocked
+      │  2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
+      │  3. wrapper commands (sudo, env, timeout, nice) are unwrapped
+      │  4. inline scripts (-c, -e, -pe) are parsed and scanned
+      │  5. file paths from input redirections, command substitutions, and chained
+      │     commands are extracted and scanned
+      │  6. read commands (cat, head, tail, sed, awk, grep, rg, cut, sort, base64,
+      │     xxd, strings, diff, comm, dd, and git subcommands) targeting a file
+      │     → file contents scanned
+      │
+      ├─ Grep tool ──────────────────────────────────────────────────────
+      │  1. target file path contains secret / PII → blocked
+      │
+      └─ MCP tools (mcp__*) ───────────────────────────────────────────
+         1. common input fields (path, file_path, and nested arguments) are
+            scanned for secret / PII → blocked
 ```
 
 When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
 The terminal also receives a direct message (via `/dev/tty`).
+
+### Known Limitations
+
+- **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
+- **Grep on directories** — when the Grep tool's `path` input is a directory, the inspection is skipped (to avoid scanning all files within).
+- **Paths held in shell variables** — a path is only scanned when it appears literally in the command. `f=.env; cat "$f"` resolves at run time, after the hook has already decided.
+- **Paths arriving over a pipe** — `find . -name '.env' | xargs cat` names no file the hook can see.
+- **Programs that read files themselves** — `python script.py` is not scanned, because running a script does not print its source; whatever the script opens at run time is beyond the hook's reach.
+- **Best effort only** — detection is not exhaustive. Arbitrary shell metacharacters, eval chains, and complex expansions may not be fully tracked.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **Paths arriving over a pipe** — `find . -name '.env' | xargs cat` names no file the hook can see.
 - **Programs that read files themselves** — `python script.py` is not scanned, because running a script does not print its source; whatever the script opens at run time is beyond the hook's reach.
 - **Heredoc bodies are not scanned** — a heredoc is treated as text, so a heredoc that feeds commands to a remote shell (`ssh host <<EOF` followed by `cat /secret`) is not caught.
+- **Nesting is followed four levels deep** — each command substitution and each inline script costs one level, so a read buried under five nested `$(…)` is not reached.
 - **Best effort only** — detection is not exhaustive. Arbitrary shell metacharacters, eval chains, and complex expansions may not be fully tracked.
 
 ---

--- a/README.md
+++ b/README.md
@@ -462,22 +462,27 @@ PreToolUse hook
       │
       ├─ Bash tool ──────────────────────────────────────────────────────
       │  1. env var values referenced in the command contain secret / PII → blocked
-      │  2. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
-      │  3. wrapper commands (sudo, env, timeout, nice) are unwrapped
-      │  4. inline scripts (-c, -e, -pe) are parsed and scanned
-      │  5. file paths from input redirections, command substitutions, and chained
+      │  2. a bare env / printenv would print the whole environment → every
+      │     variable is scanned
+      │  3. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
+      │  4. the command is located past any wrapper (sudo, env VAR=1, timeout,
+      │     nice, xargs) and any leading VAR=value assignment
+      │  5. inline scripts (-c, -e, -pe) are parsed and scanned
+      │  6. file paths from input redirections, command substitutions, and chained
       │     commands are extracted and scanned
-      │  6. read commands (cat, head, tail, sed, awk, grep, rg, cut, sort, base64,
-      │     xxd, strings, diff, comm, dd, and git subcommands) targeting a file
-      │     → file contents scanned
+      │  7. printing commands (cat, head, tail, sed, awk, grep, rg, cut, sort,
+      │     base64, xxd, strings, diff, comm, dd, and git subcommands) targeting
+      │     a named file → file contents scanned
       │
       ├─ Grep tool ──────────────────────────────────────────────────────
       │  1. target file path contains secret / PII → blocked
       │
       └─ MCP tools (mcp__*) ───────────────────────────────────────────
-         1. common input fields (path, file_path, and nested arguments) are
-            scanned for secret / PII → blocked
+         1. input fields naming an existing file (path, file_path, and nested
+            arguments) are scanned for secret / PII → blocked
 ```
+
+Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Tools whose name says they write, both the built-in `Write` and `Edit` and MCP tools such as `mcp__fs__write_file`, are skipped for the same reason.
 
 When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
 The terminal also receives a direct message (via `/dev/tty`).
@@ -485,7 +490,9 @@ The terminal also receives a direct message (via `/dev/tty`).
 ### Known Limitations
 
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
-- **Grep on directories** — when the Grep tool's `path` input is a directory, the inspection is skipped (to avoid scanning all files within).
+- **Directory targets** — nothing that names a directory rather than a file is scanned. That covers the Grep tool's `path` and a recursive search such as `grep -r pattern src/`, both of which would otherwise mean reading every file underneath.
+- **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
+- **`.env.*` is blocked by name** — the filename guard covers every `.env.*`, so a template like `.env.example` is blocked as well, now through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` for those.
 - **Paths held in shell variables** — a path is only scanned when it appears literally in the command. `f=.env; cat "$f"` resolves at run time, after the hook has already decided.
 - **Paths arriving over a pipe** — `find . -name '.env' | xargs cat` names no file the hook can see.
 - **Programs that read files themselves** — `python script.py` is not scanned, because running a script does not print its source; whatever the script opens at run time is beyond the hook's reach.

--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **Paths held in shell variables** — a path is only scanned when it appears literally in the command. `f=.env; cat "$f"` resolves at run time, after the hook has already decided.
 - **Paths arriving over a pipe** — `find . -name '.env' | xargs cat` names no file the hook can see.
 - **Programs that read files themselves** — `python script.py` is not scanned, because running a script does not print its source; whatever the script opens at run time is beyond the hook's reach.
+- **Heredoc bodies are not scanned** — a heredoc is treated as text, so a heredoc that feeds commands to a remote shell (`ssh host <<EOF` followed by `cat /secret`) is not caught.
 - **Best effort only** — detection is not exhaustive. Arbitrary shell metacharacters, eval chains, and complex expansions may not be fully tracked.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,10 @@ Sensitive Canary intercepts secrets and PII before they leave your machine:
 | `.env` file exposure | `PreToolUse` (Read) | Blocks by filename (secret category only) |
 | Secret in Bash command | `PreToolUse` (Bash) | Blocks the command before execution |
 | Secret in env var value | `PreToolUse` (Bash) | Expands and scans `$VAR` references |
+| Secret in a file a Bash command would print | `PreToolUse` (Bash) | Resolves the file arguments of printing commands, including behind wrappers, inline scripts, redirections and substitutions |
+| Whole environment printed | `PreToolUse` (Bash) | Scans every variable when a bare `env` or `printenv` would print it |
+| Secret in a file Claude greps | `PreToolUse` (Grep) | Blocks when the target is a single file |
+| Secret in a file an MCP tool would return | `PreToolUse` (MCP) | Scans input fields that name an existing file |
 
 ---
 
@@ -38,7 +42,10 @@ sensitive-canary is a best-effort guard, not a guaranteed security boundary:
 - **Hook execution** — If the Node.js process fails to start (e.g., wrong Node version), the hook exits 0 (pass) to avoid blocking Claude entirely.
 - **Parse errors** — If the hook input cannot be parsed (malformed JSON from Claude Code), the hook exits 0 (pass) as a fail-open fallback.
 - **Binary files** — Binary files are detected by the presence of a NUL byte. Only the text portion before the first NUL is scanned; content after the NUL is not checked.
-- **Scope** — Only `Read` and `Bash` tool calls are intercepted. Other tool types are not scanned.
+- **Scope** — `Read`, `Bash`, `Grep` and MCP tool calls are intercepted. Tools whose name says they write are skipped, as are tools not matched by the configured `matcher`.
+- **Run-time paths** — a file is only found when its path appears literally in the command. A path held in a shell variable (`f=.env; cat "$f"`), arriving over a pipe (`find … | xargs cat`), or opened by a program the command merely starts (`python script.py`) is resolved after the hook has already decided.
+- **Command classification** — the set of commands known to print file contents is a list, not an analysis. An unlisted command that prints a file is not caught, and `grep -r` over a directory is not scanned because no single file is named.
+- **git history** — `git show HEAD:.env` names an object in history rather than a file on disk, so it is not scanned.
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,7 +54,7 @@ Add the following to `~/.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -111,7 +111,7 @@ Add the following to `~/.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -165,13 +165,17 @@ To allow, add a tag to your prompt:
 
 ### PreToolUse hook
 
-Runs before Claude uses the `Read` or `Bash` tool. It blocks:
+Runs before Claude uses the `Read`, `Bash` or `Grep` tool, or any MCP tool. It blocks:
 
 - `.env` and `.env.*` files by filename (a secret guard; only while the `secret` category is enabled)
 - Any file whose contents contain secrets or PII
-- `cat`, `head`, `tail`, and other file-reading commands targeting sensitive files
+- Commands that print a file: `cat`, `head`, `tail`, `sed`, `awk`, `grep`, `rg`, `cut`, `base64`, `strings`, `diff` and others, including behind a wrapper (`sudo`, `env VAR=1`, `timeout`, `xargs`), inside `sh -c` or `python3 -c`, after a `<` redirection, inside `$(…)`, and on later lines of a multi-line command
+- File arguments of git subcommands that print contents (`git show`, `git diff`, `git blame`)
 - Bash commands containing secrets inline (e.g. `echo AKIAIOSFODNN7EXAMPLE`)
-- Environment variables referenced in Bash commands whose values contain secrets
+- Environment variables referenced in Bash commands whose values contain secrets, and a bare `env` or `printenv` that would print the whole environment
+- The `Grep` tool's target file, and MCP tool inputs that name an existing file
+
+Commands that only measure a file (`wc`, `sha256sum`) and tools whose name says they write (`Write`, `Edit`, `mcp__*__write_file`) are left alone: naming a file they do not print is not a leak.
 
 ## Allow Tags
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -3,8 +3,15 @@
 // options shape, rather than a same-named helper per file.
 
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const HOOK = new URL("../pre-tool-use-hook.ts", import.meta.url).pathname;
+// fileURLToPath rather than `.pathname`, which leaves a checkout under a path
+// with spaces percent-encoded and hands `node` a filename that does not exist.
+// Exported so the integration test resolves the hook the same way: two copies of
+// this line meant one of them could be left behind.
+export const HOOK = fileURLToPath(
+  new URL("../pre-tool-use-hook.ts", import.meta.url),
+);
 const NODE_FLAGS = ["--experimental-strip-types"];
 
 export interface RunOptions {

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -26,12 +26,12 @@ export interface HookResult {
   reason: string | null;
 }
 
-// Feed the hook a raw stdin payload, for cases where the payload is not valid
-// JSON and so cannot be described as a tool call.
-export function runHookWithRawInput(input: string): HookResult {
+// Spawn the hook with a raw stdin payload and assemble its verdict.
+function spawnHook(input: string, opts?: RunOptions): HookResult {
   const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
     input,
     encoding: "utf8",
+    env: opts?.replaceEnv ? (opts.env ?? {}) : { ...process.env, ...opts?.env },
   });
   const { decision, reason } = parseHookOutput(result.stdout);
   return {
@@ -41,6 +41,12 @@ export function runHookWithRawInput(input: string): HookResult {
     decision,
     reason,
   };
+}
+
+// Feed the hook a raw stdin payload, for cases where the payload is not valid
+// JSON and so cannot be described as a tool call.
+export function runHookWithRawInput(input: string): HookResult {
+  return spawnHook(input);
 }
 
 export function parseHookOutput(stdout: string): {
@@ -66,19 +72,7 @@ export function runToolHook(
     tool_name: toolName,
     tool_input: toolInput,
   });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: opts?.replaceEnv ? (opts.env ?? {}) : { ...process.env, ...opts?.env },
-  });
-  const { decision, reason } = parseHookOutput(result.stdout);
-  return {
-    exitCode: result.status ?? -1,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    decision,
-    reason,
-  };
+  return spawnHook(input, opts);
 }
 
 // A tool call carrying a single `file_path`, as Read does.

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -1,0 +1,99 @@
+// Shared way to run the PreToolUse hook as a child process and read its verdict.
+// Both hook test files use it so that "run the hook" has one meaning and one
+// options shape, rather than a same-named helper per file.
+
+import { spawnSync } from "node:child_process";
+
+const HOOK = new URL("../pre-tool-use-hook.ts", import.meta.url).pathname;
+const NODE_FLAGS = ["--experimental-strip-types"];
+
+export interface RunOptions {
+  // Variables to add to the child environment.
+  env?: Record<string, string>;
+  // Use `env` as the whole child environment instead of adding to the parent's.
+  // Include PATH when setting this, or `node` will not be found.
+  replaceEnv?: boolean;
+  // Transcript the hook should read allow tags from.
+  transcriptPath?: string;
+}
+
+export interface HookResult {
+  // 0 allows the tool call, 2 blocks it.
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  decision: string | null;
+  reason: string | null;
+}
+
+// Feed the hook a raw stdin payload, for cases where the payload is not valid
+// JSON and so cannot be described as a tool call.
+export function runHookWithRawInput(input: string): HookResult {
+  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
+    input,
+    encoding: "utf8",
+  });
+  const { decision, reason } = parseHookOutput(result.stdout);
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    decision,
+    reason,
+  };
+}
+
+export function parseHookOutput(stdout: string): {
+  decision: string | null;
+  reason: string | null;
+} {
+  try {
+    const parsed = JSON.parse(stdout) as { decision?: string; reason?: string };
+    return { decision: parsed.decision ?? null, reason: parsed.reason ?? null };
+  } catch {
+    return { decision: null, reason: null };
+  }
+}
+
+// Run the hook against an arbitrary tool call.
+export function runToolHook(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  opts?: RunOptions,
+): HookResult {
+  const input = JSON.stringify({
+    transcript_path: opts?.transcriptPath,
+    tool_name: toolName,
+    tool_input: toolInput,
+  });
+  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
+    input,
+    encoding: "utf8",
+    env: opts?.replaceEnv ? (opts.env ?? {}) : { ...process.env, ...opts?.env },
+  });
+  const { decision, reason } = parseHookOutput(result.stdout);
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    decision,
+    reason,
+  };
+}
+
+// A tool call carrying a single `file_path`, as Read does.
+export function runHook(
+  toolName: string,
+  filePath: string,
+  opts?: RunOptions,
+): HookResult {
+  return runToolHook(toolName, { file_path: filePath }, opts);
+}
+
+export function runBashHook(command: string, opts?: RunOptions): HookResult {
+  return runToolHook("Bash", { command }, opts);
+}
+
+export function runGrepHook(searchPath: string, opts?: RunOptions): HookResult {
+  return runToolHook("Grep", { pattern: "foo", path: searchPath }, opts);
+}

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -1,61 +1,12 @@
-import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
-const HOOK = new URL("../pre-tool-use-hook.ts", import.meta.url).pathname;
-const NODE_FLAGS = ["--experimental-strip-types"];
-
-function parseHookOutput(stdout: string) {
-  try {
-    const parsed = JSON.parse(stdout);
-    return { decision: parsed.decision, reason: parsed.reason };
-  } catch {
-    return { decision: undefined, reason: undefined };
-  }
-}
-
-function runBashHook(
-  command: string,
-  opts?: { env?: Record<string, string>; replaceEnv?: boolean },
-) {
-  const input = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
-  const envToUse = opts?.replaceEnv
-    ? (opts.env ?? {})
-    : { ...process.env, ...opts?.env };
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: envToUse,
-  });
-  const { decision, reason } = parseHookOutput(result.stdout);
-  return {
-    exitCode: result.status ?? -1,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    decision,
-    reason,
-  };
-}
-
-function runGrepHook(path: string) {
-  const input = JSON.stringify({
-    tool_name: "Grep",
-    tool_input: { pattern: "foo", path },
-  });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: { ...process.env },
-  });
-  const { decision, reason } = parseHookOutput(result.stdout);
-  return { exitCode: result.status ?? -1, decision, reason };
-}
+import { runBashHook, runGrepHook, runToolHook } from "./hook-harness.ts";
 
 let tmpDir: string;
 beforeAll(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-cov-"));
+  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-forms-"));
 });
 afterAll(() => {
   rmSync(tmpDir, { recursive: true, force: true });
@@ -67,25 +18,13 @@ function writeFixture(name: string, content: string) {
   return p;
 }
 
-function runToolHook(toolName: string, toolInput: Record<string, unknown>) {
-  const input = JSON.stringify({ tool_name: toolName, tool_input: toolInput });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: { ...process.env },
-  });
-  const { decision, reason } = parseHookOutput(result.stdout);
-  return { exitCode: result.status ?? -1, decision, reason };
-}
-
 // Assemble secrets without showing full strings in file source
 const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
-const _EMAIL = ["taro.yamada", "example.com"].join("@");
 const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
   "",
 );
 
-describe("pre-tool-use-hook-coverage", () => {
+describe("pre-tool-use-hook — Bash forms and other tools", () => {
   describe("expanded read commands", () => {
     it("sed with pattern should block on file with secret", () => {
       const file = writeFixture("s.txt", `key=${AWS_KEY}`);
@@ -157,11 +96,16 @@ describe("pre-tool-use-hook-coverage", () => {
   });
 
   describe("input redirection", () => {
-    it("wc with < redirection should block on file with secret", () => {
+    it("wc with < redirection should allow: it reports counts, not content", () => {
       const file = writeFixture("wc.txt", `key=${AWS_KEY}`);
       const result = runBashHook(`wc -l < ${file}`);
-      expect(result.exitCode).toBe(2);
-      expect(result.decision).toBe("block");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("sha256sum with < redirection should allow", () => {
+      const file = writeFixture("sha.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`sha256sum < ${file}`);
+      expect(result.exitCode).toBe(0);
     });
 
     it("grep with < redirection should block on file with secret", () => {
@@ -570,6 +514,129 @@ describe("pre-tool-use-hook-coverage", () => {
     it("comm <secretFile> /dev/null should block", () => {
       const file = writeFixture("comm_file.txt", `token=${AWS_KEY}`);
       const result = runBashHook(`comm ${file} /dev/null`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  // Peeling a wrapper by counting its flags mistook a flag's value for the
+  // command: `sudo -u root cat f` resolved to `root`, and the file went unread.
+  describe("wrappers whose flags take a value", () => {
+    const blocked = (command: string) => {
+      const result = runBashHook(command);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    };
+
+    it("sudo -u root cat should block", () => {
+      const file = writeFixture("w_sudo_u.txt", `key=${AWS_KEY}`);
+      blocked(`sudo -u root cat ${file}`);
+    });
+
+    it("nice -n 10 cat should block", () => {
+      const file = writeFixture("w_nice_n.txt", `key=${AWS_KEY}`);
+      blocked(`nice -n 10 cat ${file}`);
+    });
+
+    it("ionice -c 3 cat should block", () => {
+      const file = writeFixture("w_ionice.txt", `key=${TOKEN_VALUE}`);
+      blocked(`ionice -c 3 cat ${file}`);
+    });
+
+    it("env -u FOO cat should block", () => {
+      const file = writeFixture("w_env_u.txt", `key=${AWS_KEY}`);
+      blocked(`env -u FOO cat ${file}`);
+    });
+
+    it("timeout -s KILL 5 cat should block", () => {
+      const file = writeFixture("w_timeout.txt", `key=${TOKEN_VALUE}`);
+      blocked(`timeout -s KILL 5 cat ${file}`);
+    });
+
+    it("xargs -n 1 cat should block", () => {
+      const file = writeFixture("w_xargs.txt", `key=${AWS_KEY}`);
+      blocked(`xargs -n 1 cat ${file}`);
+    });
+
+    it("flock /tmp/lockfile cat should block", () => {
+      const file = writeFixture("w_flock.txt", `key=${AWS_KEY}`);
+      blocked(`flock /tmp/canary.lock cat ${file}`);
+    });
+
+    it("nested wrappers should block", () => {
+      const file = writeFixture("w_nested.txt", `key=${TOKEN_VALUE}`);
+      blocked(`sudo -u root timeout -s KILL 5 cat ${file}`);
+    });
+  });
+
+  // A `VAR=value` prefix is not a command, and skipping assignments only after a
+  // wrapper name let `LANG=C cat f` through.
+  describe("leading variable assignments", () => {
+    it("LANG=C cat should block", () => {
+      const file = writeFixture("a_lang.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`LANG=C cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("NODE_ENV=test grep should block", () => {
+      const file = writeFixture("a_node_env.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`NODE_ENV=test grep key ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("assignment before a wrapper should block", () => {
+      const file = writeFixture("a_both.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`LANG=C sudo -u root cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("an assignment on its own should allow", () => {
+      const result = runBashHook("LANG=C");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("environment dumps behind a wrapper", () => {
+    it("sudo printenv should block when the environment holds a secret", () => {
+      const result = runBashHook("sudo printenv", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env running a command is not a dump", () => {
+      const result = runBashHook("env FOO=1 ls", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("write-shaped MCP tools are exempt", () => {
+    it("mcp__fs__write_file should allow", () => {
+      const file = writeFixture("mcp_write.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__write_file", {
+        path: file,
+        contents: "x",
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("mcp__fs__move_file should allow", () => {
+      const file = writeFixture("mcp_move.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__move_file", { path: file });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("mcp__fs__read_file should still block", () => {
+      const file = writeFixture("mcp_read.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__read_file", { path: file });
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
     });

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -941,6 +941,41 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
     });
+
+    // The exemption needs the verb to lead the name. As a substring test each of
+    // these read a file while being treated as a tool that only writes.
+    it("mcp__x__get_updates should block: it reads", () => {
+      const file = writeFixture("mcp_get_updates.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__get_updates", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("mcp__x__read_and_write_file should block: it reads too", () => {
+      const file = writeFixture("mcp_read_and_write.txt", `key=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__x__read_and_write_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("mcp__x__readwrite should block", () => {
+      const file = writeFixture("mcp_rw.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__readwrite", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("mcp__x__createPage should allow (camelCase write verb leads)", () => {
+      const file = writeFixture("mcp_camel.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__createPage", { path: file });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("TodoWrite stays exempt through the explicit list", () => {
+      const file = writeFixture("todo_write.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("TodoWrite", { path: file });
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("output process substitution", () => {

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -670,6 +670,21 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("env -S split string reading a secret should block", () => {
+      const file = writeFixture("env_split.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`env -S "cat ${file}"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env -S running a command is not a dump", () => {
+      const result = runBashHook(`env -S "echo hi"`, {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
     it("env with only assignments is still a dump", () => {
       const result = runBashHook("env FOO=1 BAR=2", {
         env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -795,6 +795,23 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
     });
+
+    it("printenv with output redirected is still a dump", () => {
+      const result = runBashHook("printenv > out.txt", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("printenv naming one variable is not a dump", () => {
+      const result = runBashHook("printenv PATH > out.txt", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("write-shaped MCP tools are exempt", () => {

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -400,6 +400,35 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    // Same reasoning as python: with a program file the operands are argv, and
+    // only a one-liner given inline reads them as input.
+    it("perl script.pl <secretFile> should allow", () => {
+      const file = writeFixture("perl_argv.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`perl script.pl ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("ruby script.rb <secretFile> should allow", () => {
+      const file = writeFixture("ruby_argv.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`ruby script.rb ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("ruby -pe with file should block", () => {
+      const file = writeFixture("ruby_inline.txt", `pass=${AWS_KEY}`);
+      const result = runBashHook(`ruby -pe 'gsub(/a/, "b")' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("perl -pe with two files should block on either", () => {
+      const clean = writeFixture("perl_clean.txt", "nothing here");
+      const file = writeFixture("perl_second.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`perl -pe 's/a/b/' ${clean} ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
     it("sh -c 'echo hello world' should allow", () => {
       const result = runBashHook(`sh -c "echo hello world"`);
       expect(result.exitCode).toBe(0);

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -433,6 +433,31 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       const result = runBashHook(`git add ${file}`);
       expect(result.exitCode).toBe(0);
     });
+
+    it("git -C <dir> show <secretFile> should block", () => {
+      const file = writeFixture("git_dash_c.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`git -C /tmp show ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("git -c k=v show <secretFile> should block", () => {
+      const file = writeFixture("git_dash_c_cfg.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`git -c core.pager=cat show ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("git difftool <secretFile> (hands off to external tool) should allow", () => {
+      const file = writeFixture("git_difftool.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`git difftool ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("git stash pop (prints no file contents) should allow", () => {
+      const result = runBashHook(`git stash pop`);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("quoted paths and dd", () => {

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -135,6 +135,13 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
     });
+
+    it("a file-descriptor prefix does not hide the operands", () => {
+      const file = writeFixture("fd_prefix.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat ${file} 2>/dev/null`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
   });
 
   describe("command substitution", () => {
@@ -771,6 +778,17 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
 
     it("env with output redirected is still a dump", () => {
       const result = runBashHook("env > out.txt", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    // The file descriptor belongs to the operator: read as a token of its own,
+    // `2` passed for env's subcommand and ruled the dump out.
+    it("env with stderr redirected is still a dump", () => {
+      const result = runBashHook("env 2>err.txt", {
         env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
         replaceEnv: true,
       });

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -662,6 +662,24 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.decision).toBe("block");
     });
 
+    it("sudo -u root printenv should block when the environment holds a secret", () => {
+      const result = runBashHook("sudo -u root printenv", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("timeout 5 env should block when the environment holds a secret", () => {
+      const result = runBashHook("timeout 5 env", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
     it("env running a command is not a dump", () => {
       const result = runBashHook("env FOO=1 ls", {
         env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -482,6 +482,15 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.decision).toBe("block");
     });
 
+    it("mcp tool with path objects inside an array should block", () => {
+      const file = writeFixture("mcp_array.txt", `secret=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__example__tool", {
+        paths: [{ path: file }],
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
     it("mcp tool with nonexistent path should allow", () => {
       const result = runToolHook("mcp__example__tool", {
         path: "/api/v1/users",

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -844,6 +844,27 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
     });
+
+    // A delimiter cut short never matches its closing line, and every following
+    // line is then swallowed as body — hiding the read that comes after it.
+    it("command after a hyphenated heredoc delimiter still scans", () => {
+      const file = writeFixture("hyphen_delim.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat > s.sh <<EOF-1\nhi\nEOF-1\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("command after a partly quoted heredoc delimiter still scans", () => {
+      const file = writeFixture("mixed_delim.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat > s.sh <<E"O"F\nhi\nEOF\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("hyphenated delimiter still hides its own body", () => {
+      const result = runBashHook("cat > deploy.sh <<EOF-1\ncat .env\nEOF-1");
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("ANSI-C and locale quoting", () => {

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -323,6 +323,13 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.decision).toBe("block");
     });
 
+    it("python3 -c reading a path with spaces should block", () => {
+      const file = writeFixture("python spaced.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`python3 -c "print(open('${file}').read())"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
     it("sh -c 'cat <secretFile>' should block", () => {
       const file = writeFixture("sh_c.txt", `secret=${TOKEN_VALUE}`);
       const result = runBashHook(`sh -c "cat ${file}"`);

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -349,6 +349,12 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("python3 script.py <secretFile> (script argv is not output) should allow", () => {
+      const file = writeFixture("python_argv.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`python3 script.py ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
     it("sh -c 'echo hello world' should allow", () => {
       const result = runBashHook(`sh -c "echo hello world"`);
       expect(result.exitCode).toBe(0);
@@ -435,6 +441,12 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       const result = runBashHook(`dd if=${file}`);
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
+    });
+
+    it("if=<secretFile> without dd (echo) should allow", () => {
+      const file = writeFixture("not_dd.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo if=${file}`);
+      expect(result.exitCode).toBe(0);
     });
 
     it("wc -l <secretFile> (wc outputs only count) should allow", () => {

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -163,6 +163,37 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       const result = runBashHook("cat <<EOF\nhello world\nEOF");
       expect(result.exitCode).toBe(0);
     });
+
+    // The substitution body carries parentheses of its own, so a scan that stops
+    // at the first `)` never sees the read inside it.
+    it("$(...) whose body contains parentheses should block", () => {
+      const file = writeFixture("sub_parens.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(
+        `echo $(python3 -c "print(open('${file}').read())")`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("nested $( $(...) ) should block on file with secret", () => {
+      const file = writeFixture("sub_nested.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo $(echo $(cat ${file}))`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("$(...) inside double quotes should block", () => {
+      const file = writeFixture("sub_dq.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo "$(cat ${file})"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("$(...) inside single quotes should allow (no expansion)", () => {
+      const file = writeFixture("sub_sq.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo '$(cat ${file})'`);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("environment variables", () => {

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -616,6 +616,50 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
       });
       expect(result.exitCode).toBe(0);
     });
+
+    it("env with only assignments is still a dump", () => {
+      const result = runBashHook("env FOO=1 BAR=2", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env -u FOO unsets one variable and dumps the rest", () => {
+      const result = runBashHook("env -u FOO", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env --unset FOO should also block", () => {
+      const result = runBashHook("env --unset FOO", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env -i starts from an empty environment: not a dump", () => {
+      const result = runBashHook("env -i FOO=1", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("env with output redirected is still a dump", () => {
+      const result = runBashHook("env > out.txt", {
+        env: { PATH: process.env["PATH"] ?? "", TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
   });
 
   describe("write-shaped MCP tools are exempt", () => {
@@ -637,6 +681,112 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
     it("mcp__fs__read_file should still block", () => {
       const file = writeFixture("mcp_read.txt", `key=${AWS_KEY}`);
       const result = runToolHook("mcp__fs__read_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    // The write-name heuristic matches the tool component only: a server named
+    // "editor" or "readwrite" must not exempt the read tools it offers.
+    it("mcp__editor__read_file should block (server name is not the tool name)", () => {
+      const file = writeFixture("mcp_editor.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__editor__read_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("mcp__readwrite__read_file should block (server name is not the tool name)", () => {
+      const file = writeFixture("mcp_readwrite.txt", `key=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__readwrite__read_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  describe("output process substitution", () => {
+    it(">(...) should block on file with secret", () => {
+      const file = writeFixture("psub_out.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo hi >(cat ${file})`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  // Only a known wrapper is peeled: the first real token of any other command
+  // is the command, even when a later operand happens to name a read command.
+  describe("operands that look like commands", () => {
+    it("echo cat <secretFile> should allow (echo prints the words, not the file)", () => {
+      const file = writeFixture("echo_cat.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo cat ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("printf cat <secretFile> should allow", () => {
+      const file = writeFixture("printf_cat.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`printf cat ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("heredoc bodies", () => {
+    it("heredoc writing a script that mentions .env should allow", () => {
+      const result = runBashHook("cat > deploy.sh <<'EOF'\ncat .env\nEOF");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("heredoc body naming a sensitive file should allow (body is text)", () => {
+      const file = writeFixture("heredoc_body.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat > s.sh <<EOF\ncat ${file}\nEOF`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("<<- heredoc with tab-indented delimiter should allow", () => {
+      const result = runBashHook("cat > s.sh <<-EOF\n\tcat .env\n\tEOF");
+      expect(result.exitCode).toBe(0);
+    });
+
+    // Known limitation: the body is skipped entirely, so a heredoc that feeds
+    // commands to a remote shell is no longer caught.
+    it("ssh heredoc running cat on a sensitive file is not caught (documented limitation)", () => {
+      const file = writeFixture("ssh_heredoc.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`ssh host <<EOF\ncat ${file}\nEOF`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("command after the heredoc still scans", () => {
+      const file = writeFixture("after_heredoc.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat <<EOF\nhi\nEOF\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  describe("ANSI-C and locale quoting", () => {
+    it("cat $'<path>' should block on file with secret", () => {
+      const file = writeFixture("ansi_c.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat $'${file}'`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it('cat $"<path>" should block on file with secret', () => {
+      const file = writeFixture("locale_q.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat $"${file}"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("cat $'<path with space>' should block", () => {
+      const file = writeFixture("ansi space.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat $'${file}'`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("$'...' hex escapes should decode", () => {
+      const file = writeFixture("hexesc.txt", `key=${AWS_KEY}`);
+      // "hexesc" as h e x e \x73 c
+      const escaped = file.replace("hexesc", "hexe\\x73c");
+      const result = runBashHook(`cat $'${escaped}'`);
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("block");
     });

--- a/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
+++ b/src/__tests__/pre-tool-use-hook-bash-and-tools.test.ts
@@ -463,6 +463,66 @@ describe("pre-tool-use-hook — Bash forms and other tools", () => {
     });
   });
 
+  // A grouping construct or a shell keyword stands where a command name would.
+  // Segments led by one were classified as a command called `(cat` or `then`,
+  // and the file they read was never looked at.
+  describe("grouped and keyword-led commands", () => {
+    it("subshell should block on file with secret", () => {
+      const file = writeFixture("subshell.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`(cat ${file})`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("subshell after && should block", () => {
+      const file = writeFixture("subshell_and.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo hi && (cat ${file})`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("subshell piped onward should block", () => {
+      const file = writeFixture("subshell_pipe.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`(cat ${file}) | head`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("brace group should block on file with secret", () => {
+      const file = writeFixture("brace_group.txt", `token=${TOKEN_VALUE}`);
+      const result = runBashHook(`{ cat ${file}; }`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("command after then should block", () => {
+      const file = writeFixture("if_then.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`if true; then cat ${file}; fi`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("command after do should block", () => {
+      const file = writeFixture("for_do.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`for f in a; do cat ${file}; done`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("subshell on a clean file should allow", () => {
+      const file = writeFixture("subshell_clean.txt", "nothing here");
+      const result = runBashHook(`(cat ${file})`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // The parens are inside single quotes, so they are text rather than a group.
+    it("awk program using $(NF) should allow", () => {
+      const file = writeFixture("awk_nf.txt", "one two three");
+      const result = runBashHook(`awk '{print $(NF)}' ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a quoted subshell is text and should allow", () => {
+      const file = writeFixture("quoted_subshell.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo '(cat ${file})'`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
   describe("git subcommands", () => {
     it("git diff <secretFile> should block", () => {
       const file = writeFixture("git_diff.txt", `key=${AWS_KEY}`);

--- a/src/__tests__/pre-tool-use-hook-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-coverage.test.ts
@@ -1,0 +1,577 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const HOOK = new URL("../pre-tool-use-hook.ts", import.meta.url).pathname;
+const NODE_FLAGS = ["--experimental-strip-types"];
+
+function parseHookOutput(stdout: string) {
+  try {
+    const parsed = JSON.parse(stdout);
+    return { decision: parsed.decision, reason: parsed.reason };
+  } catch {
+    return { decision: undefined, reason: undefined };
+  }
+}
+
+function runBashHook(
+  command: string,
+  opts?: { env?: Record<string, string>; replaceEnv?: boolean },
+) {
+  const input = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+  const envToUse = opts?.replaceEnv
+    ? (opts.env ?? {})
+    : { ...process.env, ...opts?.env };
+  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
+    input,
+    encoding: "utf8",
+    env: envToUse,
+  });
+  const { decision, reason } = parseHookOutput(result.stdout);
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    decision,
+    reason,
+  };
+}
+
+function runGrepHook(path: string) {
+  const input = JSON.stringify({
+    tool_name: "Grep",
+    tool_input: { pattern: "foo", path },
+  });
+  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
+    input,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  const { decision, reason } = parseHookOutput(result.stdout);
+  return { exitCode: result.status ?? -1, decision, reason };
+}
+
+let tmpDir: string;
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-cov-"));
+});
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFixture(name: string, content: string) {
+  const p = join(tmpDir, name);
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+function runToolHook(toolName: string, toolInput: Record<string, unknown>) {
+  const input = JSON.stringify({ tool_name: toolName, tool_input: toolInput });
+  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
+    input,
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  const { decision, reason } = parseHookOutput(result.stdout);
+  return { exitCode: result.status ?? -1, decision, reason };
+}
+
+// Assemble secrets without showing full strings in file source
+const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
+const _EMAIL = ["taro.yamada", "example.com"].join("@");
+const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
+  "",
+);
+
+describe("pre-tool-use-hook-coverage", () => {
+  describe("expanded read commands", () => {
+    it("sed with pattern should block on file with secret", () => {
+      const file = writeFixture("s.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`sed -n '1,5p' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("sed -i should allow (in-place edit doesn't output)", () => {
+      const file = writeFixture("edit.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`sed -i '' 's/a/b/' ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("awk should block on file with secret", () => {
+      const file = writeFixture("awk.txt", `token=${TOKEN_VALUE}`);
+      const result = runBashHook(`awk '{print}' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("grep should block on file with secret", () => {
+      const file = writeFixture("grep.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`grep key ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("grep should allow on clean file", () => {
+      const file = writeFixture("clean.txt", "no secrets here");
+      const result = runBashHook(`grep key ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rg (ripgrep) should block on file with secret", () => {
+      const file = writeFixture("rg.txt", `api_key=${AWS_KEY}`);
+      const result = runBashHook(`rg key ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("cut should block on file with secret", () => {
+      const file = writeFixture("cut.txt", `field=${TOKEN_VALUE}`);
+      const result = runBashHook(`cut -d= -f2 ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("sort should block on file with secret", () => {
+      const file = writeFixture("sort.txt", `line ${AWS_KEY} end`);
+      const result = runBashHook(`sort ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("base64 should block on file with secret", () => {
+      const file = writeFixture("b64.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`base64 ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("xxd (hex dump) should block on file with secret", () => {
+      const file = writeFixture("hex.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`xxd ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  describe("input redirection", () => {
+    it("wc with < redirection should block on file with secret", () => {
+      const file = writeFixture("wc.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`wc -l < ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("grep with < redirection should block on file with secret", () => {
+      const file = writeFixture("grep_redir.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`grep key < ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("tr (non-read-command) with < redirection should block", () => {
+      const file = writeFixture("tr.txt", `data=${AWS_KEY}`);
+      const result = runBashHook(`tr a b < ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("output redirection > should not scan target file", () => {
+      const file = writeFixture("output.txt", `key=${AWS_KEY}`);
+      // Redirect to existing file with secret: output redirection is skipped, so no block expected
+      const result = runBashHook(`echo hello > ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("<file form (no space) should block on secret", () => {
+      const file = writeFixture("nosp.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`grep pattern <${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  describe("command substitution", () => {
+    it("$(...) substitution should block on file with secret", () => {
+      const file = writeFixture("sub1.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo $(cat ${file})`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("backtick substitution should block on file with secret", () => {
+      const file = writeFixture("sub2.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo \`cat ${file}\``);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("process substitution <(...) should block on file with secret", () => {
+      const file = writeFixture("sub3.txt", `api=${AWS_KEY}`);
+      const result = runBashHook(`diff <(cat ${file}) /dev/null`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("heredoc should not false positive on harmless content", () => {
+      const result = runBashHook("cat <<EOF\nhello world\nEOF");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("environment variables", () => {
+    it("VAR expansion with default should block when var contains secret", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook(`echo $\{TOKEN:-fallback}`, {
+        env: { PATH: pathVal, TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("printenv VAR should block when var contains secret", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook("printenv SECRET", {
+        env: { PATH: pathVal, SECRET: TOKEN_VALUE },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env (single token) should block when env contains secret", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook("env", {
+        env: { PATH: pathVal, TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("printenv (single token) should block when env contains secret", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook("printenv", {
+        env: { PATH: pathVal, SECRET: TOKEN_VALUE },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env FOO=bar ls (env as launcher) should allow when no secrets", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook("env FOO=1 ls", {
+        env: { PATH: pathVal },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("VAR with default should allow when var unset", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook(`echo $\{UNSET_VAR:-safe_default}`, {
+        env: { PATH: pathVal },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("Grep tool", () => {
+    it("should block on file with secret", () => {
+      const file = writeFixture("grep_tool.txt", `key=${AWS_KEY}`);
+      const result = runGrepHook(file);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("should allow on clean file", () => {
+      const file = writeFixture("clean_grep.txt", "normal content");
+      const result = runGrepHook(file);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should block on .env file", () => {
+      const file = writeFixture(".env", `TOKEN=${TOKEN_VALUE}`);
+      const result = runGrepHook(file);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("should allow on directory path (known limitation)", () => {
+      const result = runGrepHook(tmpDir);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should allow on non-existent path", () => {
+      const result = runGrepHook(join(tmpDir, "nonexistent.txt"));
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("classic cat should still block on secret", () => {
+      const file = writeFixture("classic.txt", `password=${AWS_KEY}`);
+      const result = runBashHook(`cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("piped commands should work", () => {
+      const file = writeFixture("pipe.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat ${file} | grep key`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("multiple arguments should all be scanned", () => {
+      const file1 = writeFixture("f1.txt", "clean");
+      const file2 = writeFixture("f2.txt", `secret=${AWS_KEY}`);
+      const result = runBashHook(`cat ${file1} ${file2}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+
+  describe("wrapper commands", () => {
+    it("sudo cat <secretFile> should block", () => {
+      const file = writeFixture("sudo_cat.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`sudo cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("env FOO=1 cat <secretFile> should block", () => {
+      const file = writeFixture("env_cat.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`env FOO=1 cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("timeout 5 cat <secretFile> should block", () => {
+      const file = writeFixture("timeout_cat.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`timeout 5 cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("xargs cat (no file argument) should allow", () => {
+      const result = runBashHook(`xargs cat`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("sudo ls <secretFile> (ls doesn't output content) should allow", () => {
+      const file = writeFixture("sudo_ls.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`sudo ls ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("inline scripts", () => {
+    it("python3 -c with file read should block", () => {
+      const file = writeFixture("python_script.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`python3 -c "print(open('${file}').read())"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("sh -c 'cat <secretFile>' should block", () => {
+      const file = writeFixture("sh_c.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`sh -c "cat ${file}"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("bash -c 'cat <secretFile>' should block", () => {
+      const file = writeFixture("bash_c.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`bash -c 'cat ${file}'`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("perl -pe with file should block", () => {
+      const file = writeFixture("perl_file.txt", `pass=${TOKEN_VALUE}`);
+      const result = runBashHook(`perl -pe 's/a/b/' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("node -e without file reference should allow", () => {
+      const result = runBashHook(`node -e "console.log(1)"`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("sh -c 'echo hello world' should allow", () => {
+      const result = runBashHook(`sh -c "echo hello world"`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("multi-line and chained commands", () => {
+    it("newline-separated commands should block if any reads secret", () => {
+      const file = writeFixture("multiline.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo hi\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("command1 && command2 should block if any reads secret", () => {
+      const file = writeFixture("and.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`ls && cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("command1; command2 should block if any reads secret", () => {
+      const file = writeFixture("semi.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`ls; cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("newline-separated safe commands should allow", () => {
+      const result = runBashHook(`echo one\necho two`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("git subcommands", () => {
+    it("git diff <secretFile> should block", () => {
+      const file = writeFixture("git_diff.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`git diff ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("git show <secretFile> should block", () => {
+      const file = writeFixture("git_show.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`git show ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("git blame <secretFile> should block", () => {
+      const file = writeFixture("git_blame.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`git blame ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("git status should allow", () => {
+      const result = runBashHook(`git status`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("git log --oneline -5 should allow", () => {
+      const result = runBashHook(`git log --oneline -5`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("git add <secretFile> (add doesn't output content) should allow", () => {
+      const file = writeFixture("git_add.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`git add ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("quoted paths and dd", () => {
+    it("filename with space should block when secret is read", () => {
+      const file = writeFixture("with space.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat "${file}"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("dd if=<secretFile> should block", () => {
+      const file = writeFixture("dd_file.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`dd if=${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("wc -l <secretFile> (wc outputs only count) should allow", () => {
+      const file = writeFixture("wc_file.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`wc -l ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("other tools and MCP", () => {
+    it("mcp__filesystem__read_text_file should block on secret", () => {
+      const file = writeFixture("mcp_secret.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__filesystem__read_text_file", {
+        path: file,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("mcp tool with nested path should block", () => {
+      const file = writeFixture("mcp_nested.txt", `secret=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__example__tool", {
+        arguments: { file_path: file },
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("mcp tool with nonexistent path should allow", () => {
+      const result = runToolHook("mcp__example__tool", {
+        path: "/api/v1/users",
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("Write tool should allow (write operations are not checked)", () => {
+      const file = writeFixture("write_target.txt", "");
+      const result = runToolHook("Write", {
+        file_path: file,
+        content: "x",
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("Glob tool should allow (not checked)", () => {
+      const file = writeFixture("glob_target.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("Glob", {
+        pattern: "*.ts",
+        path: file,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("TodoWrite tool should allow (not checked)", () => {
+      const result = runToolHook("TodoWrite", {
+        todos: [],
+      });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("expanded read commands (additional)", () => {
+    it("strings <secretFile> should block", () => {
+      const file = writeFixture("strings_file.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`strings ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("diff <secretFile> /dev/null should block", () => {
+      const file = writeFixture("diff_file.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`diff ${file} /dev/null`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+
+    it("comm <secretFile> /dev/null should block", () => {
+      const file = writeFixture("comm_file.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`comm ${file} /dev/null`);
+      expect(result.exitCode).toBe(2);
+      expect(result.decision).toBe("block");
+    });
+  });
+});

--- a/src/__tests__/pre-tool-use-hook.integration.test.ts
+++ b/src/__tests__/pre-tool-use-hook.integration.test.ts
@@ -1,0 +1,121 @@
+// The only test that exercises the other side of the hook contract.
+//
+// Every other test spawns the hook and reads its output itself, so the whole
+// suite can pass while Claude Code ignores everything the hook says. Nothing
+// there distinguishes a channel the runtime reads from one it does not. This
+// test runs a real headless session with the hook installed and asserts both
+// halves of the contract: the read is stopped, and the reason arrives.
+//
+// Its negative control was run by hand — a hook that exits 2 with no output at
+// all makes the session report only `No stderr output`, and the assertion below
+// fails. So the test is not vacuous.
+//
+// It needs credentials and network, so it is opt-in: set
+// SENSITIVE_CANARY_INTEGRATION=1 to run it. CI skips it. Run it by hand when the
+// block contract changes — see the "Integration test" section in CONTRIBUTING.md.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { HOOK } from "./hook-harness.ts";
+
+const ENABLED = process.env["SENSITIVE_CANARY_INTEGRATION"] === "1";
+
+// Not the canonical AKIAIOSFODNN7EXAMPLE the other tests use. That string is
+// famous enough that the session recites it from memory when asked about AWS
+// keys, and the assertion below cannot tell a recital from a leak. This value
+// has the same shape and is not in any model's training data.
+const AWS_KEY = ["AKIA", "3QF7ZLM2", "VXKD9WTB"].join("");
+
+// A headless session is a network round trip; give it room.
+const TIMEOUT_MS = 180_000;
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "sensitive-canary-integration-"));
+  writeFileSync(join(dir, "config.txt"), `aws_key=${AWS_KEY}\n`, "utf8");
+  writeFileSync(
+    join(dir, "settings.json"),
+    JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Read|Bash|Grep|mcp__.*",
+            hooks: [
+              {
+                // A hook command is run by a shell, so the path is quoted: a
+                // checkout under a directory with spaces would otherwise arrive
+                // as two arguments.
+                type: "command",
+                command: `node --experimental-strip-types "${HOOK}"`,
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    "utf8",
+  );
+});
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+// `claude -p` with the hook registered through --settings, run inside the
+// fixture directory so the file is a plain relative path in the workspace.
+// bypassPermissions keeps the run from stalling on a prompt no one can answer;
+// hooks still run, which is the point.
+function runHeadless(prompt: string): string {
+  const result = spawnSync(
+    "claude",
+    [
+      "-p",
+      prompt,
+      "--settings",
+      join(dir, "settings.json"),
+      "--permission-mode",
+      "bypassPermissions",
+    ],
+    { encoding: "utf8", cwd: dir, timeout: TIMEOUT_MS },
+  );
+
+  // A session that never ran would satisfy the leak assertion for the wrong
+  // reason — no output cannot contain a secret — and then fail the second one
+  // with nothing to explain why. Say so here instead.
+  if (result.error) {
+    throw new Error(
+      `could not run \`claude -p\`: ${result.error.message}. The integration test needs the Claude Code CLI on PATH and a signed-in session.`,
+    );
+  }
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  if (output.trim() === "") {
+    throw new Error(
+      `\`claude -p\` produced no output (exit ${result.status}). Check that the CLI is signed in.`,
+    );
+  }
+  return output;
+}
+
+describe.skipIf(!ENABLED)("PreToolUse hook in a live session", () => {
+  it(
+    "stops the read and tells Claude why",
+    () => {
+      const output = runHeadless(
+        "Read config.txt and tell me the value of aws_key.",
+      );
+
+      // Half one: the secret did not reach the conversation.
+      expect(output).not.toContain(AWS_KEY);
+
+      // Half two: the reason arrived. The allow-tag guidance is asserted rather
+      // than the word "sensitive-canary", which also appears in the message
+      // written to the terminal and would pass on that alone.
+      expect(output.toLowerCase()).toContain("allow-secret");
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -1,22 +1,10 @@
-import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
-const HOOK = new URL("../pre-tool-use-hook.ts", import.meta.url).pathname;
-const NODE_FLAGS = ["--experimental-strip-types"];
+import { runBashHook, runHook, runHookWithRawInput } from "./hook-harness.ts";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
-
-function parseHookOutput(stdout: string) {
-  try {
-    const parsed = JSON.parse(stdout) as { decision?: string; reason?: string };
-    return { decision: parsed.decision ?? null, reason: parsed.reason ?? null };
-  } catch {
-    return { decision: null, reason: null };
-  }
-}
 
 let transcriptSeq = 0;
 
@@ -53,55 +41,6 @@ function writeTranscriptWithToolResults(
   const p = join(tmpDir, `transcript-${++transcriptSeq}.jsonl`);
   writeFileSync(p, lines.join("\n"), "utf8");
   return p;
-}
-
-function runHook(
-  toolName: string,
-  filePath: string,
-  opts?: { env?: Record<string, string>; transcriptPath?: string },
-) {
-  const input = JSON.stringify({
-    transcript_path: opts?.transcriptPath,
-    tool_name: toolName,
-    tool_input: { file_path: filePath },
-  });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: { ...process.env, ...opts?.env },
-  });
-  const { decision, reason } = parseHookOutput(result.stdout);
-  return {
-    exitCode: result.status ?? -1,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    decision,
-    reason,
-  };
-}
-
-function runBashHook(
-  command: string,
-  opts?: { env?: Record<string, string>; transcriptPath?: string },
-) {
-  const input = JSON.stringify({
-    transcript_path: opts?.transcriptPath,
-    tool_name: "Bash",
-    tool_input: { command },
-  });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: { ...process.env, ...opts?.env },
-  });
-  const { decision, reason } = parseHookOutput(result.stdout);
-  return {
-    exitCode: result.status ?? -1,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    decision,
-    reason,
-  };
 }
 
 // ── temp directory for fixture files ─────────────────────────────────────────
@@ -700,11 +639,8 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
 
 describe("pre-tool-use-hook — malformed input", () => {
   it("exits 0 on invalid JSON", () => {
-    const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-      input: "not json",
-      encoding: "utf8",
-    });
-    expect(result.status).toBe(0);
+    const result = runHookWithRawInput("not json");
+    expect(result.exitCode).toBe(0);
   });
 });
 

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -351,6 +351,15 @@ function tokenizeCommand(command: string): string[][] {
     }
 
     if (ch === "<" || ch === ">") {
+      // A file-descriptor prefix belongs to the operator, not to a token of its
+      // own: `env 2>err` has to tokenize like `env >err`, or the `2` reads as
+      // env's subcommand and the environment dump goes unnoticed. The number
+      // names neither a file nor a command, so it is dropped. Only digits
+      // written against the operator count, leaving `sort 1 >out` alone.
+      if (hasCurrent && /^\d+$/.test(current)) {
+        current = "";
+        hasCurrent = false;
+      }
       endToken();
       let op = ch;
       i++;

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -558,12 +558,20 @@ function isClassifiableCommand(name: string): boolean {
   );
 }
 
+// Commands a wrapper may hand off to. Beyond the classifiable ones, `env` and
+// `printenv` count here — and only here — so wrapper operands do not hide an
+// environment dump: `sudo -u root printenv` must still find printenv.
+function isWrapperTarget(name: string): boolean {
+  return isClassifiableCommand(name) || name === "env" || name === "printenv";
+}
+
 // Index of the token naming the command whose operands matter.
 //
 // The lead command is the first token that is not a flag, redirection or
 // `VAR=value` assignment. Only a known wrapper (`sudo`, `env`, `timeout`, …)
 // is peeled, by searching the rest of the segment for the first token this
-// hook can classify; anything else is treated as the command itself. Searching
+// hook can classify (`env` and `printenv` included, so their detection behind
+// wrapper operands works); anything else is treated as the command itself. Searching
 // unconditionally mistook operands for commands: `echo cat secrets` resolved
 // to `cat`, and a file that was never read was scanned and blocked. Wrappers
 // are still not peeled by counting their flags: `sudo -u root cat f` would
@@ -590,80 +598,71 @@ function findCommandIndex(tokens: string[]): number {
   for (let i = lead + 1; i < tokens.length; i++) {
     const tok = tokens[i] ?? "";
     if (isNonCommandToken(tok)) continue;
-    if (isClassifiableCommand(path.basename(tok))) return i;
+    if (isWrapperTarget(path.basename(tok))) return i;
   }
   return lead;
 }
 
 // `env` and `printenv` print the environment unless they are being used to run
-// another command. `sudo printenv` counts; `env FOO=1 cat f` does not.
+// another command. `sudo printenv` counts; `env FOO=1 cat f` does not. The
+// command is located with findCommandIndex, so wrapper flags and operands
+// (`sudo -u root printenv`, `timeout 5 env`) cannot hide it.
 function inspectEnvironmentCommand(tokens: string[]): {
   dumps: boolean;
   named: string[];
 } {
   const nothing = { dumps: false, named: [] };
 
-  for (let i = 0; i < tokens.length; i++) {
-    const tok = tokens[i] ?? "";
-    if (isNonCommandToken(tok)) continue;
+  const start = findCommandIndex(tokens);
+  const cmdToken = tokens[start];
+  if (cmdToken === undefined) return nothing;
 
-    const name = path.basename(tok);
-    if (name !== "env" && name !== "printenv") {
-      // Wrappers may still precede it; any other command rules both out.
-      if (
-        WRAPPER_COMMANDS.has(name) ||
-        WRAPPER_COMMANDS_WITH_OPERAND.has(name)
-      ) {
-        continue;
-      }
-      return nothing;
-    }
+  const name = path.basename(cmdToken);
+  if (name !== "env" && name !== "printenv") return nothing;
 
-    const operands = tokens.slice(i + 1).filter((t) => !isNonCommandToken(t));
-    if (name === "printenv") {
-      return operands.length === 0
-        ? { dumps: true, named: [] }
-        : { dumps: false, named: operands };
-    }
-    // `env` prints the environment unless a subcommand follows its own
-    // arguments: assignments (`FOO=1`), flags, and the values of flags that
-    // take one (`-u FOO`, `-C dir`) are all env's own. The `-S` split string
-    // is the subcommand itself (`env -S "cat f"` runs cat), so it rules a dump
-    // out. With no subcommand the whole environment is printed — `env FOO=1`
-    // and `env -u FOO` included. Exception: `-i` starts from an empty
-    // environment, so only the given assignments (already scanned as command
-    // text) print.
-    if (name === "env") {
-      const rest = tokens.slice(i + 1);
-      let ignoreEnvironment = false;
-      let hasCommand = false;
-      for (let j = 0; j < rest.length; j++) {
-        const t = rest[j] ?? "";
-        if (t === "-i" || t === "--ignore-environment") {
-          ignoreEnvironment = true;
-          continue;
-        }
-        if (t === "<" || t === ">" || t === "<<" || t === ">>") {
-          j++; // redirection operator: its target is env's own argument here
-          continue;
-        }
-        if (t === "-u" || t === "--unset" || t === "-C" || t === "--chdir") {
-          j++; // flag value
-          continue;
-        }
-        if (t === "-S" || t === "--split-string") {
-          hasCommand = true; // the split string is the subcommand
-          break;
-        }
-        if (isNonCommandToken(t)) continue; // flags and FOO=1 assignments
-        hasCommand = true;
-        break;
-      }
-      return { dumps: !hasCommand && !ignoreEnvironment, named: [] };
-    }
+  if (name === "printenv") {
+    const operands = tokens
+      .slice(start + 1)
+      .filter((t) => !isNonCommandToken(t));
+    return operands.length === 0
+      ? { dumps: true, named: [] }
+      : { dumps: false, named: operands };
   }
 
-  return nothing;
+  // `env` prints the environment unless a subcommand follows its own
+  // arguments: assignments (`FOO=1`), flags, and the values of flags that
+  // take one (`-u FOO`, `-C dir`) are all env's own. The `-S` split string
+  // is the subcommand itself (`env -S "cat f"` runs cat), so it rules a dump
+  // out. With no subcommand the whole environment is printed — `env FOO=1`
+  // and `env -u FOO` included. Exception: `-i` starts from an empty
+  // environment, so only the given assignments (already scanned as command
+  // text) print.
+  const rest = tokens.slice(start + 1);
+  let ignoreEnvironment = false;
+  let hasCommand = false;
+  for (let j = 0; j < rest.length; j++) {
+    const t = rest[j] ?? "";
+    if (t === "-i" || t === "--ignore-environment") {
+      ignoreEnvironment = true;
+      continue;
+    }
+    if (t === "<" || t === ">" || t === "<<" || t === ">>") {
+      j++; // redirection operator: its target is env's own argument here
+      continue;
+    }
+    if (t === "-u" || t === "--unset" || t === "-C" || t === "--chdir") {
+      j++; // flag value
+      continue;
+    }
+    if (t === "-S" || t === "--split-string") {
+      hasCommand = true; // the split string is the subcommand
+      break;
+    }
+    if (isNonCommandToken(t)) continue; // flags and FOO=1 assignments
+    hasCommand = true;
+    break;
+  }
+  return { dumps: !hasCommand && !ignoreEnvironment, named: [] };
 }
 
 // True when `token` introduces inline program text for `cmd`. POSIX shells only

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -150,8 +150,12 @@ const COUNT_ONLY_COMMANDS = new Set([
   "sha256sum",
 ]);
 
-// Commands whose first non-flag argument is a pattern, expression or script name,
+// Commands whose first non-flag argument is a pattern, expression or script,
 // and whose remaining non-flag arguments are files written to stdout.
+// General-purpose runtimes (`python`, `node`, `deno`, `bun`) are absent: they
+// execute their first argument rather than print it, and the files named after
+// it are argv, not output. Their inline code (`-c`, `-e`) is still scanned via
+// INLINE_CODE_COMMANDS.
 const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
   "sed",
   "awk",
@@ -165,11 +169,6 @@ const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
   "yq",
   "perl",
   "ruby",
-  "python",
-  "python3",
-  "node",
-  "deno",
-  "bun",
 ]);
 
 // Commands that run another command. They are stripped so the wrapped command
@@ -826,10 +825,14 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
       continue;
     }
 
-    const ddInput = /^if=(.+)$/.exec(tok);
-    if (ddInput?.[1]) {
-      paths.push(ddInput[1]);
-      continue;
+    // `if=<file>` names an input only for `dd`; other commands taking an
+    // `if=` argument are not reading the file it names.
+    if (cmd === "dd") {
+      const ddInput = /^if=(.+)$/.exec(tok);
+      if (ddInput?.[1]) {
+        paths.push(ddInput[1]);
+        continue;
+      }
     }
 
     if (behaviour.firstOperandIsPatternOrScript && !patternSkipped) {

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -659,8 +659,9 @@ function isInlineCodeFlag(cmd: string, token: string): boolean {
 }
 
 // Quoted literals inside inline program text — the ".env" in
-// `python3 -c "print(open('.env').read())"`. Literals containing whitespace are
-// skipped: those are messages and patterns, not paths.
+// `python3 -c "print(open('.env').read())"`. Literals containing line breaks or
+// tabs are skipped: those are messages and patterns, not paths. Spaces are
+// kept, so a path like `open('my secret.txt')` is still found.
 function extractQuotedLiterals(code: string): string[] {
   const literals: string[] = [];
   for (const match of code.matchAll(/'([^']*)'|"([^"]*)"/g)) {
@@ -668,7 +669,7 @@ function extractQuotedLiterals(code: string): string[] {
     if (
       value &&
       value.length <= MAX_QUOTED_LITERAL_LENGTH &&
-      !/\s/.test(value)
+      !/[\t\r\n]/.test(value)
     ) {
       literals.push(value);
     }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -642,6 +642,13 @@ function extractSubstitutions(command: string): string[] {
   return found;
 }
 
+// True for a redirection operator token: `<`, `>`, `<<`, `>>`, `<<<`. The
+// tokenizer emits each on its own, with any file-descriptor prefix dropped, and
+// the token after one is a target or a heredoc delimiter rather than an operand.
+function isRedirectionOperator(token: string): boolean {
+  return /^[<>]+$/.test(token);
+}
+
 // True for a token that cannot name a command: a flag, a redirection operator,
 // or a `VAR=value` assignment placed before one.
 function isNonCommandToken(token: string): boolean {
@@ -729,13 +736,25 @@ function inspectEnvironmentCommand(tokens: string[]): {
   const name = path.basename(cmdToken);
   if (name !== "env" && name !== "printenv") return nothing;
 
+  // `printenv` prints the whole environment unless it is given variables to
+  // print. A redirection target is not one of them: `printenv > out.txt` prints
+  // everything, and counting `out.txt` as a named variable left the environment
+  // unscanned.
   if (name === "printenv") {
-    const operands = tokens
-      .slice(start + 1)
-      .filter((t) => !isNonCommandToken(t));
-    return operands.length === 0
+    const rest = tokens.slice(start + 1);
+    const named: string[] = [];
+    for (let j = 0; j < rest.length; j++) {
+      const t = rest[j] ?? "";
+      if (isRedirectionOperator(t)) {
+        j++; // its target, or a heredoc delimiter
+        continue;
+      }
+      if (isNonCommandToken(t)) continue; // flags
+      named.push(t);
+    }
+    return named.length === 0
       ? { dumps: true, named: [] }
-      : { dumps: false, named: operands };
+      : { dumps: false, named };
   }
 
   // `env` prints the environment unless a subcommand follows its own
@@ -755,7 +774,7 @@ function inspectEnvironmentCommand(tokens: string[]): {
       ignoreEnvironment = true;
       continue;
     }
-    if (t === "<" || t === ">" || t === "<<" || t === ">>") {
+    if (isRedirectionOperator(t)) {
       j++; // redirection operator: its target is env's own argument here
       continue;
     }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -15,9 +15,10 @@ import { enabledCategoriesFromEnv, type Finding, scan } from "./lib/rules.ts";
 interface HookInput {
   transcript_path?: string;
   tool_name?: string;
-  tool_input?: {
+  tool_input?: Record<string, unknown> & {
     file_path?: string;
     command?: string;
+    path?: string;
   };
 }
 
@@ -99,6 +100,8 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
 
 // ── Bash helpers ──────────────────────────────────────────────────────────────
 
+// Commands that write the contents of every non-flag argument to stdout.
+// `wc` is deliberately absent: it reports counts, never the bytes themselves.
 const FILE_READ_COMMANDS = new Set([
   "cat",
   "head",
@@ -107,11 +110,132 @@ const FILE_READ_COMMANDS = new Set([
   "more",
   "bat",
   "nl",
+  "tac",
+  "rev",
+  "strings",
+  "xxd",
+  "od",
+  "hexdump",
+  "base64",
+  "cut",
+  "sort",
+  "uniq",
+  "shuf",
+  "column",
+  "paste",
+  "fold",
+  "fmt",
+  "pr",
+  "expand",
+  "unexpand",
+  "iconv",
+  "zcat",
+  "gzcat",
+  "bzcat",
+  "xzcat",
+  "zstdcat",
+  "diff",
+  "comm",
+  "join",
+  "look",
 ]);
 
+// Commands whose first non-flag argument is a pattern, expression or script,
+// and whose remaining non-flag arguments are files written to stdout.
+const PATTERN_FIRST_READ_COMMANDS = new Set([
+  "sed",
+  "awk",
+  "gawk",
+  "grep",
+  "egrep",
+  "fgrep",
+  "rg",
+  "ag",
+  "jq",
+  "yq",
+  "perl",
+  "ruby",
+  "python",
+  "python3",
+  "node",
+  "deno",
+  "bun",
+]);
+
+// Commands that run another command. They are stripped so the wrapped command
+// is classified instead: `sudo cat secrets` is treated as `cat secrets`.
+const WRAPPER_COMMANDS = new Set([
+  "sudo",
+  "doas",
+  "command",
+  "builtin",
+  "exec",
+  "nohup",
+  "time",
+  "nice",
+  "ionice",
+  "stdbuf",
+  "xargs",
+  "env",
+]);
+
+// Wrappers that take one operand of their own before the wrapped command
+// (`timeout 5 cat f`, `flock /tmp/lock cat f`).
+const WRAPPER_COMMANDS_WITH_OPERAND = new Set(["timeout", "flock"]);
+
+// Interpreters that accept inline program text, which is scanned both as a
+// nested command line and for quoted path literals.
+const INLINE_CODE_COMMANDS = new Set([
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "ksh",
+  "python",
+  "python3",
+  "perl",
+  "ruby",
+  "node",
+  "deno",
+  "bun",
+  "php",
+]);
+
+const POSIX_SHELLS = new Set(["sh", "bash", "zsh", "dash", "ksh"]);
+
+// git subcommands that can write file contents to stdout. Blob references such
+// as `git show HEAD:.env` name history, not the working tree, and stay
+// uncovered — only paths that exist on disk are scanned.
+const GIT_READ_SUBCOMMANDS = new Set([
+  "show",
+  "diff",
+  "log",
+  "blame",
+  "annotate",
+  "grep",
+  "cat-file",
+  "difftool",
+  "stash",
+]);
+
+// Recursion limit for command substitutions and inline scripts.
+const MAX_NESTING_DEPTH = 4;
+
+// References a single Bash command makes to data the hook can inspect.
+interface CommandRefs {
+  // File paths whose contents the command may write to stdout.
+  paths: string[];
+  // Environment variables the command names explicitly.
+  envVars: string[];
+  // Whether the command dumps the whole environment (bare `env` / `printenv`).
+  dumpsEnvironment: boolean;
+}
+
+// Variable names referenced by the command, including expansion forms that carry
+// a suffix such as `${TOKEN:-fallback}` or `${TOKEN#prefix}`.
 function extractEnvVarNames(command: string): string[] {
   const names = new Set<string>();
-  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
   for (const match of command.matchAll(re)) {
     const name = match[1] ?? match[2];
     if (name) names.add(name);
@@ -119,35 +243,317 @@ function extractEnvVarNames(command: string): string[] {
   return [...names];
 }
 
-function extractFilePathsFromCommand(command: string): string[] {
+// Split a command line into segments (at |, ;, &, &&, || and newlines) and each
+// segment into tokens with quotes removed. Redirection operators become tokens of
+// their own so that `wc -l <f` and `wc -l < f` tokenize alike. Substitutions are
+// left in place; extractSubstitutions handles them against the raw string.
+function tokenizeCommand(command: string): string[][] {
+  const segments: string[][] = [];
+  let tokens: string[] = [];
+  let current = "";
+  let hasCurrent = false;
+  let i = 0;
+
+  const endToken = (): void => {
+    if (hasCurrent) {
+      tokens.push(current);
+      current = "";
+      hasCurrent = false;
+    }
+  };
+  const endSegment = (): void => {
+    endToken();
+    if (tokens.length > 0) segments.push(tokens);
+    tokens = [];
+  };
+
+  while (i < command.length) {
+    const ch = command[i] as string;
+
+    if (ch === "\\") {
+      const next = command[i + 1];
+      if (next !== undefined && next !== "\n") {
+        current += next;
+        hasCurrent = true;
+      }
+      i += next === undefined ? 1 : 2;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      i++;
+      hasCurrent = true;
+      while (i < command.length && command[i] !== ch) {
+        if (ch === '"' && command[i] === "\\" && command[i + 1] !== undefined) {
+          current += command[i + 1];
+          i += 2;
+          continue;
+        }
+        current += command[i];
+        i++;
+      }
+      i++; // closing quote, or end of input for an unbalanced one
+      continue;
+    }
+
+    if (ch === "|" || ch === ";" || ch === "&" || ch === "\n") {
+      endSegment();
+      while (i < command.length && /[|;&\n\s]/.test(command[i] as string)) i++;
+      continue;
+    }
+
+    if (ch === "<" || ch === ">") {
+      endToken();
+      let op = ch;
+      i++;
+      while (i < command.length && command[i] === ch) {
+        op += ch;
+        i++;
+      }
+      tokens.push(op);
+      continue;
+    }
+
+    if (ch === " " || ch === "\t" || ch === "\r") {
+      endToken();
+      i++;
+      continue;
+    }
+
+    current += ch;
+    hasCurrent = true;
+    i++;
+  }
+
+  endSegment();
+  return segments;
+}
+
+// Inner text of every command substitution, process substitution and backtick
+// expression, innermost first. Each is a command line in its own right.
+function extractSubstitutions(command: string): string[] {
+  const found: string[] = [];
+  let remaining = command;
+
+  for (let pass = 0; pass < 8; pass++) {
+    const before = remaining;
+    remaining = remaining
+      .replace(/\$\(([^()]*)\)/g, (_, inner: string) => {
+        found.push(inner);
+        return " ";
+      })
+      .replace(/<\(([^()]*)\)/g, (_, inner: string) => {
+        found.push(inner);
+        return " ";
+      })
+      .replace(/`([^`]*)`/g, (_, inner: string) => {
+        found.push(inner);
+        return " ";
+      });
+    if (remaining === before) break;
+  }
+
+  return found;
+}
+
+// Index of the token naming the command actually being run, after stripping
+// wrappers such as `sudo`, `env VAR=1`, `timeout 5` and `xargs -0`.
+function resolveCommandStart(tokens: string[]): number {
+  let i = 0;
+
+  while (i < tokens.length) {
+    const name = path.basename(tokens[i] as string);
+
+    if (WRAPPER_COMMANDS_WITH_OPERAND.has(name)) {
+      i++;
+      while (i < tokens.length && (tokens[i] as string).startsWith("-")) i++;
+      i++; // the wrapper's own operand (duration, lock file)
+      continue;
+    }
+
+    if (WRAPPER_COMMANDS.has(name)) {
+      i++;
+      while (i < tokens.length) {
+        const next = tokens[i] as string;
+        if (next.startsWith("-") || /^[A-Za-z_][A-Za-z0-9_]*=/.test(next)) {
+          i++;
+          continue;
+        }
+        break;
+      }
+      continue;
+    }
+
+    return i;
+  }
+
+  return tokens.length;
+}
+
+// True when `token` introduces inline program text for `cmd`. POSIX shells only
+// take code after -c; other interpreters also use -e and combined forms (-pe).
+function isInlineCodeFlag(cmd: string, token: string): boolean {
+  if (token === "-c" || token === "--command" || token === "--eval")
+    return true;
+  if (POSIX_SHELLS.has(cmd)) return false;
+  if (token === "-r") return true; // php -r
+  return /^-[A-Za-z]*[eE]$/.test(token);
+}
+
+// Quoted literals inside inline program text — the ".env" in
+// `python3 -c "print(open('.env').read())"`. Literals containing whitespace are
+// skipped: those are messages and patterns, not paths.
+function extractQuotedLiterals(code: string): string[] {
+  const literals: string[] = [];
+  for (const match of code.matchAll(/'([^']*)'|"([^"]*)"/g)) {
+    const value = match[1] ?? match[2];
+    if (value && value.length <= 4096 && !/\s/.test(value)) {
+      literals.push(value);
+    }
+  }
+  return literals;
+}
+
+// Everything a Bash command reveals that the hook can inspect before it runs:
+// the files whose contents it may print, and the environment it may expose.
+function extractCommandRefs(command: string, depth = 0): CommandRefs {
   const paths: string[] = [];
-  const segments = command.split(/\s*[|;&]+\s*/);
+  const envVars: string[] = [];
+  let dumpsEnvironment = false;
 
-  for (const seg of segments) {
-    const tokens = seg.trim().split(/\s+/).filter(Boolean);
-    if (tokens.length < 2) continue;
+  if (depth > MAX_NESTING_DEPTH) return { paths, envVars, dumpsEnvironment };
 
-    const cmd = path.basename(tokens[0] ?? "");
-    if (!FILE_READ_COMMANDS.has(cmd)) continue;
+  const merge = (refs: CommandRefs): void => {
+    paths.push(...refs.paths);
+    envVars.push(...refs.envVars);
+    dumpsEnvironment = dumpsEnvironment || refs.dumpsEnvironment;
+  };
+
+  // `echo $(cat secrets)` reads secrets just as `cat secrets` does.
+  for (const inner of extractSubstitutions(command)) {
+    merge(extractCommandRefs(inner, depth + 1));
+  }
+
+  for (const tokens of tokenizeCommand(command)) {
+    // `env` and `printenv` with no command to run print the environment itself.
+    const leadName = path.basename(tokens[0] as string);
+    if (leadName === "env" || leadName === "printenv") {
+      const named = tokens
+        .slice(1)
+        .filter(
+          (t) => !t.startsWith("-") && !t.startsWith("<") && !t.startsWith(">"),
+        );
+      const assignments = named.filter((t) =>
+        /^[A-Za-z_][A-Za-z0-9_]*=/.test(t),
+      );
+      const rest = named.filter((t) => !assignments.includes(t));
+      if (
+        rest.length === 0 &&
+        (leadName === "printenv" || !assignments.length)
+      ) {
+        dumpsEnvironment = true;
+      } else if (leadName === "printenv") {
+        envVars.push(...rest);
+      }
+    }
+
+    const start = resolveCommandStart(tokens);
+    const cmdToken = tokens[start];
+    if (cmdToken === undefined) continue;
+
+    const cmd = path.basename(cmdToken);
+    const operands = tokens.slice(start + 1);
+
+    // `sed -i` edits in place and writes nothing to stdout.
+    if (
+      cmd === "sed" &&
+      operands.some((t) => /^-i/.test(t) || t === "--in-place")
+    ) {
+      continue;
+    }
+
+    const isFileReadCmd = FILE_READ_COMMANDS.has(cmd);
+    const isPatternFirst = PATTERN_FIRST_READ_COMMANDS.has(cmd);
+    const isInlineCodeCmd = INLINE_CODE_COMMANDS.has(cmd);
+    const isGit = cmd === "git";
 
     let skipNext = false;
-    for (let i = 1; i < tokens.length; i++) {
+    let collectNext = false;
+    let codeNext = false;
+    let patternSkipped = false;
+    let gitSubcommandSeen = false;
+    let gitReadsFiles = false;
+
+    for (const tok of operands) {
       if (skipNext) {
         skipNext = false;
         continue;
       }
-      const tok = tokens[i];
-      if (!tok) continue;
-      if (tok.startsWith("-")) continue;
-      if (tok === ">" || tok === ">>" || tok === "<") {
-        skipNext = true;
+      if (collectNext) {
+        collectNext = false;
+        paths.push(tok);
         continue;
       }
-      paths.push(tok);
+      if (codeNext) {
+        codeNext = false;
+        // The expression came from -e/-c, so a later operand is a file, not the
+        // script `perl file` would have run.
+        patternSkipped = true;
+        merge(extractCommandRefs(tok, depth + 1));
+        paths.push(...extractQuotedLiterals(tok));
+        continue;
+      }
+
+      if (tok === "<") {
+        collectNext = true; // stdin is fed from the next token
+        continue;
+      }
+      if (tok.startsWith("<")) {
+        skipNext = true; // heredoc / herestring delimiter, not a path
+        continue;
+      }
+      if (tok.startsWith(">")) {
+        skipNext = true; // output target, never read
+        continue;
+      }
+
+      if (isInlineCodeCmd && isInlineCodeFlag(cmd, tok)) {
+        codeNext = true;
+        continue;
+      }
+
+      if (tok.startsWith("-")) continue;
+
+      if (isGit) {
+        if (!gitSubcommandSeen) {
+          gitSubcommandSeen = true;
+          gitReadsFiles = GIT_READ_SUBCOMMANDS.has(tok);
+          continue;
+        }
+        if (gitReadsFiles) paths.push(tok);
+        continue;
+      }
+
+      const ddInput = /^if=(.+)$/.exec(tok);
+      if (ddInput?.[1]) {
+        paths.push(ddInput[1]);
+        continue;
+      }
+
+      if (isPatternFirst && !patternSkipped) {
+        patternSkipped = true; // the pattern, expression or script name
+        continue;
+      }
+
+      if (isFileReadCmd || isPatternFirst) paths.push(tok);
     }
   }
 
-  return [...new Set(paths)];
+  return {
+    paths: [...new Set(paths)],
+    envVars: [...new Set(envVars)],
+    dumpsEnvironment,
+  };
 }
 
 // ── .env pattern ──────────────────────────────────────────────────────────────
@@ -245,7 +651,79 @@ function block(
   process.exit(2);
 }
 
+// ── Tool input inspection ─────────────────────────────────────────────────────
+
+// Tools that never surface the contents of a file they name. Scanning these
+// would block writing to a file that already holds a secret, which is not a leak.
+const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
+  "Write",
+  "Edit",
+  "MultiEdit",
+  "NotebookEdit",
+  "TodoWrite",
+  "Glob",
+  "WebFetch",
+  "WebSearch",
+  "ExitPlanMode",
+  "AskUserQuestion",
+]);
+
+// Input field names that commonly carry a filesystem path.
+const PATH_FIELD_NAMES = new Set([
+  "file_path",
+  "filePath",
+  "path",
+  "file",
+  "filename",
+  "fileName",
+  "absolute_path",
+  "notebook_path",
+  "source",
+  "src",
+  "paths",
+  "files",
+]);
+
+function collectPathFields(
+  input: Record<string, unknown>,
+  depth = 0,
+): string[] {
+  if (depth > 2) return [];
+  const found: string[] = [];
+
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === "string") {
+      if (PATH_FIELD_NAMES.has(key)) found.push(value);
+    } else if (Array.isArray(value)) {
+      if (PATH_FIELD_NAMES.has(key)) {
+        found.push(...value.filter((v): v is string => typeof v === "string"));
+      }
+    } else if (value !== null && typeof value === "object") {
+      found.push(
+        ...collectPathFields(value as Record<string, unknown>, depth + 1),
+      );
+    }
+  }
+
+  return found;
+}
+
 // ── Core scan logic ───────────────────────────────────────────────────────────
+
+// Scan a candidate only when it names an existing regular file. Tools whose
+// "path" means something else (a URL route, an object key) are left alone.
+function scanIfRegularFile(
+  candidate: string | undefined,
+  allowTags: Set<string>,
+): void {
+  if (!candidate) return;
+  try {
+    if (!fs.statSync(candidate).isFile()) return;
+  } catch {
+    return;
+  }
+  scanFile(candidate, allowTags);
+}
 
 function scanFile(filePath: string, allowTags: Set<string>): void {
   if (shouldBlockEnvFile(filePath)) {
@@ -316,8 +794,14 @@ process.stdin.on("end", () => {
 
   if (tool === "Bash") {
     const command = input.command ?? "";
+    const refs = extractCommandRefs(command);
 
-    for (const varName of extractEnvVarNames(command)) {
+    // A bare `env` or `printenv` prints everything, so every variable is in play.
+    const envVarNames = refs.dumpsEnvironment
+      ? Object.keys(process.env)
+      : [...new Set([...extractEnvVarNames(command), ...refs.envVars])];
+
+    for (const varName of envVarNames) {
       const value = process.env[varName];
       if (!value) continue;
       const findings = applyAllowTags(
@@ -352,11 +836,24 @@ process.stdin.on("end", () => {
       );
     }
 
-    for (const fp of extractFilePathsFromCommand(command)) {
+    for (const fp of refs.paths) {
       scanFile(fp, allowTags);
     }
 
     process.exit(0);
+  }
+
+  if (tool === "Grep") {
+    scanIfRegularFile(input.path, allowTags);
+    process.exit(0);
+  }
+
+  // Any other tool, MCP tools included: those can return file contents the same
+  // way Read does, so a field naming an existing file is scanned before the call.
+  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool)) {
+    for (const candidate of collectPathFields(input)) {
+      scanIfRegularFile(candidate, allowTags);
+    }
   }
 
   process.exit(0);

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -1186,14 +1186,37 @@ const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
 // an MCP tool's semantics are not otherwise knowable from its input. For MCP
 // tools (`mcp__<server>__<tool>`) only the tool component is matched — a server
 // named "editor" or "readwrite" must not exempt every read tool it offers.
-const WRITING_TOOL_NAME =
-  /(write|create|edit|update|append|delete|remove|move|rename|mkdir|copy)/i;
+// The verb has to be the first word of the name, not a substring of it anywhere.
+// As a substring test this exempted reads: "update" sits inside `get_updates`,
+// and "write" inside `read_and_write_file` — a tool that returns contents was
+// treated as one that only writes. Word boundaries are the `_`/`-` in snake and
+// kebab names and the capital in camelCase, so `write_file` and `createPage`
+// still match while `overwrite_file` and `readwrite` no longer do.
+//
+// Erring this way costs a false block on a noun-first write tool (`file_write`),
+// which is the direction to fail in. The built-in write tools are named
+// explicitly in TOOLS_WITHOUT_FILE_OUTPUT, so `TodoWrite` and `MultiEdit` do not
+// depend on this at all.
+const WRITING_TOOL_VERBS = new Set([
+  "write",
+  "create",
+  "edit",
+  "update",
+  "append",
+  "delete",
+  "remove",
+  "move",
+  "rename",
+  "mkdir",
+  "copy",
+]);
 
 function isWritingTool(tool: string): boolean {
   const name = tool.startsWith("mcp__")
     ? (tool.split("__").pop() ?? tool)
     : tool;
-  return WRITING_TOOL_NAME.test(name);
+  const [first] = name.split(/[^A-Za-z0-9]+|(?=[A-Z])/).filter(Boolean);
+  return first !== undefined && WRITING_TOOL_VERBS.has(first.toLowerCase());
 }
 
 // Input field names that commonly carry a filesystem path.

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -140,9 +140,19 @@ const FILE_READ_COMMANDS = new Set([
   "look",
 ]);
 
-// Commands whose first non-flag argument is a pattern, expression or script,
+// Commands that read a file but report only measurements of it. Their stdin is
+// not echoed either, so a redirection into one of them is not a read.
+const COUNT_ONLY_COMMANDS = new Set([
+  "wc",
+  "cksum",
+  "md5sum",
+  "sha1sum",
+  "sha256sum",
+]);
+
+// Commands whose first non-flag argument is a pattern, expression or script name,
 // and whose remaining non-flag arguments are files written to stdout.
-const PATTERN_FIRST_READ_COMMANDS = new Set([
+const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
   "sed",
   "awk",
   "gawk",
@@ -220,6 +230,15 @@ const GIT_READ_SUBCOMMANDS = new Set([
 
 // Recursion limit for command substitutions and inline scripts.
 const MAX_NESTING_DEPTH = 4;
+
+// Passes made while peeling nested command substitutions.
+const MAX_SUBSTITUTION_PASSES = 8;
+
+// Longest quoted literal inside inline code still treated as a path candidate.
+const MAX_QUOTED_LITERAL_LENGTH = 4096;
+
+// Depth to which a tool's input object is searched for path-bearing fields.
+const MAX_PATH_FIELD_DEPTH = 2;
 
 // References a single Bash command makes to data the hook can inspect.
 interface CommandRefs {
@@ -335,7 +354,7 @@ function extractSubstitutions(command: string): string[] {
   const found: string[] = [];
   let remaining = command;
 
-  for (let pass = 0; pass < 8; pass++) {
+  for (let pass = 0; pass < MAX_SUBSTITUTION_PASSES; pass++) {
     const before = remaining;
     remaining = remaining
       .replace(/\$\(([^()]*)\)/g, (_, inner: string) => {
@@ -356,38 +375,80 @@ function extractSubstitutions(command: string): string[] {
   return found;
 }
 
-// Index of the token naming the command actually being run, after stripping
-// wrappers such as `sudo`, `env VAR=1`, `timeout 5` and `xargs -0`.
-function resolveCommandStart(tokens: string[]): number {
-  let i = 0;
+// True for a token that cannot name a command: a flag, a redirection operator,
+// or a `VAR=value` assignment placed before one.
+function isNonCommandToken(token: string): boolean {
+  if (token.startsWith("-") || token.startsWith("<") || token.startsWith(">")) {
+    return true;
+  }
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
 
-  while (i < tokens.length) {
-    const name = path.basename(tokens[i] as string);
+// Commands whose operands this hook knows how to interpret. `env` and `printenv`
+// are absent on purpose: they are wrappers as often as they are commands, and
+// inspectEnvironmentCommand handles the cases where they print the environment.
+function isClassifiableCommand(name: string): boolean {
+  return (
+    FILE_READ_COMMANDS.has(name) ||
+    COUNT_ONLY_COMMANDS.has(name) ||
+    PATTERN_OR_SCRIPT_FIRST_COMMANDS.has(name) ||
+    INLINE_CODE_COMMANDS.has(name) ||
+    name === "git" ||
+    name === "dd"
+  );
+}
 
-    if (WRAPPER_COMMANDS_WITH_OPERAND.has(name)) {
-      i++;
-      while (i < tokens.length && (tokens[i] as string).startsWith("-")) i++;
-      i++; // the wrapper's own operand (duration, lock file)
-      continue;
-    }
+// Index of the token naming the command whose operands matter.
+//
+// Wrappers are not peeled by counting their flags: `sudo -u root cat f` would
+// then mistake `root` for the command, and `timeout -s KILL 5 cat f` would
+// mistake `5`. The whole segment is searched for the first token this hook can
+// classify instead, which also carries `LANG=C cat f` and `xargs -n 1 cat f`.
+// Falling back to index 0 leaves an unknown command classified as itself.
+function findCommandIndex(tokens: string[]): number {
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i] ?? "";
+    if (isNonCommandToken(tok)) continue;
+    if (isClassifiableCommand(path.basename(tok))) return i;
+  }
+  return 0;
+}
 
-    if (WRAPPER_COMMANDS.has(name)) {
-      i++;
-      while (i < tokens.length) {
-        const next = tokens[i] as string;
-        if (next.startsWith("-") || /^[A-Za-z_][A-Za-z0-9_]*=/.test(next)) {
-          i++;
-          continue;
-        }
-        break;
+// `env` and `printenv` print the environment unless they are being used to run
+// another command. `sudo printenv` counts; `env FOO=1 cat f` does not.
+function inspectEnvironmentCommand(tokens: string[]): {
+  dumps: boolean;
+  named: string[];
+} {
+  const nothing = { dumps: false, named: [] };
+
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i] ?? "";
+    if (isNonCommandToken(tok)) continue;
+
+    const name = path.basename(tok);
+    if (name !== "env" && name !== "printenv") {
+      // Wrappers may still precede it; any other command rules both out.
+      if (
+        WRAPPER_COMMANDS.has(name) ||
+        WRAPPER_COMMANDS_WITH_OPERAND.has(name)
+      ) {
+        continue;
       }
-      continue;
+      return nothing;
     }
 
-    return i;
+    const operands = tokens.slice(i + 1).filter((t) => !isNonCommandToken(t));
+    if (name === "printenv") {
+      return operands.length === 0
+        ? { dumps: true, named: [] }
+        : { dumps: false, named: operands };
+    }
+    // `env` with an operand is running a command, not printing anything.
+    return { dumps: operands.length === 0, named: [] };
   }
 
-  return tokens.length;
+  return nothing;
 }
 
 // True when `token` introduces inline program text for `cmd`. POSIX shells only
@@ -407,7 +468,11 @@ function extractQuotedLiterals(code: string): string[] {
   const literals: string[] = [];
   for (const match of code.matchAll(/'([^']*)'|"([^"]*)"/g)) {
     const value = match[1] ?? match[2];
-    if (value && value.length <= 4096 && !/\s/.test(value)) {
+    if (
+      value &&
+      value.length <= MAX_QUOTED_LITERAL_LENGTH &&
+      !/\s/.test(value)
+    ) {
       literals.push(value);
     }
   }
@@ -435,118 +500,11 @@ function extractCommandRefs(command: string, depth = 0): CommandRefs {
   }
 
   for (const tokens of tokenizeCommand(command)) {
-    // `env` and `printenv` with no command to run print the environment itself.
-    const leadName = path.basename(tokens[0] as string);
-    if (leadName === "env" || leadName === "printenv") {
-      const named = tokens
-        .slice(1)
-        .filter(
-          (t) => !t.startsWith("-") && !t.startsWith("<") && !t.startsWith(">"),
-        );
-      const assignments = named.filter((t) =>
-        /^[A-Za-z_][A-Za-z0-9_]*=/.test(t),
-      );
-      const rest = named.filter((t) => !assignments.includes(t));
-      if (
-        rest.length === 0 &&
-        (leadName === "printenv" || !assignments.length)
-      ) {
-        dumpsEnvironment = true;
-      } else if (leadName === "printenv") {
-        envVars.push(...rest);
-      }
-    }
+    const environment = inspectEnvironmentCommand(tokens);
+    if (environment.dumps) dumpsEnvironment = true;
+    envVars.push(...environment.named);
 
-    const start = resolveCommandStart(tokens);
-    const cmdToken = tokens[start];
-    if (cmdToken === undefined) continue;
-
-    const cmd = path.basename(cmdToken);
-    const operands = tokens.slice(start + 1);
-
-    // `sed -i` edits in place and writes nothing to stdout.
-    if (
-      cmd === "sed" &&
-      operands.some((t) => /^-i/.test(t) || t === "--in-place")
-    ) {
-      continue;
-    }
-
-    const isFileReadCmd = FILE_READ_COMMANDS.has(cmd);
-    const isPatternFirst = PATTERN_FIRST_READ_COMMANDS.has(cmd);
-    const isInlineCodeCmd = INLINE_CODE_COMMANDS.has(cmd);
-    const isGit = cmd === "git";
-
-    let skipNext = false;
-    let collectNext = false;
-    let codeNext = false;
-    let patternSkipped = false;
-    let gitSubcommandSeen = false;
-    let gitReadsFiles = false;
-
-    for (const tok of operands) {
-      if (skipNext) {
-        skipNext = false;
-        continue;
-      }
-      if (collectNext) {
-        collectNext = false;
-        paths.push(tok);
-        continue;
-      }
-      if (codeNext) {
-        codeNext = false;
-        // The expression came from -e/-c, so a later operand is a file, not the
-        // script `perl file` would have run.
-        patternSkipped = true;
-        merge(extractCommandRefs(tok, depth + 1));
-        paths.push(...extractQuotedLiterals(tok));
-        continue;
-      }
-
-      if (tok === "<") {
-        collectNext = true; // stdin is fed from the next token
-        continue;
-      }
-      if (tok.startsWith("<")) {
-        skipNext = true; // heredoc / herestring delimiter, not a path
-        continue;
-      }
-      if (tok.startsWith(">")) {
-        skipNext = true; // output target, never read
-        continue;
-      }
-
-      if (isInlineCodeCmd && isInlineCodeFlag(cmd, tok)) {
-        codeNext = true;
-        continue;
-      }
-
-      if (tok.startsWith("-")) continue;
-
-      if (isGit) {
-        if (!gitSubcommandSeen) {
-          gitSubcommandSeen = true;
-          gitReadsFiles = GIT_READ_SUBCOMMANDS.has(tok);
-          continue;
-        }
-        if (gitReadsFiles) paths.push(tok);
-        continue;
-      }
-
-      const ddInput = /^if=(.+)$/.exec(tok);
-      if (ddInput?.[1]) {
-        paths.push(ddInput[1]);
-        continue;
-      }
-
-      if (isPatternFirst && !patternSkipped) {
-        patternSkipped = true; // the pattern, expression or script name
-        continue;
-      }
-
-      if (isFileReadCmd || isPatternFirst) paths.push(tok);
-    }
+    merge(collectSegmentRefs(tokens, depth));
   }
 
   return {
@@ -554,6 +512,136 @@ function extractCommandRefs(command: string, depth = 0): CommandRefs {
     envVars: [...new Set(envVars)],
     dumpsEnvironment,
   };
+}
+
+// What this hook knows about how a command treats its operands.
+interface CommandBehaviour {
+  // Every non-flag operand is a file written to stdout.
+  printsOperands: boolean;
+  // The first non-flag operand is a pattern or script name, the rest are files.
+  firstOperandIsPatternOrScript: boolean;
+  // -c / -e introduce inline program text.
+  takesInlineCode: boolean;
+  // Reads a file but prints only a measurement of it, and does not echo stdin.
+  printsNothing: boolean;
+  // `git <subcommand> [paths]`.
+  isGit: boolean;
+}
+
+// Single place where a command name becomes a behaviour, so a name added to one
+// list cannot silently disagree with another.
+function classifyCommand(cmd: string): CommandBehaviour {
+  return {
+    printsOperands: FILE_READ_COMMANDS.has(cmd),
+    firstOperandIsPatternOrScript: PATTERN_OR_SCRIPT_FIRST_COMMANDS.has(cmd),
+    takesInlineCode: INLINE_CODE_COMMANDS.has(cmd),
+    printsNothing: COUNT_ONLY_COMMANDS.has(cmd),
+    isGit: cmd === "git",
+  };
+}
+
+// File paths one segment of a command line may print, plus anything found inside
+// inline program text it carries.
+function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
+  const paths: string[] = [];
+  const envVars: string[] = [];
+  let dumpsEnvironment = false;
+
+  const start = findCommandIndex(tokens);
+  const cmdToken = tokens[start];
+  if (cmdToken === undefined) return { paths, envVars, dumpsEnvironment };
+
+  const cmd = path.basename(cmdToken);
+  const operands = tokens.slice(start + 1);
+
+  // `sed -i` edits in place and writes nothing to stdout.
+  if (
+    cmd === "sed" &&
+    operands.some((t) => /^-i/.test(t) || t === "--in-place")
+  ) {
+    return { paths, envVars, dumpsEnvironment };
+  }
+
+  const behaviour = classifyCommand(cmd);
+
+  let skipNext = false;
+  let collectNext = false;
+  let codeNext = false;
+  let patternSkipped = false;
+  let gitSubcommandSeen = false;
+  let gitReadsFiles = false;
+
+  for (const tok of operands) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (collectNext) {
+      collectNext = false;
+      paths.push(tok);
+      continue;
+    }
+    if (codeNext) {
+      codeNext = false;
+      // The expression came from -e/-c, so a later operand is a file, not the
+      // script `perl file` would have run.
+      patternSkipped = true;
+      const inner = extractCommandRefs(tok, depth + 1);
+      paths.push(...inner.paths, ...extractQuotedLiterals(tok));
+      envVars.push(...inner.envVars);
+      dumpsEnvironment = dumpsEnvironment || inner.dumpsEnvironment;
+      continue;
+    }
+
+    if (tok === "<") {
+      // stdin is fed from the next token, unless nothing of it is printed
+      collectNext = !behaviour.printsNothing;
+      skipNext = behaviour.printsNothing;
+      continue;
+    }
+    if (tok.startsWith("<")) {
+      skipNext = true; // heredoc / herestring delimiter, not a path
+      continue;
+    }
+    if (tok.startsWith(">")) {
+      skipNext = true; // output target, never read
+      continue;
+    }
+
+    if (behaviour.takesInlineCode && isInlineCodeFlag(cmd, tok)) {
+      codeNext = true;
+      continue;
+    }
+
+    if (tok.startsWith("-")) continue;
+
+    if (behaviour.isGit) {
+      if (!gitSubcommandSeen) {
+        gitSubcommandSeen = true;
+        gitReadsFiles = GIT_READ_SUBCOMMANDS.has(tok);
+        continue;
+      }
+      if (gitReadsFiles) paths.push(tok);
+      continue;
+    }
+
+    const ddInput = /^if=(.+)$/.exec(tok);
+    if (ddInput?.[1]) {
+      paths.push(ddInput[1]);
+      continue;
+    }
+
+    if (behaviour.firstOperandIsPatternOrScript && !patternSkipped) {
+      patternSkipped = true; // the pattern, expression or script name
+      continue;
+    }
+
+    if (behaviour.printsOperands || behaviour.firstOperandIsPatternOrScript) {
+      paths.push(tok);
+    }
+  }
+
+  return { paths, envVars, dumpsEnvironment };
 }
 
 // ── .env pattern ──────────────────────────────────────────────────────────────
@@ -668,27 +756,28 @@ const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
   "AskUserQuestion",
 ]);
 
+// A tool whose name says it writes is treated like the built-in Write and Edit:
+// naming a file it does not read is not a leak. Matched on the tool name because
+// an MCP tool's semantics are not otherwise knowable from its input.
+const WRITING_TOOL_NAME =
+  /(write|create|edit|update|append|delete|remove|move|rename|mkdir|copy)/i;
+
 // Input field names that commonly carry a filesystem path.
 const PATH_FIELD_NAMES = new Set([
   "file_path",
   "filePath",
   "path",
+  "paths",
   "file",
-  "filename",
-  "fileName",
   "absolute_path",
   "notebook_path",
-  "source",
-  "src",
-  "paths",
-  "files",
 ]);
 
 function collectPathFields(
   input: Record<string, unknown>,
   depth = 0,
 ): string[] {
-  if (depth > 2) return [];
+  if (depth > MAX_PATH_FIELD_DEPTH) return [];
   const found: string[] = [];
 
   for (const [key, value] of Object.entries(input)) {
@@ -850,7 +939,7 @@ process.stdin.on("end", () => {
 
   // Any other tool, MCP tools included: those can return file contents the same
   // way Read does, so a field naming an existing file is scanned before the call.
-  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool)) {
+  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool) && !WRITING_TOOL_NAME.test(tool)) {
     for (const candidate of collectPathFields(input)) {
       scanIfRegularFile(candidate, allowTags);
     }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -214,7 +214,9 @@ const POSIX_SHELLS = new Set(["sh", "bash", "zsh", "dash", "ksh"]);
 
 // git subcommands that can write file contents to stdout. Blob references such
 // as `git show HEAD:.env` name history, not the working tree, and stay
-// uncovered — only paths that exist on disk are scanned.
+// uncovered — only paths that exist on disk are scanned. `difftool` hands off
+// to an external tool and `stash` prints no file contents, so neither is here:
+// classifying them would push tokens like the `pop` in `git stash pop` as paths.
 const GIT_READ_SUBCOMMANDS = new Set([
   "show",
   "diff",
@@ -223,8 +225,19 @@ const GIT_READ_SUBCOMMANDS = new Set([
   "annotate",
   "grep",
   "cat-file",
-  "difftool",
-  "stash",
+]);
+
+// Global git flags that carry a separate value before the subcommand
+// (`git -C repo show f`, `git -c k=v show f`). Attached forms (`--git-dir=x`)
+// are single flag tokens and need no entry here.
+const GIT_GLOBAL_FLAGS_WITH_OPERAND = new Set([
+  "-C",
+  "-c",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--exec-path",
+  "--config-env",
 ]);
 
 // Recursion limit for command substitutions and inline scripts.
@@ -396,13 +409,18 @@ function decodeAnsiCEscape(command: string, i: number): string {
   return simple[esc] ?? esc;
 }
 
+// One heredoc delimiter introduced by a command line. `allowTabs` marks the
+// `<<-` form, whose closing delimiter may be tab-indented.
+interface HeredocDelimiter {
+  delim: string;
+  allowTabs: boolean;
+}
+
 // Heredoc delimiters introduced by one command line, in order. `<<-` allows a
 // tab-indented closing delimiter; `<<<` is a herestring and is not a heredoc.
 // Matches outside quotes only, so `echo "a <<EOF b"` is not a heredoc start.
-function findHeredocDelimiters(
-  line: string,
-): { delim: string; allowTabs: boolean }[] {
-  const found: { delim: string; allowTabs: boolean }[] = [];
+function findHeredocDelimiters(line: string): HeredocDelimiter[] {
+  const found: HeredocDelimiter[] = [];
   let quote: string | null = null;
   let i = 0;
 
@@ -469,11 +487,11 @@ function findHeredocDelimiters(
 function stripHeredocBodies(command: string): string {
   const lines = command.split("\n");
   const kept: string[] = [];
-  const pending: { delim: string; allowTabs: boolean }[] = [];
+  const pending: HeredocDelimiter[] = [];
 
   for (const line of lines) {
     if (pending.length > 0) {
-      const first = pending[0] as { delim: string; allowTabs: boolean };
+      const first = pending[0] as HeredocDelimiter;
       const cmp = first.allowTabs ? line.replace(/^\t+/, "") : line;
       if (cmp === first.delim) pending.shift();
       continue;
@@ -485,6 +503,15 @@ function stripHeredocBodies(command: string): string {
   return kept.join("\n");
 }
 
+// Substitution syntaxes whose inner text is a command line in its own right:
+// `$(...)`, `<(...)`, `>(...)` and backticks.
+const SUBSTITUTION_PATTERNS = [
+  /\$\(([^()]*)\)/g,
+  /<\(([^()]*)\)/g,
+  />\(([^()]*)\)/g,
+  /`([^`]*)`/g,
+];
+
 // Inner text of every command substitution, process substitution and backtick
 // expression, innermost first. Each is a command line in its own right.
 function extractSubstitutions(command: string): string[] {
@@ -493,23 +520,13 @@ function extractSubstitutions(command: string): string[] {
 
   for (let pass = 0; pass < MAX_SUBSTITUTION_PASSES; pass++) {
     const before = remaining;
-    remaining = remaining
-      .replace(/\$\(([^()]*)\)/g, (_, inner: string) => {
-        found.push(inner);
-        return " ";
-      })
-      .replace(/<\(([^()]*)\)/g, (_, inner: string) => {
-        found.push(inner);
-        return " ";
-      })
-      .replace(/>\(([^()]*)\)/g, (_, inner: string) => {
-        found.push(inner);
-        return " ";
-      })
-      .replace(/`([^`]*)`/g, (_, inner: string) => {
+    for (const pattern of SUBSTITUTION_PATTERNS) {
+      pattern.lastIndex = 0;
+      remaining = remaining.replace(pattern, (_, inner: string) => {
         found.push(inner);
         return " ";
       });
+    }
     if (remaining === before) break;
   }
 
@@ -525,17 +542,19 @@ function isNonCommandToken(token: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 
-// Commands whose operands this hook knows how to interpret. `env` and `printenv`
+// Commands whose operands this hook knows how to interpret. Derived from
+// classifyCommand so the two cannot silently disagree. `env` and `printenv`
 // are absent on purpose: they are wrappers as often as they are commands, and
 // inspectEnvironmentCommand handles the cases where they print the environment.
 function isClassifiableCommand(name: string): boolean {
+  const b = classifyCommand(name);
   return (
-    FILE_READ_COMMANDS.has(name) ||
-    COUNT_ONLY_COMMANDS.has(name) ||
-    PATTERN_OR_SCRIPT_FIRST_COMMANDS.has(name) ||
-    INLINE_CODE_COMMANDS.has(name) ||
-    name === "git" ||
-    name === "dd"
+    b.printsOperands ||
+    b.firstOperandIsPatternOrScript ||
+    b.takesInlineCode ||
+    b.printsNothing ||
+    b.isGit ||
+    b.isDd
   );
 }
 
@@ -727,6 +746,8 @@ interface CommandBehaviour {
   printsNothing: boolean;
   // `git <subcommand> [paths]`.
   isGit: boolean;
+  // `dd if=<file>` names its input in an assignment-style operand.
+  isDd: boolean;
 }
 
 // Single place where a command name becomes a behaviour, so a name added to one
@@ -738,6 +759,7 @@ function classifyCommand(cmd: string): CommandBehaviour {
     takesInlineCode: INLINE_CODE_COMMANDS.has(cmd),
     printsNothing: COUNT_ONLY_COMMANDS.has(cmd),
     isGit: cmd === "git",
+    isDd: cmd === "dd",
   };
 }
 
@@ -814,7 +836,18 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
       continue;
     }
 
-    if (tok.startsWith("-")) continue;
+    if (tok.startsWith("-")) {
+      // A global git flag with a separate value consumes the next token too:
+      // in `git -C repo show f`, `repo` is not the subcommand.
+      if (
+        behaviour.isGit &&
+        !gitSubcommandSeen &&
+        GIT_GLOBAL_FLAGS_WITH_OPERAND.has(tok)
+      ) {
+        skipNext = true;
+      }
+      continue;
+    }
 
     if (behaviour.isGit) {
       if (!gitSubcommandSeen) {
@@ -828,7 +861,7 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
 
     // `if=<file>` names an input only for `dd`; other commands taking an
     // `if=` argument are not reading the file it names.
-    if (cmd === "dd") {
+    if (behaviour.isDd) {
       const ddInput = /^if=(.+)$/.exec(tok);
       if (ddInput?.[1]) {
         paths.push(ddInput[1]);

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -152,9 +152,10 @@ const COUNT_ONLY_COMMANDS = new Set([
 
 // Commands whose first non-flag argument is a pattern, expression or script,
 // and whose remaining non-flag arguments are files written to stdout.
-// General-purpose runtimes (`python`, `node`, `deno`, `bun`) are absent: they
-// execute their first argument rather than print it, and the files named after
-// it are argv, not output. Their inline code (`-c`, `-e`) is still scanned via
+// General-purpose runtimes (`python`, `node`, `deno`, `bun`, and `perl` and
+// `ruby` when they run a program file) are absent: they execute their first
+// argument rather than print it, and the files named after it are argv, not
+// output. Their inline code (`-c`, `-e`) is still scanned via
 // INLINE_CODE_COMMANDS.
 const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
   "sed",
@@ -167,9 +168,13 @@ const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
   "ag",
   "jq",
   "yq",
-  "perl",
-  "ruby",
 ]);
+
+// Interpreters whose file operands are input to a one-liner given inline:
+// `perl -pe 's/a/b/' f` and `ruby -pe '…' f` print f. Hand them a program file
+// instead and the operands are argv — `perl script.pl data.txt` prints neither —
+// so their operands count as reads only once inline code has been seen.
+const INLINE_CODE_READS_OPERANDS = new Set(["perl", "ruby"]);
 
 // Commands that run another command. They are stripped so the wrapped command
 // is classified instead: `sudo cat secrets` is treated as `cat secrets`.
@@ -668,6 +673,7 @@ function isClassifiableCommand(name: string): boolean {
     b.printsOperands ||
     b.firstOperandIsPatternOrScript ||
     b.takesInlineCode ||
+    b.inlineCodeReadsOperands ||
     b.printsNothing ||
     b.isGit ||
     b.isDd
@@ -868,6 +874,8 @@ interface CommandBehaviour {
   firstOperandIsPatternOrScript: boolean;
   // -c / -e introduce inline program text.
   takesInlineCode: boolean;
+  // Operands following inline program text are input files written to stdout.
+  inlineCodeReadsOperands: boolean;
   // Reads a file but prints only a measurement of it, and does not echo stdin.
   printsNothing: boolean;
   // `git <subcommand> [paths]`.
@@ -883,6 +891,7 @@ function classifyCommand(cmd: string): CommandBehaviour {
     printsOperands: FILE_READ_COMMANDS.has(cmd),
     firstOperandIsPatternOrScript: PATTERN_OR_SCRIPT_FIRST_COMMANDS.has(cmd),
     takesInlineCode: INLINE_CODE_COMMANDS.has(cmd),
+    inlineCodeReadsOperands: INLINE_CODE_READS_OPERANDS.has(cmd),
     printsNothing: COUNT_ONLY_COMMANDS.has(cmd),
     isGit: cmd === "git",
     isDd: cmd === "dd",
@@ -932,6 +941,7 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
   let skipNext = false;
   let collectNext = false;
   let codeNext = false;
+  let inlineCodeSeen = false;
   let patternSkipped = false;
   let gitSubcommandSeen = false;
   let gitReadsFiles = false;
@@ -951,6 +961,7 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
       // The expression came from -e/-c, so a later operand is a file, not the
       // script `perl file` would have run.
       patternSkipped = true;
+      if (behaviour.inlineCodeReadsOperands) inlineCodeSeen = true;
       const inner = extractCommandRefs(tok, depth + 1);
       paths.push(...inner.paths, ...extractQuotedLiterals(tok));
       envVars.push(...inner.envVars);
@@ -1016,7 +1027,11 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
       continue;
     }
 
-    if (behaviour.printsOperands || behaviour.firstOperandIsPatternOrScript) {
+    if (
+      behaviour.printsOperands ||
+      behaviour.firstOperandIsPatternOrScript ||
+      inlineCodeSeen
+    ) {
       paths.push(tok);
     }
   }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -416,6 +416,50 @@ interface HeredocDelimiter {
   allowTabs: boolean;
 }
 
+// The delimiter word starting at `line[from]`, with quote removal applied the way
+// the shell does it: `<<EOF`, `<<'EOF'`, `<<"EOF"` and `<<E"O"F` all end their
+// body at the line `EOF`. The word ends at whitespace or a shell metacharacter.
+//
+// A narrower character class (`[A-Za-z0-9_.]`) used to cut the word short, and the
+// truncated delimiter then never matched the real closing line: stripHeredocBodies
+// swallowed the rest of the command, so `cat > f <<EOF-1 … EOF-1` followed by
+// `cat .env` hid the read entirely.
+function readHeredocDelimiter(
+  line: string,
+  from: number,
+): { delim: string; next: number } {
+  let delim = "";
+  let i = from;
+
+  while (i < line.length) {
+    const ch = line[i] as string;
+    if (ch === "'" || ch === '"') {
+      i++;
+      while (i < line.length && line[i] !== ch) {
+        if (ch === '"' && line[i] === "\\" && line[i + 1] !== undefined) {
+          delim += line[i + 1];
+          i += 2;
+          continue;
+        }
+        delim += line[i];
+        i++;
+      }
+      i++; // closing quote, or end of line for an unbalanced one
+      continue;
+    }
+    if (ch === "\\" && line[i + 1] !== undefined) {
+      delim += line[i + 1];
+      i += 2;
+      continue;
+    }
+    if (/[\s|&;()<>`]/.test(ch)) break;
+    delim += ch;
+    i++;
+  }
+
+  return { delim, next: i };
+}
+
 // Heredoc delimiters introduced by one command line, in order. `<<-` allows a
 // tab-indented closing delimiter; `<<<` is a herestring and is not a heredoc.
 // Matches outside quotes only, so `echo "a <<EOF b"` is not a heredoc start.
@@ -453,23 +497,9 @@ function findHeredocDelimiters(line: string): HeredocDelimiter[] {
         continue;
       }
       while (line[j] === " " || line[j] === "\t") j++;
-      let delim = "";
-      const q = line[j];
-      if (q === "'" || q === '"') {
-        j++;
-        while (j < line.length && line[j] !== q) {
-          delim += line[j];
-          j++;
-        }
-        j++; // closing quote, or end of line for an unbalanced one
-      } else {
-        while (j < line.length && /[A-Za-z0-9_.]/.test(line[j] as string)) {
-          delim += line[j];
-          j++;
-        }
-      }
+      const { delim, next } = readHeredocDelimiter(line, j);
       if (delim) found.push({ delim, allowTabs });
-      i = j;
+      i = next;
       continue;
     }
     i++;

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -627,10 +627,12 @@ function inspectEnvironmentCommand(tokens: string[]): {
     }
     // `env` prints the environment unless a subcommand follows its own
     // arguments: assignments (`FOO=1`), flags, and the values of flags that
-    // take one (`-u FOO`, `-C dir`, `-S str`) are all env's own. With no
-    // subcommand the whole environment is printed — `env FOO=1` and
-    // `env -u FOO` included. Exception: `-i` starts from an empty environment,
-    // so only the given assignments (already scanned as command text) print.
+    // take one (`-u FOO`, `-C dir`) are all env's own. The `-S` split string
+    // is the subcommand itself (`env -S "cat f"` runs cat), so it rules a dump
+    // out. With no subcommand the whole environment is printed — `env FOO=1`
+    // and `env -u FOO` included. Exception: `-i` starts from an empty
+    // environment, so only the given assignments (already scanned as command
+    // text) print.
     if (name === "env") {
       const rest = tokens.slice(i + 1);
       let ignoreEnvironment = false;
@@ -645,16 +647,13 @@ function inspectEnvironmentCommand(tokens: string[]): {
           j++; // redirection operator: its target is env's own argument here
           continue;
         }
-        if (
-          t === "-u" ||
-          t === "--unset" ||
-          t === "-C" ||
-          t === "--chdir" ||
-          t === "-S" ||
-          t === "--split-string"
-        ) {
+        if (t === "-u" || t === "--unset" || t === "-C" || t === "--chdir") {
           j++; // flag value
           continue;
+        }
+        if (t === "-S" || t === "--split-string") {
+          hasCommand = true; // the split string is the subcommand
+          break;
         }
         if (isNonCommandToken(t)) continue; // flags and FOO=1 assignments
         hasCommand = true;
@@ -783,6 +782,22 @@ function collectSegmentRefs(tokens: string[], depth: number): CommandRefs {
     operands.some((t) => /^-i/.test(t) || t === "--in-place")
   ) {
     return { paths, envVars, dumpsEnvironment };
+  }
+
+  // `env -S "cmd args"` splits the string into the command it runs, so scan
+  // inside it the way inline code is scanned.
+  if (cmd === "env") {
+    for (let k = 0; k < operands.length; k++) {
+      const t = operands[k];
+      if (t !== "-S" && t !== "--split-string") continue;
+      const script = operands[k + 1];
+      if (script === undefined) continue;
+      const inner = extractCommandRefs(script, depth + 1);
+      paths.push(...inner.paths);
+      envVars.push(...inner.envVars);
+      dumpsEnvironment = dumpsEnvironment || inner.dumpsEnvironment;
+      k++;
+    }
   }
 
   const behaviour = classifyCommand(cmd);

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -1001,6 +1001,15 @@ function collectPathFields(
       if (PATH_FIELD_NAMES.has(key)) {
         found.push(...value.filter((v): v is string => typeof v === "string"));
       }
+      // Paths also arrive as objects inside an array, e.g.
+      // `{ paths: [{ path: "…" }] }` — recurse into those elements too.
+      for (const item of value) {
+        if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+          found.push(
+            ...collectPathFields(item as Record<string, unknown>, depth + 1),
+          );
+        }
+      }
     } else if (value !== null && typeof value === "object") {
       found.push(
         ...collectPathFields(value as Record<string, unknown>, depth + 1),

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -355,6 +355,18 @@ function tokenizeCommand(command: string): string[][] {
       continue;
     }
 
+    // A subshell holds a command line of its own. Without this, `(cat secrets)`
+    // tokenized as `(cat` and `secrets)`, naming neither a command this hook
+    // classifies nor a path that exists, and the read went unseen. The opening
+    // paren of `$(`, `<(` and `>(` lands here too, which only means the inner
+    // command is reached twice — extractSubstitutions already recurses into it,
+    // and the paths are deduplicated.
+    if (ch === "(" || ch === ")") {
+      endSegment();
+      i++;
+      continue;
+    }
+
     if (ch === "<" || ch === ">") {
       // A file-descriptor prefix belongs to the operator, not to a token of its
       // own: `env 2>err` has to tokenize like `env >err`, or the `2` reads as
@@ -654,12 +666,30 @@ function isRedirectionOperator(token: string): boolean {
   return /^[<>]+$/.test(token);
 }
 
+// Shell keywords and the brace-group delimiters. They stand where a command
+// name would, so a segment led by one used to be classified as a command called
+// `{` or `then` and its operands never looked at: `{ cat secrets; }` and
+// `if …; then cat secrets; fi` both read a file nothing noticed.
+const SHELL_KEYWORD_TOKENS = new Set([
+  "{",
+  "}",
+  "!",
+  "then",
+  "else",
+  "elif",
+  "do",
+  "done",
+  "fi",
+  "in",
+]);
+
 // True for a token that cannot name a command: a flag, a redirection operator,
-// or a `VAR=value` assignment placed before one.
+// a `VAR=value` assignment placed before one, or a shell keyword.
 function isNonCommandToken(token: string): boolean {
   if (token.startsWith("-") || token.startsWith("<") || token.startsWith(">")) {
     return true;
   }
+  if (SHELL_KEYWORD_TOKENS.has(token)) return true;
   return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
 }
 

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -299,14 +299,33 @@ function tokenizeCommand(command: string): string[][] {
       continue;
     }
 
-    if (ch === "'" || ch === '"') {
-      i++;
+    if (
+      ch === "'" ||
+      ch === '"' ||
+      (ch === "$" && (command[i + 1] === "'" || command[i + 1] === '"'))
+    ) {
+      // $'...' (ANSI-C) and $"..." (locale) are quoting syntax: the `$` is not
+      // part of the token. Inside $'...', backslash escapes are decoded.
+      let quote = ch;
+      let ansiC = false;
+      if (ch === "$") {
+        quote = command[i + 1] as string;
+        ansiC = quote === "'";
+        i += 2;
+      } else {
+        i++;
+      }
       hasCurrent = true;
-      while (i < command.length && command[i] !== ch) {
-        if (ch === '"' && command[i] === "\\" && command[i + 1] !== undefined) {
-          current += command[i + 1];
-          i += 2;
-          continue;
+      while (i < command.length && command[i] !== quote) {
+        if (command[i] === "\\" && command[i + 1] !== undefined) {
+          if (quote === '"' || ansiC) {
+            current += ansiC
+              ? decodeAnsiCEscape(command, i)
+              : (command[i + 1] as string);
+            i += ansiC ? ansiCEscapeLength(command, i) : 2;
+            continue;
+          }
+          // plain single quotes keep backslashes literal
         }
         current += command[i];
         i++;
@@ -348,6 +367,125 @@ function tokenizeCommand(command: string): string[][] {
   return segments;
 }
 
+// Length of the ANSI-C escape starting at `command[i]` (a backslash), so the
+// tokenizer can skip the whole sequence: \xHH is 4 chars, anything else is 2.
+function ansiCEscapeLength(command: string, i: number): number {
+  return command[i + 1] === "x" &&
+    /^[0-9A-Fa-f]{2}$/.test(command.slice(i + 2, i + 4))
+    ? 4
+    : 2;
+}
+
+// Decode the ANSI-C escape starting at `command[i]` (a backslash). Covers the
+// escapes that appear in paths: \\, \', \", \xHH and the common letter escapes.
+function decodeAnsiCEscape(command: string, i: number): string {
+  const esc = command[i + 1] as string;
+  if (esc === "x" && /^[0-9A-Fa-f]{2}$/.test(command.slice(i + 2, i + 4))) {
+    return String.fromCharCode(
+      Number.parseInt(command.slice(i + 2, i + 4), 16),
+    );
+  }
+  const simple: Record<string, string> = {
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    n: "\n",
+    t: "\t",
+    r: "\r",
+    "0": "\0",
+  };
+  return simple[esc] ?? esc;
+}
+
+// Heredoc delimiters introduced by one command line, in order. `<<-` allows a
+// tab-indented closing delimiter; `<<<` is a herestring and is not a heredoc.
+// Matches outside quotes only, so `echo "a <<EOF b"` is not a heredoc start.
+function findHeredocDelimiters(
+  line: string,
+): { delim: string; allowTabs: boolean }[] {
+  const found: { delim: string; allowTabs: boolean }[] = [];
+  let quote: string | null = null;
+  let i = 0;
+
+  while (i < line.length) {
+    const ch = line[i] as string;
+    if (quote !== null) {
+      if (quote === '"' && ch === "\\") i++;
+      else if (ch === quote) quote = null;
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === "<" && line[i + 1] === "<") {
+      let j = i + 2;
+      let allowTabs = false;
+      if (line[j] === "-") {
+        allowTabs = true;
+        j++;
+      }
+      if (line[j] === "<") {
+        i = j; // herestring
+        continue;
+      }
+      while (line[j] === " " || line[j] === "\t") j++;
+      let delim = "";
+      const q = line[j];
+      if (q === "'" || q === '"') {
+        j++;
+        while (j < line.length && line[j] !== q) {
+          delim += line[j];
+          j++;
+        }
+        j++; // closing quote, or end of line for an unbalanced one
+      } else {
+        while (j < line.length && /[A-Za-z0-9_.]/.test(line[j] as string)) {
+          delim += line[j];
+          j++;
+        }
+      }
+      if (delim) found.push({ delim, allowTabs });
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return found;
+}
+
+// Remove heredoc bodies from a command line. A body is text, not commands —
+// `cat > deploy.sh <<EOF` followed by a script that mentions `.env` reads
+// nothing, and scanning the body as shell blocked exactly that everyday case.
+// The trade-off: a heredoc that *feeds* commands to a remote shell
+// (`ssh host <<EOF\ncat /secret\nEOF`) is no longer caught. Documented as a
+// known limitation in the README.
+function stripHeredocBodies(command: string): string {
+  const lines = command.split("\n");
+  const kept: string[] = [];
+  const pending: { delim: string; allowTabs: boolean }[] = [];
+
+  for (const line of lines) {
+    if (pending.length > 0) {
+      const first = pending[0] as { delim: string; allowTabs: boolean };
+      const cmp = first.allowTabs ? line.replace(/^\t+/, "") : line;
+      if (cmp === first.delim) pending.shift();
+      continue;
+    }
+    pending.push(...findHeredocDelimiters(line));
+    kept.push(line);
+  }
+
+  return kept.join("\n");
+}
+
 // Inner text of every command substitution, process substitution and backtick
 // expression, innermost first. Each is a command line in its own right.
 function extractSubstitutions(command: string): string[] {
@@ -362,6 +500,10 @@ function extractSubstitutions(command: string): string[] {
         return " ";
       })
       .replace(/<\(([^()]*)\)/g, (_, inner: string) => {
+        found.push(inner);
+        return " ";
+      })
+      .replace(/>\(([^()]*)\)/g, (_, inner: string) => {
         found.push(inner);
         return " ";
       })
@@ -400,18 +542,39 @@ function isClassifiableCommand(name: string): boolean {
 
 // Index of the token naming the command whose operands matter.
 //
-// Wrappers are not peeled by counting their flags: `sudo -u root cat f` would
-// then mistake `root` for the command, and `timeout -s KILL 5 cat f` would
-// mistake `5`. The whole segment is searched for the first token this hook can
-// classify instead, which also carries `LANG=C cat f` and `xargs -n 1 cat f`.
-// Falling back to index 0 leaves an unknown command classified as itself.
+// The lead command is the first token that is not a flag, redirection or
+// `VAR=value` assignment. Only a known wrapper (`sudo`, `env`, `timeout`, …)
+// is peeled, by searching the rest of the segment for the first token this
+// hook can classify; anything else is treated as the command itself. Searching
+// unconditionally mistook operands for commands: `echo cat secrets` resolved
+// to `cat`, and a file that was never read was scanned and blocked. Wrappers
+// are still not peeled by counting their flags: `sudo -u root cat f` would
+// mistake `root` for the command, and `timeout -s KILL 5 cat f` would
+// mistake `5`. Falling back to the lead leaves an unknown command classified
+// as itself.
 function findCommandIndex(tokens: string[]): number {
+  let lead = -1;
   for (let i = 0; i < tokens.length; i++) {
+    if (isNonCommandToken(tokens[i] ?? "")) continue;
+    lead = i;
+    break;
+  }
+  if (lead === -1) return 0;
+
+  const leadName = path.basename(tokens[lead] ?? "");
+  if (
+    !WRAPPER_COMMANDS.has(leadName) &&
+    !WRAPPER_COMMANDS_WITH_OPERAND.has(leadName)
+  ) {
+    return lead;
+  }
+
+  for (let i = lead + 1; i < tokens.length; i++) {
     const tok = tokens[i] ?? "";
     if (isNonCommandToken(tok)) continue;
     if (isClassifiableCommand(path.basename(tok))) return i;
   }
-  return 0;
+  return lead;
 }
 
 // `env` and `printenv` print the environment unless they are being used to run
@@ -444,8 +607,43 @@ function inspectEnvironmentCommand(tokens: string[]): {
         ? { dumps: true, named: [] }
         : { dumps: false, named: operands };
     }
-    // `env` with an operand is running a command, not printing anything.
-    return { dumps: operands.length === 0, named: [] };
+    // `env` prints the environment unless a subcommand follows its own
+    // arguments: assignments (`FOO=1`), flags, and the values of flags that
+    // take one (`-u FOO`, `-C dir`, `-S str`) are all env's own. With no
+    // subcommand the whole environment is printed — `env FOO=1` and
+    // `env -u FOO` included. Exception: `-i` starts from an empty environment,
+    // so only the given assignments (already scanned as command text) print.
+    if (name === "env") {
+      const rest = tokens.slice(i + 1);
+      let ignoreEnvironment = false;
+      let hasCommand = false;
+      for (let j = 0; j < rest.length; j++) {
+        const t = rest[j] ?? "";
+        if (t === "-i" || t === "--ignore-environment") {
+          ignoreEnvironment = true;
+          continue;
+        }
+        if (t === "<" || t === ">" || t === "<<" || t === ">>") {
+          j++; // redirection operator: its target is env's own argument here
+          continue;
+        }
+        if (
+          t === "-u" ||
+          t === "--unset" ||
+          t === "-C" ||
+          t === "--chdir" ||
+          t === "-S" ||
+          t === "--split-string"
+        ) {
+          j++; // flag value
+          continue;
+        }
+        if (isNonCommandToken(t)) continue; // flags and FOO=1 assignments
+        hasCommand = true;
+        break;
+      }
+      return { dumps: !hasCommand && !ignoreEnvironment, named: [] };
+    }
   }
 
   return nothing;
@@ -494,12 +692,15 @@ function extractCommandRefs(command: string, depth = 0): CommandRefs {
     dumpsEnvironment = dumpsEnvironment || refs.dumpsEnvironment;
   };
 
+  // Heredoc bodies are text, not commands; strip them before any other pass.
+  const text = stripHeredocBodies(command);
+
   // `echo $(cat secrets)` reads secrets just as `cat secrets` does.
-  for (const inner of extractSubstitutions(command)) {
+  for (const inner of extractSubstitutions(text)) {
     merge(extractCommandRefs(inner, depth + 1));
   }
 
-  for (const tokens of tokenizeCommand(command)) {
+  for (const tokens of tokenizeCommand(text)) {
     const environment = inspectEnvironmentCommand(tokens);
     if (environment.dumps) dumpsEnvironment = true;
     envVars.push(...environment.named);
@@ -758,9 +959,18 @@ const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
 
 // A tool whose name says it writes is treated like the built-in Write and Edit:
 // naming a file it does not read is not a leak. Matched on the tool name because
-// an MCP tool's semantics are not otherwise knowable from its input.
+// an MCP tool's semantics are not otherwise knowable from its input. For MCP
+// tools (`mcp__<server>__<tool>`) only the tool component is matched — a server
+// named "editor" or "readwrite" must not exempt every read tool it offers.
 const WRITING_TOOL_NAME =
   /(write|create|edit|update|append|delete|remove|move|rename|mkdir|copy)/i;
+
+function isWritingTool(tool: string): boolean {
+  const name = tool.startsWith("mcp__")
+    ? (tool.split("__").pop() ?? tool)
+    : tool;
+  return WRITING_TOOL_NAME.test(name);
+}
 
 // Input field names that commonly carry a filesystem path.
 const PATH_FIELD_NAMES = new Set([
@@ -939,7 +1149,7 @@ process.stdin.on("end", () => {
 
   // Any other tool, MCP tools included: those can return file contents the same
   // way Read does, so a field naming an existing file is scanned before the call.
-  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool) && !WRITING_TOOL_NAME.test(tool)) {
+  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool) && !isWritingTool(tool)) {
     for (const candidate of collectPathFields(input)) {
       scanIfRegularFile(candidate, allowTags);
     }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -240,11 +240,9 @@ const GIT_GLOBAL_FLAGS_WITH_OPERAND = new Set([
   "--config-env",
 ]);
 
-// Recursion limit for command substitutions and inline scripts.
+// Recursion limit for command substitutions and inline scripts. Nesting costs
+// one level per substitution, so `$( $( … ) )` is followed four deep.
 const MAX_NESTING_DEPTH = 4;
-
-// Passes made while peeling nested command substitutions.
-const MAX_SUBSTITUTION_PASSES = 8;
 
 // Longest quoted literal inside inline code still treated as a path candidate.
 const MAX_QUOTED_LITERAL_LENGTH = 4096;
@@ -533,31 +531,103 @@ function stripHeredocBodies(command: string): string {
   return kept.join("\n");
 }
 
-// Substitution syntaxes whose inner text is a command line in its own right:
-// `$(...)`, `<(...)`, `>(...)` and backticks.
-const SUBSTITUTION_PATTERNS = [
-  /\$\(([^()]*)\)/g,
-  /<\(([^()]*)\)/g,
-  />\(([^()]*)\)/g,
-  /`([^`]*)`/g,
+// Substitution syntaxes whose inner text is a command line in its own right.
+// Command substitution and backticks expand inside double quotes; the process
+// substitutions do not, so `echo "<(cat f)"` is a literal string.
+const SUBSTITUTIONS = [
+  { open: "$(", close: ")", expandsInDoubleQuotes: true },
+  { open: "<(", close: ")", expandsInDoubleQuotes: false },
+  { open: ">(", close: ")", expandsInDoubleQuotes: false },
+  { open: "`", close: "`", expandsInDoubleQuotes: true },
 ];
 
-// Inner text of every command substitution, process substitution and backtick
-// expression, innermost first. Each is a command line in its own right.
+// Index of the character closing a substitution whose body starts at `from`.
+// Parentheses are counted rather than matched with a regex, because a body
+// carries parentheses of its own: `$(python3 -c "print(open('.env').read())")`
+// was cut short at the first `)` by the old `[^()]*` pattern, and the read it
+// contained was never scanned. Quotes and backslashes inside the body are
+// respected. An unbalanced substitution runs to the end of the string.
+function findSubstitutionEnd(
+  command: string,
+  from: number,
+  close: string,
+): number {
+  let depth = 0;
+  let quote: string | null = null;
+
+  for (let i = from; i < command.length; i++) {
+    const ch = command[i] as string;
+    if (ch === "\\" && quote !== "'") {
+      i++;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (close === "`") {
+      if (ch === "`") return i;
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      if (depth === 0) return i;
+      depth--;
+    }
+  }
+
+  return command.length;
+}
+
+// Inner text of every outermost command substitution, process substitution and
+// backtick expression. Each is a command line in its own right; nested ones are
+// reached because extractCommandRefs recurses into what this returns.
 function extractSubstitutions(command: string): string[] {
   const found: string[] = [];
-  let remaining = command;
+  let quote: string | null = null;
+  let i = 0;
 
-  for (let pass = 0; pass < MAX_SUBSTITUTION_PASSES; pass++) {
-    const before = remaining;
-    for (const pattern of SUBSTITUTION_PATTERNS) {
-      pattern.lastIndex = 0;
-      remaining = remaining.replace(pattern, (_, inner: string) => {
-        found.push(inner);
-        return " ";
-      });
+  while (i < command.length) {
+    const ch = command[i] as string;
+
+    if (ch === "\\") {
+      i += quote === "'" ? 1 : 2;
+      continue;
     }
-    if (remaining === before) break;
+    if (quote === "'") {
+      if (ch === quote) quote = null;
+      i++;
+      continue;
+    }
+    if (quote === '"' && ch === '"') {
+      quote = null;
+      i++;
+      continue;
+    }
+    if (quote === null && (ch === "'" || ch === '"')) {
+      quote = ch;
+      i++;
+      continue;
+    }
+
+    const opener = SUBSTITUTIONS.find(
+      (s) =>
+        command.startsWith(s.open, i) &&
+        (quote === null || s.expandsInDoubleQuotes),
+    );
+    if (opener === undefined) {
+      i++;
+      continue;
+    }
+
+    const bodyStart = i + opener.open.length;
+    const end = findSubstitutionEnd(command, bodyStart, opener.close);
+    found.push(command.slice(bodyStart, end));
+    i = end + 1;
   }
 
   return found;


### PR DESCRIPTION
## Why

The PreToolUse hook inspected only `Read` and `Bash`, and within `Bash` only seven content-printing commands (`cat`, `head`, `tail`, `less`, `more`, `bat`, `nl`). Several ordinary ways of pulling a file into the conversation were therefore unchecked: `sed -n 1,5p secrets`, `sudo cat secrets`, `python3 -c "open('.env').read()"`, `echo $(cat secrets)`, a `cat` on the second line of a multi-line command, and the `Grep` tool. MCP tools that return file contents were not inspected at all.

## What changed

### Bash inspection

- Added ~40 content-printing commands (`tac`, `rev`, `strings`, `xxd`, `od`, `hexdump`, `base64`, `cut`, `sort`, `uniq`, `shuf`, `column`, `paste`, `fold`, `fmt`, `pr`, `expand`, `unexpand`, `iconv`, the `z*cat` family, `diff`, `comm`, `join`, `look`), plus a second class whose first non-flag argument is a pattern or script and whose remaining arguments are files (`sed`, `awk`, `grep`, `rg`, `ag`, `jq`, `yq`, `perl`, `ruby`, `python`, `node`, `deno`, `bun`). `sed -i` is exempt: it writes nothing to stdout.
- Wrapper commands (`sudo`, `env VAR=1`, `timeout N`, `nice`, `xargs`, `stdbuf`, …) are stripped so the wrapped command is classified instead.
- Inline program text from `-c` / `-e` / `-pe` is parsed and scanned both as a nested command line and for quoted path literals, which is what catches `python3 -c "open('.env')"`.
- The whitespace split was replaced with a tokenizer that understands quotes, newlines, `&&` / `;` / `|` and redirection operators. Multi-line commands, chained commands and quoted paths containing spaces were previously skipped.
- The target of an input redirection is now collected for every command whose stdin it would print, not only for commands named in the read list. The old code set a skip flag on `<` outright, so `tr a b < secrets` passed through. Commands that only measure their input (`wc`, `cksum`, `sha256sum`) are exempt, as are heredoc and herestring delimiters.
- `$(...)`, backticks and `<(...)` are recursed into.
- File arguments of git subcommands that print contents (`show`, `diff`, `log`, `blame`, `grep`, `cat-file`, …) and `dd if=` are scanned.
- `${VAR:-default}` style expansions now resolve when checking environment variable values.
- `wc` was dropped from the read-command list: it reports counts, never file bytes.

### New tools

- `Grep`: the target is scanned when `path` names a regular file.
- Any other tool, MCP included: input fields that name an existing regular file are scanned (`path`, `file_path`, nested up to two levels). `Write`, `Edit`, `Glob`, `TodoWrite` and friends are exempt, since naming a file they do not read is not a leak. The matcher becomes `Read|Bash|Grep|mcp__.*`.

## Verification

- `npx tsc --noEmit`, `npx biome check src`: clean.
- `npx vitest run`: 409 passed (343 pre-existing, 66 new). The pre-existing suite is unchanged and serves as the backward-compatibility baseline.
- Ran the hook end-to-end against 36 hand-built cases: 19 previously-open bypasses now block, and 17 everyday operations (`git status`, `ls`, `npm test`, `git add`, `cat` on a clean file, a heredoc, an output redirection, `Write`, `Glob`, an MCP `path` that is a URL route, `Grep` on a directory) still pass.
- Hook cost is ~83 ms per invocation.

## Limits that remain (documented in README)

Paths held in shell variables (`f=.env; cat "$f"`), paths arriving over a pipe (`find | xargs cat`), programs that open files themselves (`python script.py`), git history references (`git show HEAD:.env`), and `Grep` on a directory. All of these resolve at run time, after the hook has already decided.

## Follow-ups, not in this PR

- The hook blocks via exit code 2 plus a stdout `{"decision":"block"}` payload. The docs now describe exit 0 with `hookSpecificOutput.permissionDecision: "deny"` as the supported form and say exit 2 ignores JSON. The current form was verified working, but migrating would touch the assertions in the existing suite and belongs in its own change.
- `.claude-plugin/plugin.json` says `0.5.1` while `package.json` says `0.7.0`.

