### PR TITLE
refactor: return the PreToolUse block reason on stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@
   reads its output itself, which says nothing about whether the runtime acts on
   it. Set `SENSITIVE_CANARY_INTEGRATION=1` to run it; it needs credentials and
   network, so CI skips it
+- The PreToolUse block reason is written to stderr instead of to a stdout
+  `{"decision":"block"}` payload. Both reach Claude on the current version, but
+  the documentation describes stdout as ignored on a non-zero exit and takes the
+  PreToolUse decision from `hookSpecificOutput` rather than a top-level
+  `decision` field, so the old form depended on undescribed behaviour. Blocking
+  is unchanged: exit 2 is what stops the call
 - Heredoc bodies are treated as text, not commands: writing a script that
   mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known limitation: a
   heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated a
 
 Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` included) edit in place and write nothing to stdout. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `--patch` or `-U<n>`.
 
-When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
+When blocked, the hook exits 2, which stops the tool call, and writes the reason to stderr, which is where Claude reads it from. The reason names what was detected and which allow tag lifts the block, and asks Claude to pass that on to the user.
 The terminal also receives a direct message (via `/dev/tty`).
 
 ### Known Limitations

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -33,7 +33,9 @@ export interface HookResult {
   // payload it is read from, so a test says what it means and does not have to
   // change if the way a block is returned ever does.
   blocked: boolean;
-  // The text the hook offers Claude on a block, from its stdout payload.
+  // The text Claude receives on a block. Read from stderr, which is where a
+  // hook exiting 2 is heard; on an allowed call there is none, so a config
+  // warning printed to stderr is not mistaken for a reason.
   reason: string | null;
 }
 
@@ -50,18 +52,8 @@ function spawnHook(input: string, opts?: RunOptions): HookResult {
     stdout: result.stdout,
     stderr: result.stderr,
     blocked: exitCode === 2,
-    reason: parseReason(result.stdout),
+    reason: exitCode === 2 ? result.stderr : null,
   };
-}
-
-// The hook's block payload carries the reason it offers Claude. A run that
-// allowed the call writes nothing, so there is nothing to parse.
-function parseReason(stdout: string): string | null {
-  try {
-    return (JSON.parse(stdout) as { reason?: string }).reason ?? null;
-  } catch {
-    return null;
-  }
 }
 
 // Feed the hook a raw stdin payload, for cases where the payload is not valid

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -1,22 +1,10 @@
-import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-
-const HOOK = new URL("../pre-tool-use-hook.ts", import.meta.url).pathname;
-const NODE_FLAGS = ["--experimental-strip-types"];
+import { runBashHook, runHook, runHookWithRawInput } from "./hook-harness.ts";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
-
-// The hook blocks by exiting 2, and writes the reason it offers Claude to
-// stderr. `blocked` is named for the outcome rather than for a payload field, so
-// a test says what it means and does not have to change if the way a block is
-// returned does.
-function readVerdict(result: { status: number | null; stderr: string }) {
-  const blocked = result.status === 2;
-  return { blocked, reason: blocked ? result.stderr : null };
-}
 
 let transcriptSeq = 0;
 
@@ -53,55 +41,6 @@ function writeTranscriptWithToolResults(
   const p = join(tmpDir, `transcript-${++transcriptSeq}.jsonl`);
   writeFileSync(p, lines.join("\n"), "utf8");
   return p;
-}
-
-function runHook(
-  toolName: string,
-  filePath: string,
-  opts?: { env?: Record<string, string>; transcriptPath?: string },
-) {
-  const input = JSON.stringify({
-    transcript_path: opts?.transcriptPath,
-    tool_name: toolName,
-    tool_input: { file_path: filePath },
-  });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: { ...process.env, ...opts?.env },
-  });
-  const { blocked, reason } = readVerdict(result);
-  return {
-    exitCode: result.status ?? -1,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    blocked,
-    reason,
-  };
-}
-
-function runBashHook(
-  command: string,
-  opts?: { env?: Record<string, string>; transcriptPath?: string },
-) {
-  const input = JSON.stringify({
-    transcript_path: opts?.transcriptPath,
-    tool_name: "Bash",
-    tool_input: { command },
-  });
-  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-    input,
-    encoding: "utf8",
-    env: { ...process.env, ...opts?.env },
-  });
-  const { blocked, reason } = readVerdict(result);
-  return {
-    exitCode: result.status ?? -1,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    blocked,
-    reason,
-  };
 }
 
 // ── temp directory for fixture files ─────────────────────────────────────────
@@ -700,11 +639,8 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
 
 describe("pre-tool-use-hook — malformed input", () => {
   it("exits 0 on invalid JSON", () => {
-    const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
-      input: "not json",
-      encoding: "utf8",
-    });
-    expect(result.status).toBe(0);
+    const { exitCode } = runHookWithRawInput("not json");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -75,6 +75,37 @@ describe("pre-tool-use-hook — non-Read/non-Bash tools", () => {
   });
 });
 
+// ── which channel a block is reported on ──────────────────────────────────────
+
+// The reason goes on stderr alone. Writing to both channels would leave the
+// documented one dead, because stdout wins and stderr is discarded when both
+// carry text — measured with probe hooks, and the reason this hook writes one.
+// Nothing asserted the stdout half of that, so a payload could come back on
+// stdout and every other test would still pass.
+describe("pre-tool-use-hook — block channel", () => {
+  it("reports the reason on stderr and writes nothing to stdout", () => {
+    const p = writeFixture(".env", "DEBUG=true\n");
+    const { exitCode, stdout, stderr } = runHook("Read", p);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("allow-secret");
+  });
+
+  // An allowed call cannot be recognised by an empty stderr: node's type
+  // stripping is experimental, so it warns there on every run. That is why the
+  // harness reads the reason only when the exit code says a block happened,
+  // rather than treating whatever is on stderr as one.
+  it("says nothing about a block when the call is allowed", () => {
+    const p = writeFixture("channel-clean.txt", "nothing here\n");
+    const { exitCode, stdout, stderr, reason } = runHook("Read", p);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(reason).toBeNull();
+    expect(stderr).not.toContain("allow-secret");
+    expect(stderr).not.toContain("Blocked");
+  });
+});
+
 // ── .env / .env.* — secret name block ─────────────────────────────────────────
 
 describe("pre-tool-use-hook — .env/.env.* name block (secret category)", () => {

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -9,13 +9,13 @@ const NODE_FLAGS = ["--experimental-strip-types"];
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-function parseHookOutput(stdout: string) {
-  try {
-    const parsed = JSON.parse(stdout) as { decision?: string; reason?: string };
-    return { decision: parsed.decision ?? null, reason: parsed.reason ?? null };
-  } catch {
-    return { decision: null, reason: null };
-  }
+// The hook blocks by exiting 2, and writes the reason it offers Claude to
+// stderr. `blocked` is named for the outcome rather than for a payload field, so
+// a test says what it means and does not have to change if the way a block is
+// returned does.
+function readVerdict(result: { status: number | null; stderr: string }) {
+  const blocked = result.status === 2;
+  return { blocked, reason: blocked ? result.stderr : null };
 }
 
 let transcriptSeq = 0;
@@ -70,12 +70,12 @@ function runHook(
     encoding: "utf8",
     env: { ...process.env, ...opts?.env },
   });
-  const { decision, reason } = parseHookOutput(result.stdout);
+  const { blocked, reason } = readVerdict(result);
   return {
     exitCode: result.status ?? -1,
     stdout: result.stdout,
     stderr: result.stderr,
-    decision,
+    blocked,
     reason,
   };
 }
@@ -94,12 +94,12 @@ function runBashHook(
     encoding: "utf8",
     env: { ...process.env, ...opts?.env },
   });
-  const { decision, reason } = parseHookOutput(result.stdout);
+  const { blocked, reason } = readVerdict(result);
   return {
     exitCode: result.status ?? -1,
     stdout: result.stdout,
     stderr: result.stderr,
-    decision,
+    blocked,
     reason,
   };
 }
@@ -141,23 +141,23 @@ describe("pre-tool-use-hook — non-Read/non-Bash tools", () => {
 describe("pre-tool-use-hook — .env/.env.* name block (secret category)", () => {
   it("blocks .env regardless of content", () => {
     const p = writeFixture(".env", "DEBUG=true\nNODE_ENV=development\n");
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("blocks .env.local regardless of content", () => {
     const p = writeFixture(".env.local", "DEBUG=true\n");
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("blocks .env.production regardless of content", () => {
     const p = writeFixture(".env.production", "DEBUG=true\n");
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("includes [allow-secret], [allow-pii], and [allow-all] hints in reason", () => {
@@ -195,24 +195,24 @@ describe("pre-tool-use-hook — clean file", () => {
 describe("pre-tool-use-hook — sensitive content blocking", () => {
   it("blocks a file containing an AWS key", () => {
     const p = writeFixture("config.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision, reason } = runHook("Read", p);
+    const { exitCode, blocked, reason } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
     expect(reason).toContain("aws-access-key");
   });
 
   it("blocks a file containing an email address", () => {
     const p = writeFixture("contacts.txt", "Email: user@example.com\n");
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("blocks a file containing a private IP", () => {
     const p = writeFixture("infra.txt", "server: 192.168.1.100\n");
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("includes [allow-secret] and [allow-all] hints in reason for a secret", () => {
@@ -257,9 +257,9 @@ describe("pre-tool-use-hook — binary file handling", () => {
     ]);
     const p = join(tmpDir, "binary-secret-before-nul.bin");
     writeFileSync(p, content);
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("allows a binary file when no secret appears before the first NUL byte", () => {
@@ -317,11 +317,11 @@ describe("pre-tool-use-hook — transcript tail read (64 KB)", () => {
 
 describe("pre-tool-use-hook — Bash tool (env var expansion)", () => {
   it("blocks echo $TOKEN when TOKEN contains an AWS key", () => {
-    const { exitCode, decision } = runBashHook("echo $TOKEN", {
+    const { exitCode, blocked } = runBashHook("echo $TOKEN", {
       env: { TOKEN: "AKIAIOSFODNN7EXAMPLE" },
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("includes the variable name and rule in reason", () => {
@@ -368,9 +368,9 @@ describe("pre-tool-use-hook — Bash tool (command string)", () => {
   });
 
   it("blocks a Bash command containing an AWS key (e.g. echo)", () => {
-    const { exitCode, decision } = runBashHook("echo AKIAIOSFODNN7EXAMPLE");
+    const { exitCode, blocked } = runBashHook("echo AKIAIOSFODNN7EXAMPLE");
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("includes aws-access-key in reason for inline secret", () => {
@@ -394,17 +394,17 @@ describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
         `creds-${cmd}.txt`,
         "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n",
       );
-      const { exitCode, decision } = runBashHook(`${cmd} ${p}`);
+      const { exitCode, blocked } = runBashHook(`${cmd} ${p}`);
       expect(exitCode).toBe(2);
-      expect(decision).toBe("block");
+      expect(blocked).toBe(true);
     },
   );
 
   it("blocks cat on a file with PII", () => {
     const p = writeFixture("contacts-bash.txt", "Email: user@example.com\n");
-    const { exitCode, decision } = runBashHook(`cat ${p}`);
+    const { exitCode, blocked } = runBashHook(`cat ${p}`);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("allows cat on a clean file", () => {
@@ -420,9 +420,9 @@ describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
 
   it("blocks cat in a compound command (pipe) on a file with secrets", () => {
     const p = writeFixture("pipe-secret.txt", "AWS_KEY=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runBashHook(`cat ${p} | grep KEY`);
+    const { exitCode, blocked } = runBashHook(`cat ${p} | grep KEY`);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("allows cat in a compound command (pipe) on a clean file", () => {
@@ -433,9 +433,9 @@ describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
 
   it("blocks cat on a .env.* file by name", () => {
     const p = writeFixture(".env.bash-name", "DEBUG=true\n");
-    const { exitCode, decision } = runBashHook(`cat ${p}`);
+    const { exitCode, blocked } = runBashHook(`cat ${p}`);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("[allow-pii] bypasses cat on a .env.* file", () => {
@@ -499,11 +499,11 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
       "mixed-allow-pii.txt",
       "email=user@example.com\nkey=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("[allow-all] in the latest message is respected even with older messages", () => {
@@ -528,11 +528,11 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
       "config-old-allow.txt",
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("blocks when transcript path is missing (no allow tags)", () => {
@@ -540,9 +540,9 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
       "config-no-transcript.txt",
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runHook("Read", p);
+    const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("blocks when transcript path points to non-existent file", () => {
@@ -550,11 +550,11 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
       "config-bad-transcript.txt",
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: "/tmp/no-such-transcript.jsonl",
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   // ── Bash tool ──────────────────────────────────────────────────────────────
@@ -622,11 +622,11 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
       "config-second-call.txt",
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("[allow-secret] is consumed after a tool_result", () => {
@@ -635,11 +635,11 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
       { toolResult: "first tool result" },
     ]);
     const p = writeFixture("secret-consumed.txt", "key=AKIAIOSFODNN7EXAMPLE\n");
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("[allow-pii] is consumed after a tool_result", () => {
@@ -648,11 +648,11 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
       { toolResult: "previous tool output" },
     ]);
     const p = writeFixture("pii-consumed.txt", "email=user@example.com\n");
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("blocks when latest real user message has no allow tag despite earlier allow", () => {
@@ -666,11 +666,11 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
       "no-allow-after-new-msg.txt",
       "key=AKIAIOSFODNN7EXAMPLE\n",
     );
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("[allow-all] consumed for Bash after tool_result", () => {
@@ -678,11 +678,11 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
       { text: "[allow-all] run the commands" },
       { toolResult: "result of first command" },
     ]);
-    const { exitCode, decision } = runBashHook("echo AKIAIOSFODNN7EXAMPLE", {
+    const { exitCode, blocked } = runBashHook("echo AKIAIOSFODNN7EXAMPLE", {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("[allow-all] works for Bash when no tool_result yet", () => {
@@ -732,11 +732,11 @@ describe("pre-tool-use-hook — SENSITIVE_CANARY_CATEGORIES", () => {
 
   it("pii-only: still blocks a file containing PII", () => {
     const p = writeFixture("pii-only-pii.txt", "card: 4111111111111111");
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       env: { SENSITIVE_CANARY_CATEGORIES: "pii" },
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("secret-only: allows a file containing only PII", () => {
@@ -752,11 +752,11 @@ describe("pre-tool-use-hook — SENSITIVE_CANARY_CATEGORIES", () => {
       "secret-only-secret.txt",
       "key=AKIAIOSFODNN7EXAMPLE",
     );
-    const { exitCode, decision } = runHook("Read", p, {
+    const { exitCode, blocked } = runHook("Read", p, {
       env: { SENSITIVE_CANARY_CATEGORIES: "secret" },
     });
     expect(exitCode).toBe(2);
-    expect(decision).toBe("block");
+    expect(blocked).toBe(true);
   });
 
   it("secret-only: allows a bash command containing only PII", () => {

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -177,7 +177,8 @@ function block(
       fs.closeSync(fd);
     }
   } catch {
-    process.stderr.write(terminalMessage);
+    // No controlling terminal. The reason written to stderr below carries the
+    // same detection lines, so there is nothing to fall back to.
   }
 
   const reasonLines = [
@@ -191,12 +192,20 @@ function block(
     "Please tell the user about this block and suggest the appropriate tag.",
   ];
 
-  process.stdout.write(
-    `${JSON.stringify({
-      decision: "block",
-      reason: reasonLines.join("\n"),
-    })}\n`,
-  );
+  // Exit 2 blocks the tool call and stderr is the documented way to say why.
+  //
+  // The reason used to be written to stdout as `{"decision":"block", …}`. That
+  // does reach Claude on the current version — measured with a probe hook, not
+  // assumed — but the documentation says stdout is ignored on a non-zero exit
+  // and that PreToolUse takes its decision from `hookSpecificOutput`, not from a
+  // top-level `decision` field. So the old form worked by way of behaviour no
+  // longer described anywhere, and a release could drop it without breaking a
+  // documented contract. Blocking would survive that (exit 2 is the block), but
+  // the reason and the allow-tag guidance would not.
+  //
+  // When both channels carry text, stdout wins and stderr is discarded, so
+  // writing both would leave the documented one dead. Hence stderr alone.
+  process.stderr.write(`${reasonLines.join("\n")}\n`);
   process.exit(2);
 }
 


### PR DESCRIPTION
Stacked on #175, the last of the five PRs replacing #163. It sits on top because the test harness it changes is introduced down that stack; it retargets to `develop` as each one merges. Review #171 → #172 → #173 → #174 → #175 first.

## What was actually measured

#163 recorded a follow-up: the hook blocks with exit 2 plus a stdout `{"decision":"block"}` payload, while the docs describe exit 0 with `hookSpecificOutput.permissionDecision: "deny"` as the supported form and say exit 2 ignores JSON.

I checked what the runtime does, with probe hooks in a headless session rather than by reading the docs alone:

| Hook writes | What Claude receives |
|---|---|
| stdout JSON reason only, nothing on stderr | the reason, verbatim |
| stderr only | the reason, verbatim |
| both | the stdout reason; **stderr is discarded** |
| neither (bare exit 2) | `No stderr output` and nothing else |

So the current form is not broken — the reason does arrive today. I had assumed otherwise from the documentation, and that assumption was wrong.

## Why change it anyway

The behaviour the old form relies on is not described anywhere: the documentation says stdout is ignored on a non-zero exit, and that PreToolUse takes its decision from `hookSpecificOutput`, not a top-level `decision` field. A release could drop it without breaking a documented contract. Blocking would survive that — exit 2 is what stops the call — but the reason and the allow-tag guidance would not.

The migration named in #163 (exit 0 + `permissionDecision: "deny"`) was **not** taken. Its failure direction is fail-open: exit 0 lets the call through, so a runtime that does not interpret the payload loses the block itself, not just the message. It would also require raising the minimum Claude Code version in the README, and which version introduced `hookSpecificOutput` is unverified. exit 2 plus stderr is documented, fails closed, and matches how the `UserPromptSubmit` hook in this repo already reports.

Writing both was ruled out by the table above: stdout wins, so the documented channel would sit dead.

## What changed

- `block()` writes the reason to stderr and keeps exit 2. The `/dev/tty` message is unchanged; its stderr fallback is gone, since the reason on stderr carries the same detection lines.
- The harness reports `blocked` from the exit code instead of a `decision` field that was never part of this event's contract, and reads `reason` from stderr.
- `pre-tool-use-hook.test.ts` now runs through that harness. It had kept its own `HOOK` path, spawn call, `runHook`, `runBashHook` and `readVerdict` alongside it, so a change to the block contract had to be made twice — and its copy resolved the hook with `URL.pathname`, which hands `node` a percent-encoded filename under a checkout whose path contains a space. That file holds the 16 assertions on the reason text, and they are what checks that stderr carries it.
- `README.md` no longer describes the block as a JSON response.

## Verification

526 passing, 1 skipped by default. `tsc --noEmit`, `biome lint src`, `biome ci --linter-enabled=false src` and `docs:build` clean. The integration test added in #175 passes against a live session on this branch, which is what shows the reason still arrives after the move to stderr.

