### PR TITLE
refactor: move the Bash helpers into src/lib modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
+# No `branches` filter: it matches the *base* branch, so a stacked PR whose base
+# is another feature branch got no CI at all — exactly the changes that most want
+# checking, since nobody has seen them yet.
 on:
   pull_request:
-    branches: [main, develop]
 
 permissions: {}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,14 @@ on:
 
 permissions: {}
 
+# Two pushes in quick succession otherwise run two full analyses of the same
+# branch, and the older one's results are stale the moment it finishes.
+# Cancelling is safe here: every trigger analyses a single ref, so the surviving
+# run covers the tree the cancelled one was working towards.
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+# Moved off GitHub's default setup, which only analyses pull requests whose base
+# is the default or a protected branch. A PR stacked on another feature branch
+# was therefore never scanned — the same gap `ci.yml` had, and for the same
+# reason. Advanced setup is the only way to lift it, since the branches default
+# setup covers are not configurable.
+#
+# The two configurations cannot coexist: default setup has to be off for these
+# analyses to be accepted.
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+  # Default setup scanned on a schedule as well. Advisories land after a change
+  # merges, not only alongside one.
+  schedule:
+    - cron: '17 4 * * 1'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # The languages default setup was configured with. `actions` covers the
+        # workflow files themselves.
+        language: [actions, javascript-typescript]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/analyze@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -1,0 +1,48 @@
+// What this hook knows about how each command treats its operands.
+//
+// The set below is the knowledge: the commands that write the contents of the
+// files they are handed to stdout. extractFilePathsFromCommand turns a command
+// line into the paths such a command may print.
+
+import path from "node:path";
+
+const FILE_READ_COMMANDS = new Set([
+  "cat",
+  "head",
+  "tail",
+  "less",
+  "more",
+  "bat",
+  "nl",
+]);
+
+export function extractFilePathsFromCommand(command: string): string[] {
+  const paths: string[] = [];
+  const segments = command.split(/\s*[|;&]+\s*/);
+
+  for (const seg of segments) {
+    const tokens = seg.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length < 2) continue;
+
+    const cmd = path.basename(tokens[0] ?? "");
+    if (!FILE_READ_COMMANDS.has(cmd)) continue;
+
+    let skipNext = false;
+    for (let i = 1; i < tokens.length; i++) {
+      if (skipNext) {
+        skipNext = false;
+        continue;
+      }
+      const tok = tokens[i];
+      if (!tok) continue;
+      if (tok.startsWith("-")) continue;
+      if (tok === ">" || tok === ">>" || tok === "<") {
+        skipNext = true;
+        continue;
+      }
+      paths.push(tok);
+    }
+  }
+
+  return [...new Set(paths)];
+}

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -1,0 +1,17 @@
+// Shell syntax, and nothing about what any particular command means.
+//
+// Right now that is only the variable references a command line makes. It is its
+// own module because the questions are different: this one answers "what are the
+// pieces of this command line", and bash-commands.ts answers "what does a
+// command do with the pieces it is handed".
+
+// Variable names referenced by the command.
+export function extractEnvVarNames(command: string): string[] {
+  const names = new Set<string>();
+  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+  for (const match of command.matchAll(re)) {
+    const name = match[1] ?? match[2];
+    if (name) names.add(name);
+  }
+  return [...names];
+}

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { extractFilePathsFromCommand } from "./lib/bash-commands.ts";
 import {
   applyAllowTags,
   dedupeFindings,
@@ -11,6 +12,7 @@ import {
   randomBird,
 } from "./lib/inspector.ts";
 import { enabledCategoriesFromEnv, type Finding, scan } from "./lib/rules.ts";
+import { extractEnvVarNames } from "./lib/shell.ts";
 
 interface HookInput {
   transcript_path?: string;
@@ -95,59 +97,6 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
 
   if (!lastUserMessage || toolResultAfterLastText) return new Set();
   return parseAllowTags([lastUserMessage]);
-}
-
-// ── Bash helpers ──────────────────────────────────────────────────────────────
-
-const FILE_READ_COMMANDS = new Set([
-  "cat",
-  "head",
-  "tail",
-  "less",
-  "more",
-  "bat",
-  "nl",
-]);
-
-function extractEnvVarNames(command: string): string[] {
-  const names = new Set<string>();
-  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
-  for (const match of command.matchAll(re)) {
-    const name = match[1] ?? match[2];
-    if (name) names.add(name);
-  }
-  return [...names];
-}
-
-function extractFilePathsFromCommand(command: string): string[] {
-  const paths: string[] = [];
-  const segments = command.split(/\s*[|;&]+\s*/);
-
-  for (const seg of segments) {
-    const tokens = seg.trim().split(/\s+/).filter(Boolean);
-    if (tokens.length < 2) continue;
-
-    const cmd = path.basename(tokens[0] ?? "");
-    if (!FILE_READ_COMMANDS.has(cmd)) continue;
-
-    let skipNext = false;
-    for (let i = 1; i < tokens.length; i++) {
-      if (skipNext) {
-        skipNext = false;
-        continue;
-      }
-      const tok = tokens[i];
-      if (!tok) continue;
-      if (tok.startsWith("-")) continue;
-      if (tok === ">" || tok === ">>" || tok === "<") {
-        skipNext = true;
-        continue;
-      }
-      paths.push(tok);
-    }
-  }
-
-  return [...new Set(paths)];
 }
 
 // ── .env pattern ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
First of five stacked PRs replacing #163, which had grown to 2578 lines across 21 commits in one file. Review in order; each one answers a single question.

| # | PR | What it answers |
| --- | --- | --- |
| 1 | this one | where the Bash inspection lives |
| 2 | #172 | what the pieces of a command line are |
| 3 | #173 | what each command does with its operands |
| 4 | #174 | which tool calls name a file they will read |
| 5 | #175 | does Claude Code act on what the hook says |

#170 is stacked on top of #175. It predates this split and is not part of it.

## What changed

`pre-tool-use-hook.ts` keeps the transcript, the `.env` guard, the block output and the main flow. Two modules take the Bash inspection:

- `src/lib/shell.ts` — shell syntax, with nothing about what a command means.
- `src/lib/bash-commands.ts` — what a command does with its operands.

The point is the seam, not the tidying: the stacked changes add a tokenizer, around forty command classifications and a tool-input scanner, and landing all of it in one file would take it past 1400 lines with several unrelated reasons to change.

## The two CI commits

Splitting #163 into a stack exposed something the split itself did not cause, so the fix rides along here rather than in a seventh PR:

- `ci.yml` filtered `pull_request` on `branches: [main, develop]`. That filter matches the *base* branch, so every PR in this stack but the first got no CI at all — the changes nobody has seen yet were the ones going unchecked. The filter is gone.
- CodeQL ran from GitHub's default setup, which analyses only PRs based on the default or a protected branch: the same gap, for the same reason, and not configurable. It now runs from `codeql.yml` with the same languages default setup used, plus the weekly schedule default setup provided. Default setup has to be off for these analyses to be accepted.

## Verification

Nothing was rewritten. Of the 45 non-blank lines removed from the hook, 42 appear verbatim in the new modules. The other three are the section banner the move left empty, and the two function declarations, which gained `export`. develop's 343 tests pass untouched, which is what shows the behaviour did not move with the code.
