### PR TITLE
fix: align the plugin manifest version and check it in CI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "author": {
     "name": "coo-quack"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24.18.1'
+          node-version: '24.19.0'
       - name: package.json and plugin.json declare the same version
         run: |
           pkg=$(node -p "require('./package.json').version")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,31 @@ jobs:
       - run: pnpm install
       - run: pnpm audit --audit-level high
 
+  # The release checklist asks for `version` in package.json and
+  # .claude-plugin/plugin.json to be bumped together. Twice it was not: the
+  # plugin manifest stayed at 0.5.1 while 0.6.0 and 0.7.0 were released, and
+  # nothing noticed, because release.yml reads the version from package.json
+  # alone. Strengthening the checklist wording would not have caught it. This is
+  # the check that does.
+  versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.18.1'
+      - name: package.json and plugin.json declare the same version
+        run: |
+          pkg=$(node -p "require('./package.json').version")
+          plugin=$(node -p "require('./.claude-plugin/plugin.json').version")
+          if [ "$pkg" != "$plugin" ]; then
+            echo "::error::version mismatch — package.json is $pkg, .claude-plugin/plugin.json is $plugin. Bump both (see the Release Checklist in CONTRIBUTING.md)."
+            exit 1
+          fi
+          echo "both declare $pkg"
+
   typecheck:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
   # plugin manifest stayed at 0.5.1 while 0.6.0 and 0.7.0 were released, and
   # nothing noticed, because release.yml reads the version from package.json
   # alone. Strengthening the checklist wording would not have caught it. This is
-  # the check that does.
+  # the check that notices — reported as a failure here, though only a rule
+  # requiring this check would stop a merge past it.
   versions:
     runs-on: ubuntu-latest
     permissions:
@@ -57,6 +58,21 @@ jobs:
         run: |
           pkg=$(node -p "require('./package.json').version")
           plugin=$(node -p "require('./.claude-plugin/plugin.json').version")
+
+          # A comparison of two values goes quiet when neither is a value:
+          # `node -p` prints "undefined" for a missing field and "null" for a
+          # null one, and exits 0 either way, so two manifests declaring no
+          # version agreed with each other and this job passed saying so. Each
+          # side has to look like a version before the two are compared — a
+          # shape test rather than a list of the ways it can be absent, which
+          # would need extending every time a new one turns up.
+          for value in "$pkg" "$plugin"; do
+            if ! printf '%s' "$value" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+              echo "::error::a manifest declares no usable version — package.json is '$pkg', .claude-plugin/plugin.json is '$plugin'."
+              exit 1
+            fi
+          done
+
           if [ "$pkg" != "$plugin" ]; then
             echo "::error::version mismatch — package.json is $pkg, .claude-plugin/plugin.json is $plugin. Bump both (see the Release Checklist in CONTRIBUTING.md)."
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
   heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,
   written up under "② PreToolUse hook" in the README
 
-### Fixed
+### Fixes
 
 - `.claude-plugin/plugin.json` declared `0.5.1` while `package.json` declared
   `0.7.0`: the release checklist asks for both, and the bump was missed for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,17 @@
   heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,
   written up under "② PreToolUse hook" in the README
 
+### Fixed
+
+- `.claude-plugin/plugin.json` declared `0.5.1` while `package.json` declared
+  `0.7.0`: the release checklist asks for both, and the bump was missed for
+  0.6.0 and 0.7.0. The plugin manifest now matches the released version
+
+### CI
+
+- Add a `versions` job that fails when `package.json` and
+  `.claude-plugin/plugin.json` declare different versions
+
 ---
 
 ## v0.7.0 (2026-08-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,8 @@
 ### CI
 
 - Add a `versions` job that fails when `package.json` and
-  `.claude-plugin/plugin.json` declare different versions
+  `.claude-plugin/plugin.json` declare different versions, or when either
+  declares nothing that looks like one
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ If the backport PR has conflicts, resolve them manually before merging.
 
 When bumping a version, open a PR from `develop` → `main` with:
 
-1. Update `version` in `package.json` and `.claude-plugin/plugin.json`
+1. Update `version` in `package.json` and `.claude-plugin/plugin.json` — the `versions` job in CI fails when the two disagree
 2. Update `CHANGELOG.md` with a new `## vX.Y.Z (YYYY-MM-DD)` section
    - `docs/changelog.md` is a symlink to `CHANGELOG.md` — do not edit it separately
    - This content is automatically used as the GitHub Release notes by `release.yml`


### PR DESCRIPTION
## Why

`.claude-plugin/plugin.json` declares `0.5.1` while `package.json` declares `0.7.0`.

The Release Checklist in `CONTRIBUTING.md` asks for both to be bumped together, but `release.yml` reads the version from `package.json` alone, so nothing fails when only one is updated. The step was missed for 0.6.0 and again for 0.7.0, leaving the plugin manifest two releases behind the published package.

Raised as a follow-up in #163; split out because it touches neither the hook nor its tests.

## What changed

- `.claude-plugin/plugin.json` now declares `0.7.0`, matching the released version.
- A `versions` job in CI fails when the two files disagree, with an error message pointing at the Release Checklist.
- The checklist notes that CI enforces it.

The same step was missed twice, so the guard is a check rather than firmer wording.

## Verification

Both directions of the check were run locally: matching versions pass, and a deliberately mismatched `plugin.json` is reported as `package.json=0.7.0 plugin.json=9.9.9` with a non-zero exit.

## Not in this PR

Whether a stale manifest version affects update detection in the plugin marketplace is unverified. If it does, users who installed via the marketplace may not have been offered 0.6.0 or 0.7.0.