### PR TITLE
feat: parse Bash commands as shell syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,17 @@
   it, `cat <secrets` with no space, a `cat` on the second line of a multi-line
   command, `(cat secrets)`, `while cat secrets; do :; done`, and
   `echo $(cat secrets)`
+- Tokens record whether they came from a redirection operator or from a word, so
+  a quoted `>` is read as an operand. `grep ">" secrets`, an ordinary way to
+  search a file for a `>` character, previously had `secrets` skipped as though
+  it were an output target
+- Scan the value of a variable referenced through an expansion that carries a
+  suffix, such as `${TOKEN:-fallback}` or `${TOKEN#prefix}`. Only the bare
+  `$TOKEN` and `${TOKEN}` forms were recognised before
 - Heredoc bodies are treated as text, not commands: writing a script that
   mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known limitation: a
-  heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught
+  heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,
+  written up under "② PreToolUse hook" in the README
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Parse Bash commands as shell syntax rather than by splitting on whitespace.
+  The tokenizer understands quotes (including `$'…'` and `$"…"`), heredoc
+  bodies, command and process substitutions, subshells, shell keywords,
+  redirection operators and their file-descriptor prefixes. Several ordinary
+  ways of naming a file were invisible to the old split: a path with a space in
+  it, `cat <secrets` with no space, a `cat` on the second line of a multi-line
+  command, `(cat secrets)`, `while cat secrets; do :; done`, and
+  `echo $(cat secrets)`
+- Heredoc bodies are treated as text, not commands: writing a script that
+  mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known limitation: a
+  heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught
+
+---
+
 ## v0.7.0 (2026-08-04)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -468,6 +468,26 @@ PreToolUse hook
 When blocked, Claude receives a JSON response explaining the reason and is prompted to tell the user.
 The terminal also receives a direct message (via `/dev/tty`).
 
+#### Known limitation: heredoc bodies
+
+A heredoc body is treated as text, not as commands, so writing a script that mentions `.env` is not itself a read:
+
+```bash
+cat > deploy.sh <<'EOF'
+cat .env
+EOF
+```
+
+The trade-off is that a heredoc which *feeds* commands to another shell is not inspected either:
+
+```bash
+ssh host <<'EOF'
+cat /etc/secrets
+EOF
+```
+
+The `cat` inside that body runs on the remote host, and the hook does not scan it.
+
 ---
 
 ## Allow Tags (detailed)

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -1,0 +1,102 @@
+// Shared way to run the PreToolUse hook as a child process and read its verdict.
+// Both hook test files use it so that "run the hook" has one meaning and one
+// options shape, rather than a same-named helper per file.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// fileURLToPath rather than `.pathname`, which leaves a checkout under a path
+// with spaces percent-encoded and hands `node` a filename that does not exist.
+// Exported so the integration test resolves the hook the same way: two copies of
+// this line meant one of them could be left behind.
+export const HOOK = fileURLToPath(
+  new URL("../pre-tool-use-hook.ts", import.meta.url),
+);
+const NODE_FLAGS = ["--experimental-strip-types"];
+
+export interface RunOptions {
+  // Variables to add to the child environment.
+  env?: Record<string, string>;
+  // Use `env` as the whole child environment instead of adding to the parent's.
+  // Include PATH when setting this, or `node` will not be found.
+  replaceEnv?: boolean;
+  // Transcript the hook should read allow tags from.
+  transcriptPath?: string;
+}
+
+export interface HookResult {
+  // 0 allows the tool call, 2 blocks it.
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  // Whether the tool call was blocked. Named for the outcome rather than for the
+  // payload it is read from, so a test says what it means and does not have to
+  // change if the way a block is returned ever does.
+  blocked: boolean;
+  // The text the hook offers Claude on a block, from its stdout payload.
+  reason: string | null;
+}
+
+// Spawn the hook with a raw stdin payload and assemble its verdict.
+function spawnHook(input: string, opts?: RunOptions): HookResult {
+  const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
+    input,
+    encoding: "utf8",
+    env: opts?.replaceEnv ? (opts.env ?? {}) : { ...process.env, ...opts?.env },
+  });
+  const exitCode = result.status ?? -1;
+  return {
+    exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    blocked: exitCode === 2,
+    reason: parseReason(result.stdout),
+  };
+}
+
+// The hook's block payload carries the reason it offers Claude. A run that
+// allowed the call writes nothing, so there is nothing to parse.
+function parseReason(stdout: string): string | null {
+  try {
+    return (JSON.parse(stdout) as { reason?: string }).reason ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Feed the hook a raw stdin payload, for cases where the payload is not valid
+// JSON and so cannot be described as a tool call.
+export function runHookWithRawInput(input: string): HookResult {
+  return spawnHook(input);
+}
+
+// Run the hook against an arbitrary tool call.
+export function runToolHook(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  opts?: RunOptions,
+): HookResult {
+  const input = JSON.stringify({
+    transcript_path: opts?.transcriptPath,
+    tool_name: toolName,
+    tool_input: toolInput,
+  });
+  return spawnHook(input, opts);
+}
+
+// A tool call carrying a single `file_path`, as Read does.
+export function runHook(
+  toolName: string,
+  filePath: string,
+  opts?: RunOptions,
+): HookResult {
+  return runToolHook(toolName, { file_path: filePath }, opts);
+}
+
+export function runBashHook(command: string, opts?: RunOptions): HookResult {
+  return runToolHook("Bash", { command }, opts);
+}
+
+export function runGrepHook(searchPath: string, opts?: RunOptions): HookResult {
+  return runToolHook("Grep", { pattern: "foo", path: searchPath }, opts);
+}

--- a/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
+++ b/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
@@ -226,6 +226,55 @@ describe("pre-tool-use-hook — shell parsing", () => {
     });
   });
 
+  describe("redirection operators against quoted words", () => {
+    it("a quoted > is an operand, not a redirection", () => {
+      const file = writeFixture("quoted_gt.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat ">" ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("a quoted >> is an operand, not a redirection", () => {
+      const file = writeFixture("quoted_gtgt.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat ">>" ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("an unquoted > still marks the next token as an output target", () => {
+      const file = writeFixture("real_gt.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat > ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("an unquoted >> still marks the next token as an output target", () => {
+      const file = writeFixture("real_gtgt.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat >> ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("environment variable expansion", () => {
+    it("an expansion with a default should block when the var holds a secret", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook(`echo $\{TOKEN:-fallback}`, {
+        env: { PATH: pathVal, TOKEN: AWS_KEY },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("an expansion with a default should allow when the var is unset", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook(`echo $\{UNSET_VAR:-safe_default}`, {
+        env: { PATH: pathVal },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
   describe("output process substitution", () => {
     it(">(...) should block on file with secret", () => {
       const file = writeFixture("psub_out.txt", `key=${AWS_KEY}`);

--- a/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
+++ b/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
@@ -252,6 +252,23 @@ describe("pre-tool-use-hook — shell parsing", () => {
       const result = runBashHook(`cat >> ${file}`);
       expect(result.exitCode).toBe(0);
     });
+
+    // The `<` case the other direction: a printing command fed over stdin does
+    // print the file, so the token after the operator is collected rather than
+    // skipped. `wc -l <file` above is the non-read half of the same branch.
+    it("a printing command fed over < blocks, with no space", () => {
+      const file = writeFixture("stdin_nospace.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat <${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("a printing command fed over < blocks, with a space", () => {
+      const file = writeFixture("stdin_space.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat < ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
   });
 
   describe("environment variable expansion", () => {

--- a/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
+++ b/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
@@ -1,0 +1,323 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runBashHook } from "./hook-harness.ts";
+
+let tmpDir: string;
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-shell-"));
+});
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFixture(name: string, content: string) {
+  const p = join(tmpDir, name);
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+// Assembled so the full strings never appear in this file's source.
+const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
+const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
+  "",
+);
+
+describe("pre-tool-use-hook — shell parsing", () => {
+  describe("command substitution", () => {
+    it("$(...) substitution should block on file with secret", () => {
+      const file = writeFixture("sub1.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo $(cat ${file})`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("backtick substitution should block on file with secret", () => {
+      const file = writeFixture("sub2.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo \`cat ${file}\``);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("process substitution <(...) should block on file with secret", () => {
+      const file = writeFixture("sub3.txt", `api=${AWS_KEY}`);
+      const result = runBashHook(`diff <(cat ${file}) /dev/null`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("heredoc should not false positive on harmless content", () => {
+      const result = runBashHook("cat <<EOF\nhello world\nEOF");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("nested $( $(...) ) should block on file with secret", () => {
+      const file = writeFixture("sub_nested.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo $(echo $(cat ${file}))`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("$(...) inside double quotes should block", () => {
+      const file = writeFixture("sub_dq.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo "$(cat ${file})"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("$(...) inside single quotes should allow (no expansion)", () => {
+      const file = writeFixture("sub_sq.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo '$(cat ${file})'`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("classic cat should still block on secret", () => {
+      const file = writeFixture("classic.txt", `password=${AWS_KEY}`);
+      const result = runBashHook(`cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("piped commands should work", () => {
+      const file = writeFixture("pipe.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat ${file} | grep key`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("multiple arguments should all be scanned", () => {
+      const file1 = writeFixture("f1.txt", "clean");
+      const file2 = writeFixture("f2.txt", `secret=${AWS_KEY}`);
+      const result = runBashHook(`cat ${file1} ${file2}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+  });
+
+  describe("multi-line and chained commands", () => {
+    it("newline-separated commands should block if any reads secret", () => {
+      const file = writeFixture("multiline.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo hi\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("command1 && command2 should block if any reads secret", () => {
+      const file = writeFixture("and.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`ls && cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("command1; command2 should block if any reads secret", () => {
+      const file = writeFixture("semi.txt", `token=${AWS_KEY}`);
+      const result = runBashHook(`ls; cat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("newline-separated safe commands should allow", () => {
+      const result = runBashHook(`echo one\necho two`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  // A grouping construct or a shell keyword stands where a command name would.
+  // Segments led by one were classified as a command called `(cat` or `then`,
+  // and the file they read was never looked at.
+  describe("grouped and keyword-led commands", () => {
+    it("subshell should block on file with secret", () => {
+      const file = writeFixture("subshell.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`(cat ${file})`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("subshell after && should block", () => {
+      const file = writeFixture("subshell_and.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo hi && (cat ${file})`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("subshell piped onward should block", () => {
+      const file = writeFixture("subshell_pipe.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`(cat ${file}) | head`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("brace group should block on file with secret", () => {
+      const file = writeFixture("brace_group.txt", `token=${TOKEN_VALUE}`);
+      const result = runBashHook(`{ cat ${file}; }`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("command after then should block", () => {
+      const file = writeFixture("if_then.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`if true; then cat ${file}; fi`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("command after do should block", () => {
+      const file = writeFixture("for_do.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`for f in a; do cat ${file}; done`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("subshell on a clean file should allow", () => {
+      const file = writeFixture("subshell_clean.txt", "nothing here");
+      const result = runBashHook(`(cat ${file})`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // The parens are inside single quotes, so they are text rather than a group.
+    it("awk program using $(NF) should allow", () => {
+      const file = writeFixture("awk_nf.txt", "one two three");
+      const result = runBashHook(`awk '{print $(NF)}' ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // A keyword opening a condition matters as much as one opening a body: the
+    // command being tested runs too.
+    it("command in a while condition should block", () => {
+      const file = writeFixture("while_cond.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`while cat ${file}; do :; done`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("command in an until condition should block", () => {
+      const file = writeFixture("until_cond.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`until cat ${file}; do :; done`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("command in an if condition should block", () => {
+      const file = writeFixture("if_cond.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`if cat ${file}; then :; fi`);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("a quoted subshell is text and should allow", () => {
+      const file = writeFixture("quoted_subshell.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo '(cat ${file})'`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("quoted paths and dd", () => {
+    it("filename with space should block when secret is read", () => {
+      const file = writeFixture("with space.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat "${file}"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("if=<secretFile> without dd (echo) should allow", () => {
+      const file = writeFixture("not_dd.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`echo if=${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("wc -l <secretFile> (wc outputs only count) should allow", () => {
+      const file = writeFixture("wc_file.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`wc -l ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("output process substitution", () => {
+    it(">(...) should block on file with secret", () => {
+      const file = writeFixture("psub_out.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`echo hi >(cat ${file})`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+  });
+
+  describe("heredoc bodies", () => {
+    it("heredoc writing a script that mentions .env should allow", () => {
+      const result = runBashHook("cat > deploy.sh <<'EOF'\ncat .env\nEOF");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("heredoc body naming a sensitive file should allow (body is text)", () => {
+      const file = writeFixture("heredoc_body.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat > s.sh <<EOF\ncat ${file}\nEOF`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("<<- heredoc with tab-indented delimiter should allow", () => {
+      const result = runBashHook("cat > s.sh <<-EOF\n\tcat .env\n\tEOF");
+      expect(result.exitCode).toBe(0);
+    });
+
+    // Known limitation: the body is skipped entirely, so a heredoc that feeds
+    // commands to a remote shell is no longer caught.
+    it("ssh heredoc running cat on a sensitive file is not caught (documented limitation)", () => {
+      const file = writeFixture("ssh_heredoc.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`ssh host <<EOF\ncat ${file}\nEOF`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("command after the heredoc still scans", () => {
+      const file = writeFixture("after_heredoc.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat <<EOF\nhi\nEOF\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // A delimiter cut short never matches its closing line, and every following
+    // line is then swallowed as body — hiding the read that comes after it.
+    it("command after a hyphenated heredoc delimiter still scans", () => {
+      const file = writeFixture("hyphen_delim.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat > s.sh <<EOF-1\nhi\nEOF-1\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("command after a partly quoted heredoc delimiter still scans", () => {
+      const file = writeFixture("mixed_delim.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat > s.sh <<E"O"F\nhi\nEOF\ncat ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("hyphenated delimiter still hides its own body", () => {
+      const result = runBashHook("cat > deploy.sh <<EOF-1\ncat .env\nEOF-1");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("ANSI-C and locale quoting", () => {
+    it("cat $'<path>' should block on file with secret", () => {
+      const file = writeFixture("ansi_c.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat $'${file}'`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it('cat $"<path>" should block on file with secret', () => {
+      const file = writeFixture("locale_q.txt", `key=${TOKEN_VALUE}`);
+      const result = runBashHook(`cat $"${file}"`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("cat $'<path with space>' should block", () => {
+      const file = writeFixture("ansi space.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`cat $'${file}'`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("$'...' hex escapes should decode", () => {
+      const file = writeFixture("hexesc.txt", `key=${AWS_KEY}`);
+      // "hexesc" as h e x e \x73 c
+      const escaped = file.replace("hexesc", "hexe\\x73c");
+      const result = runBashHook(`cat $'${escaped}'`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+  });
+});

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -2,9 +2,16 @@
 //
 // The set below is the knowledge: the commands that write the contents of the
 // files they are handed to stdout. extractFilePathsFromCommand turns a command
-// line into the paths such a command may print.
+// line into the paths such a command may print, leaving the parsing to shell.ts.
 
 import path from "node:path";
+import {
+  extractSubstitutions,
+  isNonCommandToken,
+  isRedirectionOperator,
+  stripHeredocBodies,
+  tokenizeCommand,
+} from "./shell.ts";
 
 const FILE_READ_COMMANDS = new Set([
   "cat",
@@ -16,30 +23,53 @@ const FILE_READ_COMMANDS = new Set([
   "nl",
 ]);
 
-export function extractFilePathsFromCommand(command: string): string[] {
+// Recursion limit for command substitutions.
+const MAX_NESTING_DEPTH = 4;
+
+// Paths whose contents a command on this line may write to stdout.
+export function extractFilePathsFromCommand(
+  command: string,
+  depth = 0,
+): string[] {
+  if (depth > MAX_NESTING_DEPTH) return [];
   const paths: string[] = [];
-  const segments = command.split(/\s*[|;&]+\s*/);
 
-  for (const seg of segments) {
-    const tokens = seg.trim().split(/\s+/).filter(Boolean);
-    if (tokens.length < 2) continue;
+  // Heredoc bodies are text, not commands; strip them before any other pass.
+  const text = stripHeredocBodies(command);
 
-    const cmd = path.basename(tokens[0] ?? "");
-    if (!FILE_READ_COMMANDS.has(cmd)) continue;
+  // `echo $(cat secrets)` reads secrets just as `cat secrets` does.
+  for (const inner of extractSubstitutions(text)) {
+    paths.push(...extractFilePathsFromCommand(inner, depth + 1));
+  }
+
+  for (const tokens of tokenizeCommand(text)) {
+    // The command is the first token that is not a flag, a redirection or a
+    // `VAR=value` assignment, and not a keyword standing where a name would.
+    const lead = tokens.findIndex((t) => !isNonCommandToken(t));
+    if (lead === -1) continue;
+    if (!FILE_READ_COMMANDS.has(path.basename(tokens[lead] ?? ""))) continue;
 
     let skipNext = false;
-    for (let i = 1; i < tokens.length; i++) {
+    let collectNext = false;
+    for (const tok of tokens.slice(lead + 1)) {
       if (skipNext) {
         skipNext = false;
         continue;
       }
-      const tok = tokens[i];
-      if (!tok) continue;
-      if (tok.startsWith("-")) continue;
-      if (tok === ">" || tok === ">>" || tok === "<") {
-        skipNext = true;
+      if (collectNext) {
+        collectNext = false;
+        paths.push(tok);
         continue;
       }
+      if (tok === "<") {
+        collectNext = true; // stdin is fed from the next token
+        continue;
+      }
+      if (isRedirectionOperator(tok)) {
+        skipNext = true; // an output target or a heredoc delimiter
+        continue;
+      }
+      if (tok.startsWith("-")) continue;
       paths.push(tok);
     }
   }

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -23,7 +23,9 @@ const FILE_READ_COMMANDS = new Set([
   "nl",
 ]);
 
-// Recursion limit for command substitutions.
+// How deep a chain of nested command substitutions is followed. `depth` counts
+// nesting, so the command line itself is 0 and four levels of substitution below
+// it are inspected.
 const MAX_NESTING_DEPTH = 4;
 
 // Paths whose contents a command on this line may write to stdout.
@@ -47,7 +49,8 @@ export function extractFilePathsFromCommand(
     // `VAR=value` assignment, and not a keyword standing where a name would.
     const lead = tokens.findIndex((t) => !isNonCommandToken(t));
     if (lead === -1) continue;
-    if (!FILE_READ_COMMANDS.has(path.basename(tokens[lead] ?? ""))) continue;
+    const leadName = path.basename(tokens[lead]?.value ?? "");
+    if (!FILE_READ_COMMANDS.has(leadName)) continue;
 
     let skipNext = false;
     let collectNext = false;
@@ -58,19 +61,18 @@ export function extractFilePathsFromCommand(
       }
       if (collectNext) {
         collectNext = false;
-        paths.push(tok);
-        continue;
-      }
-      if (tok === "<") {
-        collectNext = true; // stdin is fed from the next token
+        paths.push(tok.value);
         continue;
       }
       if (isRedirectionOperator(tok)) {
-        skipNext = true; // an output target or a heredoc delimiter
+        // `<` feeds stdin from the next token; every other form names an output
+        // target or a heredoc delimiter.
+        if (tok.value === "<") collectNext = true;
+        else skipNext = true;
         continue;
       }
-      if (tok.startsWith("-")) continue;
-      paths.push(tok);
+      if (tok.value.startsWith("-")) continue;
+      paths.push(tok.value);
     }
   }
 

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -1,17 +1,466 @@
 // Shell syntax, and nothing about what any particular command means.
 //
-// Right now that is only the variable references a command line makes. It is its
-// own module because the questions are different: this one answers "what are the
-// pieces of this command line", and bash-commands.ts answers "what does a
-// command do with the pieces it is handed".
+// Splitting a command line into segments and tokens, quote removal, heredoc
+// bodies, and the substitutions whose inner text is a command line of its own.
+// Everything here answers "what are the pieces of this command line". What a
+// piece does with its operands is bash-commands.ts.
 
-// Variable names referenced by the command.
+// Longest quoted literal inside inline code still treated as a path candidate.
+const MAX_QUOTED_LITERAL_LENGTH = 4096;
+
+// Variable names referenced by the command, including expansion forms that carry
+// a suffix such as `${TOKEN:-fallback}` or `${TOKEN#prefix}`.
 export function extractEnvVarNames(command: string): string[] {
   const names = new Set<string>();
-  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
   for (const match of command.matchAll(re)) {
     const name = match[1] ?? match[2];
     if (name) names.add(name);
   }
   return [...names];
+}
+
+// Split a command line into segments (at |, ;, &, &&, || and newlines) and each
+// segment into tokens with quotes removed. Redirection operators become tokens of
+// their own so that `wc -l <f` and `wc -l < f` tokenize alike. Substitutions are
+// left in place; extractSubstitutions handles them against the raw string.
+export function tokenizeCommand(command: string): string[][] {
+  const segments: string[][] = [];
+  let tokens: string[] = [];
+  let current = "";
+  let hasCurrent = false;
+  let i = 0;
+
+  const endToken = (): void => {
+    if (hasCurrent) {
+      tokens.push(current);
+      current = "";
+      hasCurrent = false;
+    }
+  };
+  const endSegment = (): void => {
+    endToken();
+    if (tokens.length > 0) segments.push(tokens);
+    tokens = [];
+  };
+
+  while (i < command.length) {
+    const ch = command[i] as string;
+
+    if (ch === "\\") {
+      const next = command[i + 1];
+      if (next !== undefined && next !== "\n") {
+        current += next;
+        hasCurrent = true;
+      }
+      i += next === undefined ? 1 : 2;
+      continue;
+    }
+
+    if (
+      ch === "'" ||
+      ch === '"' ||
+      (ch === "$" && (command[i + 1] === "'" || command[i + 1] === '"'))
+    ) {
+      // $'...' (ANSI-C) and $"..." (locale) are quoting syntax: the `$` is not
+      // part of the token. Inside $'...', backslash escapes are decoded.
+      let quote = ch;
+      let ansiC = false;
+      if (ch === "$") {
+        quote = command[i + 1] as string;
+        ansiC = quote === "'";
+        i += 2;
+      } else {
+        i++;
+      }
+      hasCurrent = true;
+      while (i < command.length && command[i] !== quote) {
+        if (command[i] === "\\" && command[i + 1] !== undefined) {
+          if (quote === '"' || ansiC) {
+            current += ansiC
+              ? decodeAnsiCEscape(command, i)
+              : (command[i + 1] as string);
+            i += ansiC ? ansiCEscapeLength(command, i) : 2;
+            continue;
+          }
+          // plain single quotes keep backslashes literal
+        }
+        current += command[i];
+        i++;
+      }
+      i++; // closing quote, or end of input for an unbalanced one
+      continue;
+    }
+
+    if (ch === "|" || ch === ";" || ch === "&" || ch === "\n") {
+      endSegment();
+      while (i < command.length && /[|;&\n\s]/.test(command[i] as string)) i++;
+      continue;
+    }
+
+    // A subshell holds a command line of its own. Without this, `(cat secrets)`
+    // tokenized as `(cat` and `secrets)`, naming neither a command this hook
+    // classifies nor a path that exists, and the read went unseen. The opening
+    // paren of `$(`, `<(` and `>(` lands here too, which only means the inner
+    // command is reached twice — extractSubstitutions already recurses into it,
+    // and the paths are deduplicated.
+    if (ch === "(" || ch === ")") {
+      endSegment();
+      i++;
+      continue;
+    }
+
+    if (ch === "<" || ch === ">") {
+      // A file-descriptor prefix belongs to the operator, not to a token of its
+      // own: `env 2>err` has to tokenize like `env >err`, or the `2` reads as
+      // env's subcommand and the environment dump goes unnoticed. The number
+      // names neither a file nor a command, so it is dropped. Only digits
+      // written against the operator count, leaving `sort 1 >out` alone.
+      if (hasCurrent && /^\d+$/.test(current)) {
+        current = "";
+        hasCurrent = false;
+      }
+      endToken();
+      let op = ch;
+      i++;
+      while (i < command.length && command[i] === ch) {
+        op += ch;
+        i++;
+      }
+      tokens.push(op);
+      continue;
+    }
+
+    if (ch === " " || ch === "\t" || ch === "\r") {
+      endToken();
+      i++;
+      continue;
+    }
+
+    current += ch;
+    hasCurrent = true;
+    i++;
+  }
+
+  endSegment();
+  return segments;
+}
+
+// Length of the ANSI-C escape starting at `command[i]` (a backslash), so the
+// tokenizer can skip the whole sequence: \xHH is 4 chars, anything else is 2.
+function ansiCEscapeLength(command: string, i: number): number {
+  return command[i + 1] === "x" &&
+    /^[0-9A-Fa-f]{2}$/.test(command.slice(i + 2, i + 4))
+    ? 4
+    : 2;
+}
+
+// Decode the ANSI-C escape starting at `command[i]` (a backslash). Covers the
+// escapes that appear in paths: \\, \', \", \xHH and the common letter escapes.
+function decodeAnsiCEscape(command: string, i: number): string {
+  const esc = command[i + 1] as string;
+  if (esc === "x" && /^[0-9A-Fa-f]{2}$/.test(command.slice(i + 2, i + 4))) {
+    return String.fromCharCode(
+      Number.parseInt(command.slice(i + 2, i + 4), 16),
+    );
+  }
+  const simple: Record<string, string> = {
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    n: "\n",
+    t: "\t",
+    r: "\r",
+    "0": "\0",
+  };
+  return simple[esc] ?? esc;
+}
+
+// One heredoc delimiter introduced by a command line. `allowTabs` marks the
+// `<<-` form, whose closing delimiter may be tab-indented.
+interface HeredocDelimiter {
+  delim: string;
+  allowTabs: boolean;
+}
+
+// The delimiter word starting at `line[from]`, with quote removal applied the way
+// the shell does it: `<<EOF`, `<<'EOF'`, `<<"EOF"` and `<<E"O"F` all end their
+// body at the line `EOF`. The word ends at whitespace or a shell metacharacter.
+//
+// A narrower character class (`[A-Za-z0-9_.]`) used to cut the word short, and the
+// truncated delimiter then never matched the real closing line: stripHeredocBodies
+// swallowed the rest of the command, so `cat > f <<EOF-1 … EOF-1` followed by
+// `cat .env` hid the read entirely.
+function readHeredocDelimiter(
+  line: string,
+  from: number,
+): { delim: string; next: number } {
+  let delim = "";
+  let i = from;
+
+  while (i < line.length) {
+    const ch = line[i] as string;
+    if (ch === "'" || ch === '"') {
+      i++;
+      while (i < line.length && line[i] !== ch) {
+        if (ch === '"' && line[i] === "\\" && line[i + 1] !== undefined) {
+          delim += line[i + 1];
+          i += 2;
+          continue;
+        }
+        delim += line[i];
+        i++;
+      }
+      i++; // closing quote, or end of line for an unbalanced one
+      continue;
+    }
+    if (ch === "\\" && line[i + 1] !== undefined) {
+      delim += line[i + 1];
+      i += 2;
+      continue;
+    }
+    if (/[\s|&;()<>`]/.test(ch)) break;
+    delim += ch;
+    i++;
+  }
+
+  return { delim, next: i };
+}
+
+// Heredoc delimiters introduced by one command line, in order. `<<-` allows a
+// tab-indented closing delimiter; `<<<` is a herestring and is not a heredoc.
+// Matches outside quotes only, so `echo "a <<EOF b"` is not a heredoc start.
+function findHeredocDelimiters(line: string): HeredocDelimiter[] {
+  const found: HeredocDelimiter[] = [];
+  let quote: string | null = null;
+  let i = 0;
+
+  while (i < line.length) {
+    const ch = line[i] as string;
+    if (quote !== null) {
+      if (quote === '"' && ch === "\\") i++;
+      else if (ch === quote) quote = null;
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === "<" && line[i + 1] === "<") {
+      let j = i + 2;
+      let allowTabs = false;
+      if (line[j] === "-") {
+        allowTabs = true;
+        j++;
+      }
+      if (line[j] === "<") {
+        i = j; // herestring
+        continue;
+      }
+      while (line[j] === " " || line[j] === "\t") j++;
+      const { delim, next } = readHeredocDelimiter(line, j);
+      if (delim) found.push({ delim, allowTabs });
+      i = next;
+      continue;
+    }
+    i++;
+  }
+
+  return found;
+}
+
+// Remove heredoc bodies from a command line. A body is text, not commands —
+// `cat > deploy.sh <<EOF` followed by a script that mentions `.env` reads
+// nothing, and scanning the body as shell blocked exactly that everyday case.
+// The trade-off: a heredoc that *feeds* commands to a remote shell
+// (`ssh host <<EOF\ncat /secret\nEOF`) is no longer caught. Documented as a
+// known limitation in the README.
+export function stripHeredocBodies(command: string): string {
+  const lines = command.split("\n");
+  const kept: string[] = [];
+  const pending: HeredocDelimiter[] = [];
+
+  for (const line of lines) {
+    if (pending.length > 0) {
+      const first = pending[0] as HeredocDelimiter;
+      const cmp = first.allowTabs ? line.replace(/^\t+/, "") : line;
+      if (cmp === first.delim) pending.shift();
+      continue;
+    }
+    pending.push(...findHeredocDelimiters(line));
+    kept.push(line);
+  }
+
+  return kept.join("\n");
+}
+
+// Substitution syntaxes whose inner text is a command line in its own right.
+// Command substitution and backticks expand inside double quotes; the process
+// substitutions do not, so `echo "<(cat f)"` is a literal string.
+const SUBSTITUTIONS = [
+  { open: "$(", close: ")", expandsInDoubleQuotes: true },
+  { open: "<(", close: ")", expandsInDoubleQuotes: false },
+  { open: ">(", close: ")", expandsInDoubleQuotes: false },
+  { open: "`", close: "`", expandsInDoubleQuotes: true },
+];
+
+// Index of the character closing a substitution whose body starts at `from`.
+// Parentheses are counted rather than matched with a regex, because a body
+// carries parentheses of its own: `$(python3 -c "print(open('.env').read())")`
+// was cut short at the first `)` by the old `[^()]*` pattern, and the read it
+// contained was never scanned. Quotes and backslashes inside the body are
+// respected. An unbalanced substitution runs to the end of the string.
+function findSubstitutionEnd(
+  command: string,
+  from: number,
+  close: string,
+): number {
+  let depth = 0;
+  let quote: string | null = null;
+
+  for (let i = from; i < command.length; i++) {
+    const ch = command[i] as string;
+    if (ch === "\\" && quote !== "'") {
+      i++;
+      continue;
+    }
+    if (quote !== null) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (close === "`") {
+      if (ch === "`") return i;
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      if (depth === 0) return i;
+      depth--;
+    }
+  }
+
+  return command.length;
+}
+
+// Inner text of every outermost command substitution, process substitution and
+// backtick expression. Each is a command line in its own right; nested ones are
+// reached because extractCommandRefs recurses into what this returns.
+export function extractSubstitutions(command: string): string[] {
+  const found: string[] = [];
+  let quote: string | null = null;
+  let i = 0;
+
+  while (i < command.length) {
+    const ch = command[i] as string;
+
+    if (ch === "\\") {
+      i += quote === "'" ? 1 : 2;
+      continue;
+    }
+    if (quote === "'") {
+      if (ch === quote) quote = null;
+      i++;
+      continue;
+    }
+    if (quote === '"' && ch === '"') {
+      quote = null;
+      i++;
+      continue;
+    }
+    if (quote === null && (ch === "'" || ch === '"')) {
+      quote = ch;
+      i++;
+      continue;
+    }
+
+    const opener = SUBSTITUTIONS.find(
+      (s) =>
+        command.startsWith(s.open, i) &&
+        (quote === null || s.expandsInDoubleQuotes),
+    );
+    if (opener === undefined) {
+      i++;
+      continue;
+    }
+
+    const bodyStart = i + opener.open.length;
+    const end = findSubstitutionEnd(command, bodyStart, opener.close);
+    found.push(command.slice(bodyStart, end));
+    i = end + 1;
+  }
+
+  return found;
+}
+
+// True for a redirection operator token: `<`, `>`, `<<`, `>>`, `<<<`. The
+// tokenizer emits each on its own, with any file-descriptor prefix dropped, and
+// the token after one is a target or a heredoc delimiter rather than an operand.
+export function isRedirectionOperator(token: string): boolean {
+  return /^[<>]+$/.test(token);
+}
+
+// Shell keywords and the brace-group delimiters. They stand where a command
+// name would, so a segment led by one used to be classified as a command called
+// `{` or `then` and its operands never looked at: `{ cat secrets; }`,
+// `if …; then cat secrets; fi` and `while cat secrets; do :; done` all read a
+// file nothing noticed. The keywords that open a condition (`if`, `while`,
+// `until`) matter as much as the ones that open a body: the command being tested
+// runs too.
+const SHELL_KEYWORD_TOKENS = new Set([
+  "{",
+  "}",
+  "!",
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "while",
+  "until",
+  "for",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "select",
+]);
+
+// True for a token that cannot name a command: a flag, a redirection operator,
+// a `VAR=value` assignment placed before one, or a shell keyword.
+export function isNonCommandToken(token: string): boolean {
+  if (token.startsWith("-") || token.startsWith("<") || token.startsWith(">")) {
+    return true;
+  }
+  if (SHELL_KEYWORD_TOKENS.has(token)) return true;
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+// Quoted literals inside inline program text — the ".env" in
+// `python3 -c "print(open('.env').read())"`. Literals containing line breaks or
+// tabs are skipped: those are messages and patterns, not paths. Spaces are
+// kept, so a path like `open('my secret.txt')` is still found.
+export function extractQuotedLiterals(code: string): string[] {
+  const literals: string[] = [];
+  for (const match of code.matchAll(/'([^']*)'|"([^"]*)"/g)) {
+    const value = match[1] ?? match[2];
+    if (
+      value &&
+      value.length <= MAX_QUOTED_LITERAL_LENGTH &&
+      !/[\t\r\n]/.test(value)
+    ) {
+      literals.push(value);
+    }
+  }
+  return literals;
 }

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -5,8 +5,18 @@
 // Everything here answers "what are the pieces of this command line". What a
 // piece does with its operands is bash-commands.ts.
 
-// Longest quoted literal inside inline code still treated as a path candidate.
-const MAX_QUOTED_LITERAL_LENGTH = 4096;
+// One token of a command line, with quotes removed.
+//
+// `redirect` records where the token came from, which quote removal otherwise
+// destroys: `cat > out` writes a file and `cat ">" secrets` reads one, yet both
+// yield a token whose text is `>`. Reading the text alone, the second looked
+// like a redirection and the operand after it was skipped as an output target —
+// so `grep ">" secrets`, an ordinary way to search for a `>` character, went
+// unscanned. Only the source form separates the two.
+export interface ShellToken {
+  value: string;
+  redirect: boolean;
+}
 
 // Variable names referenced by the command, including expansion forms that carry
 // a suffix such as `${TOKEN:-fallback}` or `${TOKEN#prefix}`.
@@ -24,16 +34,16 @@ export function extractEnvVarNames(command: string): string[] {
 // segment into tokens with quotes removed. Redirection operators become tokens of
 // their own so that `wc -l <f` and `wc -l < f` tokenize alike. Substitutions are
 // left in place; extractSubstitutions handles them against the raw string.
-export function tokenizeCommand(command: string): string[][] {
-  const segments: string[][] = [];
-  let tokens: string[] = [];
+export function tokenizeCommand(command: string): ShellToken[][] {
+  const segments: ShellToken[][] = [];
+  let tokens: ShellToken[] = [];
   let current = "";
   let hasCurrent = false;
   let i = 0;
 
   const endToken = (): void => {
     if (hasCurrent) {
-      tokens.push(current);
+      tokens.push({ value: current, redirect: false });
       current = "";
       hasCurrent = false;
     }
@@ -112,10 +122,11 @@ export function tokenizeCommand(command: string): string[][] {
 
     if (ch === "<" || ch === ">") {
       // A file-descriptor prefix belongs to the operator, not to a token of its
-      // own: `env 2>err` has to tokenize like `env >err`, or the `2` reads as
-      // env's subcommand and the environment dump goes unnoticed. The number
-      // names neither a file nor a command, so it is dropped. Only digits
-      // written against the operator count, leaving `sort 1 >out` alone.
+      // own, so `cmd 2>err` tokenizes like `cmd >err`. Left as a token, the `2`
+      // would read as an operand of the command — a filename, or a subcommand
+      // for whatever later decides what a command does with its operands. It
+      // names neither, so it is dropped. Only digits written against the
+      // operator count, leaving `sort 1 >out` alone.
       if (hasCurrent && /^\d+$/.test(current)) {
         current = "";
         hasCurrent = false;
@@ -127,7 +138,7 @@ export function tokenizeCommand(command: string): string[][] {
         op += ch;
         i++;
       }
-      tokens.push(op);
+      tokens.push({ value: op, redirect: true });
       continue;
     }
 
@@ -279,8 +290,8 @@ function findHeredocDelimiters(line: string): HeredocDelimiter[] {
 // `cat > deploy.sh <<EOF` followed by a script that mentions `.env` reads
 // nothing, and scanning the body as shell blocked exactly that everyday case.
 // The trade-off: a heredoc that *feeds* commands to a remote shell
-// (`ssh host <<EOF\ncat /secret\nEOF`) is no longer caught. Documented as a
-// known limitation in the README.
+// (`ssh host <<EOF\ncat /secret\nEOF`) is no longer caught. Written up as a
+// known limitation under "② PreToolUse hook" in the README.
 export function stripHeredocBodies(command: string): string {
   const lines = command.split("\n");
   const kept: string[] = [];
@@ -353,8 +364,9 @@ function findSubstitutionEnd(
 }
 
 // Inner text of every outermost command substitution, process substitution and
-// backtick expression. Each is a command line in its own right; nested ones are
-// reached because extractCommandRefs recurses into what this returns.
+// backtick expression. Only the outermost ones: each is a command line in its
+// own right, so a nested substitution is reached by the caller feeding what this
+// returns back through it.
 export function extractSubstitutions(command: string): string[] {
   const found: string[] = [];
   let quote: string | null = null;
@@ -402,11 +414,13 @@ export function extractSubstitutions(command: string): string[] {
   return found;
 }
 
-// True for a redirection operator token: `<`, `>`, `<<`, `>>`, `<<<`. The
-// tokenizer emits each on its own, with any file-descriptor prefix dropped, and
-// the token after one is a target or a heredoc delimiter rather than an operand.
-export function isRedirectionOperator(token: string): boolean {
-  return /^[<>]+$/.test(token);
+// True for a redirection operator the tokenizer read from the source: `<`, `>`,
+// `<<`, `>>`, `<<<`, each emitted on its own with any file-descriptor prefix
+// dropped. The token after one is a target or a heredoc delimiter rather than an
+// operand. A quoted word reading `>` is not one of these, which is the whole
+// point of carrying `redirect` on the token rather than testing its text.
+export function isRedirectionOperator(token: ShellToken): boolean {
+  return token.redirect;
 }
 
 // Shell keywords and the brace-group delimiters. They stand where a command
@@ -436,31 +450,12 @@ const SHELL_KEYWORD_TOKENS = new Set([
   "select",
 ]);
 
-// True for a token that cannot name a command: a flag, a redirection operator,
-// a `VAR=value` assignment placed before one, or a shell keyword.
-export function isNonCommandToken(token: string): boolean {
-  if (token.startsWith("-") || token.startsWith("<") || token.startsWith(">")) {
-    return true;
-  }
-  if (SHELL_KEYWORD_TOKENS.has(token)) return true;
-  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
-}
-
-// Quoted literals inside inline program text — the ".env" in
-// `python3 -c "print(open('.env').read())"`. Literals containing line breaks or
-// tabs are skipped: those are messages and patterns, not paths. Spaces are
-// kept, so a path like `open('my secret.txt')` is still found.
-export function extractQuotedLiterals(code: string): string[] {
-  const literals: string[] = [];
-  for (const match of code.matchAll(/'([^']*)'|"([^"]*)"/g)) {
-    const value = match[1] ?? match[2];
-    if (
-      value &&
-      value.length <= MAX_QUOTED_LITERAL_LENGTH &&
-      !/[\t\r\n]/.test(value)
-    ) {
-      literals.push(value);
-    }
-  }
-  return literals;
+// True for a token that cannot name a command: a redirection operator, a flag, a
+// `VAR=value` assignment placed before one, or a shell keyword.
+export function isNonCommandToken(token: ShellToken): boolean {
+  if (token.redirect) return true;
+  const { value } = token;
+  if (value.startsWith("-")) return true;
+  if (SHELL_KEYWORD_TOKENS.has(value)) return true;
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(value);
 }


### PR DESCRIPTION
Second of five stacked PRs replacing #163. Stacked on #171 — review that first; this PR's diff shows only its own change once #171 merges.

## Why

The command line was split on whitespace and on `[|;&]`. Several ordinary ways of naming a file were invisible to that split, each verified against the hook before this change:

| command | before |
| --- | --- |
| `cat "my secrets.txt"` | the quotes made two tokens |
| `cat <secrets` | `<secrets` was one token, and a path called `<secrets` does not exist |
| `echo hi` newline `cat secrets` | only the first line was split into a segment |
| `(cat secrets)` | the command was `(cat`, the path `secrets)` |
| `while cat secrets; do :; done` | the command was `while` |
| `echo $(cat secrets)` | the substitution was never entered |

## What changed

`src/lib/shell.ts` answers what the pieces of a command line are:

- segments and tokens with quote removal, including `$'…'` (ANSI-C, with `\xHH`) and `$"…"`
- heredoc bodies stripped as the text they are, with the delimiter read as a shell word so `<<EOF-1` and `<<E"O"F` close where they actually close
- command, process and backtick substitutions, found by counting parentheses so a body carrying parentheses of its own is not cut short
- subshells and brace groups as command lines in their own right, and the keywords that stand where a command name would
- redirection operators emitted as tokens of their own, with any file-descriptor prefix dropped, so `cmd 2>err` tokenizes like `cmd >err` and the `2` is not left standing as an operand of `cmd`
- each token records whether it came from a redirection operator or from a word, because quote removal destroys the difference: `cat > out` writes a file and `cat ">" secrets` reads one, and both leave a token whose text is `>`

**What a command does with those pieces is unchanged** — still the same seven content-printing commands. Expanding that list is the next PR in the stack. Keeping it fixed here is what makes the new tests readable as statements about parsing rather than about coverage.

`extractEnvVarNames` also accepts an expansion carrying a suffix, so `${TOKEN:-fallback}` and `${TOKEN#prefix}` have their variable scanned. Only `$TOKEN` and `${TOKEN}` were recognised before.

## Verification

393 tests pass: develop's 343 unchanged, plus 50 in `pre-tool-use-hook-shell-parsing.test.ts` covering substitutions, multi-line and chained commands, quoted paths, subshells and keyword-led commands, heredoc bodies, ANSI-C quoting, quoted redirection operators, stdin redirection into a printing command, and expansions with a default.

The quoted-redirection case was measured before and after: `cat ">" <file with a secret>` exited 0 before the change and exits 2 after it, while `cat > <file>` and `cat >> <file>` still exit 0 and `cat < <file>` still exits 2.

Two tests from the same area are held back for the next PR because they need capability this one does not add: `$(python3 -c …)` and `dd if=`.

