### PR TITLE
feat: scan the file inputs of Grep and MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,16 @@
   output is redirected
 - Treat commands that only measure a file (`wc`, `cksum`, `md5sum`, `sha1sum`,
   `sha256sum`) as non-reads, whether the file is named or fed in over `<`
-- Inspect the `Grep` tool: its `path` is scanned when it names a regular file
-- Inspect every other tool, MCP included: input fields that name an existing
-  regular file (`path`, `file_path`, nested up to two levels) are scanned before
-  the call. `Write`, `Edit`, `Glob`, `TodoWrite` and tools whose name leads with a
-  write verb are exempt, since naming a file they do not read is not a leak. The
-  default matcher becomes `Read|Bash|Grep|mcp__.*`
+- Inspect the file inputs of every tool other than `Read` and `Bash`, `Grep` and
+  the MCP tools included. An input field naming an existing regular file is
+  scanned before the call: `file_path`, `filePath`, `path`, `paths`, `file`,
+  `absolute_path` and `notebook_path`, found up to two levels down and inside
+  arrays of objects. A field naming a directory is left alone. Exempt are the
+  tools that surface no file contents (`Write`, `Edit`, `MultiEdit`,
+  `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`,
+  `AskUserQuestion`) and tools whose name leads with a write verb (`write_file`,
+  `createPage`): naming a file they do not read is not a leak. The default
+  matcher becomes `Read|Bash|Grep|mcp__.*`
 - Heredoc bodies are treated as text, not commands: writing a script that
   mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known limitation: a
   heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   output is redirected
 - Treat commands that only measure a file (`wc`, `cksum`, `md5sum`, `sha1sum`,
   `sha256sum`) as non-reads, whether the file is named or fed in over `<`
+- Inspect the `Grep` tool: its `path` is scanned when it names a regular file
+- Inspect every other tool, MCP included: input fields that name an existing
+  regular file (`path`, `file_path`, nested up to two levels) are scanned before
+  the call. `Write`, `Edit`, `Glob`, `TodoWrite` and tools whose name leads with a
+  write verb are exempt, since naming a file they do not read is not a leak. The
+  default matcher becomes `Read|Bash|Grep|mcp__.*`
 - Heredoc bodies are treated as text, not commands: writing a script that
   mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known limitation: a
   heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,12 @@
   `sha256sum`) as non-reads, whether the file is named or fed in over `<`
 - Inspect the file inputs of every tool other than `Read` and `Bash`, `Grep` and
   the MCP tools included. An input field naming an existing regular file is
-  scanned before the call: `file_path`, `filePath`, `path`, `paths`, `file`,
-  `absolute_path` and `notebook_path`, found up to two levels down and inside
-  arrays of objects. A field naming a directory is left alone. Exempt are the
-  tools that surface no file contents (`Write`, `Edit`, `MultiEdit`,
+  scanned before the call: `path`, `paths`, `file`, `files`, `filepath`,
+  `filename`, `filenames`, `absolutepath`, `notebookpath` and `sourcepath`,
+  compared with separators and case removed so that `file_path`, `filePath` and
+  `filepath` are one name. Found up to four levels down and inside arrays, of
+  strings and of objects alike. A field naming a directory is left alone.
+  Exempt are the tools that surface no file contents (`Write`, `Edit`, `MultiEdit`,
   `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`,
   `AskUserQuestion`) and tools whose name leads with a write verb (`write_file`,
   `createPage`): naming a file they do not read is not a leak. The default

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ When blocked, the terminal shows what was detected and how to bypass it.
 
 ### ② PreToolUse hook
 
-Runs just before Claude calls the `Read`, `Bash`, `Grep`, or MCP tools.
+Runs just before Claude calls the `Read`, `Bash` or `Grep` tool, or any MCP tool.
 
 ```
 Claude calls Read / Bash / Grep / MCP tool
@@ -474,15 +474,16 @@ PreToolUse hook
       │     base64, xxd, strings, diff, comm, dd, and git subcommands) targeting
       │     a named file → file contents scanned
       │
-      ├─ Grep tool ──────────────────────────────────────────────────────
-      │  1. target file path contains secret / PII → blocked
-      │
-      └─ MCP tools (mcp__*) ───────────────────────────────────────────
-         1. input fields naming an existing file (path, file_path, and nested
-            arguments) are scanned for secret / PII → blocked
+      └─ every other tool, Grep and mcp__* included ─────────────────────
+         1. input fields naming an existing file are scanned for
+            secret / PII → blocked
 ```
 
-Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Tools whose name says they write, both the built-in `Write` and `Edit` and MCP tools such as `mcp__fs__write_file`, are skipped for the same reason.
+The fields searched are `file_path`, `filePath`, `path`, `paths`, `file`, `absolute_path` and `notebook_path`, found up to two levels down and inside arrays of objects — so both `{ "path": "…" }` and `{ "args": { "paths": [{ "path": "…" }] } }` are covered. A field naming a directory is left alone.
+
+Which tools reach the hook at all is the matcher's business, and the default (`Read|Bash|Grep|mcp__.*`) sends it `Read`, `Bash`, `Grep` and every MCP tool. Widen the matcher and the same field search applies to whatever else arrives.
+
+Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Neither are the tools that surface no file contents — `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`, `AskUserQuestion` — nor any tool whose name leads with a write verb, such as `mcp__fs__write_file` or `createPage`.
 
 Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` included) edit in place and write nothing to stdout. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `--patch` or `-U<n>`.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Then add to `~/.claude/settings.json`:
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -141,7 +141,7 @@ Then add to `~/.claude/settings.json`:
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -449,32 +449,40 @@ When blocked, the terminal shows what was detected and how to bypass it.
 
 ### ② PreToolUse hook
 
-Runs just before Claude calls the `Read` or `Bash` tool.
+Runs just before Claude calls the `Read`, `Bash`, `Grep`, or MCP tools.
 
 ```
-Claude calls Read / Bash tool
+Claude calls Read / Bash / Grep / MCP tool
       ↓
 PreToolUse hook
       ↓
       ── Read tool ─────────────────────────────────────────────────────
       │  1. filename is .env / .env.* → blocked (secret category only)
       │  2. file contents contain secret / PII → blocked
-      └─ Bash tool ─────────────────────────────────────────────────────
-         1. env var values referenced in the command contain secret / PII → blocked
-         2. a bare env / printenv would print the whole environment → every
-            variable is scanned
-         3. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
-         4. the command is located past any wrapper (sudo, env VAR=1, timeout,
-            nice, xargs) and any leading VAR=value assignment
-         5. inline scripts (-c, -e, -pe) are parsed and scanned
-         6. file paths from input redirections, command substitutions and chained
-            commands are extracted and scanned
-         7. printing commands (cat, head, tail, sed, awk, grep, rg, cut, sort,
-            base64, xxd, strings, diff, comm, dd, and git subcommands) targeting
-            a named file → file contents scanned
+      │
+      ├─ Bash tool ──────────────────────────────────────────────────────
+      │  1. env var values referenced in the command contain secret / PII → blocked
+      │  2. a bare env / printenv would print the whole environment → every
+      │     variable is scanned
+      │  3. command string itself contains secret / PII (e.g. echo AKIA...) → blocked
+      │  4. the command is located past any wrapper (sudo, env VAR=1, timeout,
+      │     nice, xargs) and any leading VAR=value assignment
+      │  5. inline scripts (-c, -e, -pe) are parsed and scanned
+      │  6. file paths from input redirections, command substitutions and chained
+      │     commands are extracted and scanned
+      │  7. printing commands (cat, head, tail, sed, awk, grep, rg, cut, sort,
+      │     base64, xxd, strings, diff, comm, dd, and git subcommands) targeting
+      │     a named file → file contents scanned
+      │
+      ├─ Grep tool ──────────────────────────────────────────────────────
+      │  1. target file path contains secret / PII → blocked
+      │
+      └─ MCP tools (mcp__*) ───────────────────────────────────────────
+         1. input fields naming an existing file (path, file_path, and nested
+            arguments) are scanned for secret / PII → blocked
 ```
 
-Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes.
+Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Tools whose name says they write, both the built-in `Write` and `Edit` and MCP tools such as `mcp__fs__write_file`, are skipped for the same reason.
 
 Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` included) edit in place and write nothing to stdout. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `--patch` or `-U<n>`.
 
@@ -484,6 +492,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 ### Known Limitations
 
 - **Heredoc bodies** — a heredoc body is treated as text, not as commands, so `cat > deploy.sh <<'EOF'` writing a script that mentions `.env` is not itself a read. The trade-off is that a heredoc which *feeds* commands to another shell (`ssh host <<'EOF'` with a `cat /etc/secrets` in the body) is not inspected either.
+- **Directory targets** — nothing that names a directory rather than a file is scanned. That covers the Grep tool's `path` and a recursive search such as `grep -r pattern src/`, both of which would otherwise mean reading every file underneath.
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
 - **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
 - **`.env.*` is blocked by name** — the filename guard covers every `.env.*`, so a template like `.env.example` is blocked as well, now through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` for those.

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ PreToolUse hook
             secret / PII → blocked
 ```
 
-The fields searched are `file_path`, `filePath`, `path`, `paths`, `file`, `absolute_path` and `notebook_path`, found up to two levels down and inside arrays of objects — so both `{ "path": "…" }` and `{ "args": { "paths": [{ "path": "…" }] } }` are covered. A field naming a directory is left alone.
+The field names searched are `path`, `paths`, `file`, `files`, `filepath`, `filename`, `filenames`, `absolutepath`, `notebookpath` and `sourcepath`, compared with separators and case removed — so `file_path`, `filePath` and `filepath` are one name. They are found up to four levels down and inside arrays, both of strings and of objects, so `{ "path": "…" }`, `{ "paths": ["…"] }` and `{ "args": { "paths": [{ "path": "…" }] } }` are all covered. A field naming a directory is left alone.
 
 Which tools reach the hook at all is the matcher's business, and the default (`Read|Bash|Grep|mcp__.*`) sends it `Read`, `Bash`, `Grep` and every MCP tool. Widen the matcher and the same field search applies to whatever else arrives.
 
@@ -494,6 +494,8 @@ The terminal also receives a direct message (via `/dev/tty`).
 
 - **Heredoc bodies** — a heredoc body is treated as text, not as commands, so `cat > deploy.sh <<'EOF'` writing a script that mentions `.env` is not itself a read. The trade-off is that a heredoc which *feeds* commands to another shell (`ssh host <<'EOF'` with a `cat /etc/secrets` in the body) is not inspected either.
 - **Directory targets** — nothing that names a directory rather than a file is scanned. That covers the Grep tool's `path` and a recursive search such as `grep -r pattern src/`, both of which would otherwise mean reading every file underneath.
+- **A write-named tool that also returns contents** — the exemption reads a tool's name, and assumes a name led by a write verb means the tool surfaces no file contents. `update` and `copy` are where those two things come apart: `mcp__*__update_file` and `mcp__*__copy_file` open a file to do their work, and one that returned the result would not be scanned. Scanning them instead would block writing to a file that already holds a secret, which is not a leak, so the exemption stays as it is.
+- **Field names not on the list** — a tool that carries its path under a name outside the list above (`target`, `document`, `uri`) is not scanned. The names are compared with separators and case removed, so spelling variants of a listed name are covered, but a different word is not.
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
 - **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
 - **`.env.*` is blocked by name** — the filename guard covers every `.env.*`, so a template like `.env.example` is blocked as well, now through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` for those.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runGrepHook, runToolHook } from "./hook-harness.ts";
+
+let tmpDir: string;
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-tool-inputs-"));
+});
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFixture(name: string, content: string) {
+  const p = join(tmpDir, name);
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+// Assembled so the full strings never appear in this file's source.
+const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
+const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
+  "",
+);
+
+describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
+  describe("Grep tool", () => {
+    it("should block on file with secret", () => {
+      const file = writeFixture("grep_tool.txt", `key=${AWS_KEY}`);
+      const result = runGrepHook(file);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("should allow on clean file", () => {
+      const file = writeFixture("clean_grep.txt", "normal content");
+      const result = runGrepHook(file);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should block on .env file", () => {
+      const file = writeFixture(".env", `TOKEN=${TOKEN_VALUE}`);
+      const result = runGrepHook(file);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("should allow on directory path (known limitation)", () => {
+      const result = runGrepHook(tmpDir);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should allow on non-existent path", () => {
+      const result = runGrepHook(join(tmpDir, "nonexistent.txt"));
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("other tools and MCP", () => {
+    it("mcp__filesystem__read_text_file should block on secret", () => {
+      const file = writeFixture("mcp_secret.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__filesystem__read_text_file", {
+        path: file,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp tool with nested path should block", () => {
+      const file = writeFixture("mcp_nested.txt", `secret=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__example__tool", {
+        arguments: { file_path: file },
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp tool with path objects inside an array should block", () => {
+      const file = writeFixture("mcp_array.txt", `secret=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__example__tool", {
+        paths: [{ path: file }],
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp tool with nonexistent path should allow", () => {
+      const result = runToolHook("mcp__example__tool", {
+        path: "/api/v1/users",
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("Write tool should allow (write operations are not checked)", () => {
+      const file = writeFixture("write_target.txt", "");
+      const result = runToolHook("Write", {
+        file_path: file,
+        content: "x",
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("Glob tool should allow (not checked)", () => {
+      const file = writeFixture("glob_target.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("Glob", {
+        pattern: "*.ts",
+        path: file,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("TodoWrite tool should allow (not checked)", () => {
+      const result = runToolHook("TodoWrite", {
+        todos: [],
+      });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("write-shaped MCP tools are exempt", () => {
+    it("mcp__fs__write_file should allow", () => {
+      const file = writeFixture("mcp_write.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__write_file", {
+        path: file,
+        contents: "x",
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("mcp__fs__move_file should allow", () => {
+      const file = writeFixture("mcp_move.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__move_file", { path: file });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("mcp__fs__read_file should still block", () => {
+      const file = writeFixture("mcp_read.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__read_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // The write-name heuristic matches the tool component only: a server named
+    // "editor" or "readwrite" must not exempt the read tools it offers.
+    it("mcp__editor__read_file should block (server name is not the tool name)", () => {
+      const file = writeFixture("mcp_editor.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__editor__read_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp__readwrite__read_file should block (server name is not the tool name)", () => {
+      const file = writeFixture("mcp_readwrite.txt", `key=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__readwrite__read_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // The exemption needs the verb to lead the name. As a substring test each of
+    // these read a file while being treated as a tool that only writes.
+    it("mcp__x__get_updates should block: it reads", () => {
+      const file = writeFixture("mcp_get_updates.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__get_updates", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp__x__read_and_write_file should block: it reads too", () => {
+      const file = writeFixture("mcp_read_and_write.txt", `key=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__x__read_and_write_file", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp__x__readwrite should block", () => {
+      const file = writeFixture("mcp_rw.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__readwrite", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp__x__createPage should allow (camelCase write verb leads)", () => {
+      const file = writeFixture("mcp_camel.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__createPage", { path: file });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("TodoWrite stays exempt through the explicit list", () => {
+      const file = writeFixture("todo_write.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("TodoWrite", { path: file });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -85,6 +85,50 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
       expect(result.blocked).toBe(true);
     });
 
+    // A distinct shape from the array of objects above, reached by a different
+    // branch of the collector.
+    it("mcp tool with an array of path strings should block", () => {
+      const file = writeFixture("mcp_str_array.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__example__tool", { paths: [file] });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // Field names are compared with separators and case removed, so a tool
+    // spelling the same field differently is still seen. Listing the spellings
+    // meant `file_path` and `filePath` were covered and `filepath` was not.
+    it.each([
+      ["filepath", "alias_filepath.txt"],
+      ["FILE_PATH", "alias_shout.txt"],
+      ["filename", "alias_filename.txt"],
+      ["source_path", "alias_source.txt"],
+      ["absolutePath", "alias_abs_camel.txt"],
+    ])("mcp tool naming the field %s should block", (field, fixture) => {
+      const file = writeFixture(fixture, `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__example__tool", { [field]: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("mcp tool with a path four levels down should block", () => {
+      const file = writeFixture("mcp_deep.txt", `secret=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__example__tool", {
+        a: { b: { c: { path: file } } },
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // The bound is there so a deeply nested input cannot make the hook walk an
+    // arbitrary tree before a tool call; past it, a path is not found.
+    it("mcp tool with a path below the depth bound should allow", () => {
+      const file = writeFixture("mcp_too_deep.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__example__tool", {
+        a: { b: { c: { d: { e: { path: file } } } } },
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
     it("mcp tool with nonexistent path should allow", () => {
       const result = runToolHook("mcp__example__tool", {
         path: "/api/v1/users",

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -35,6 +35,14 @@ export const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
 // which is the direction to fail in. The built-in write tools are named
 // explicitly in TOOLS_WITHOUT_FILE_OUTPUT, so `TodoWrite` and `MultiEdit` do not
 // depend on this at all.
+//
+// What the exemption assumes is that the tool returns no file contents, which is
+// not quite what its name says. `update` and `copy` are where the two come
+// apart: a tool called `update_file` or `copy_file` opens a file to do its work,
+// and one that returned the result would go unscanned. They stay, because the
+// alternative costs more — scanning them blocks writing to a file that already
+// holds a secret, which is not a leak — and the gap that leaves is written up
+// under Known Limitations in the README.
 const WRITING_TOOL_VERBS = new Set([
   "write",
   "create",
@@ -57,19 +65,36 @@ export function isWritingTool(tool: string): boolean {
   return first !== undefined && WRITING_TOOL_VERBS.has(first.toLowerCase());
 }
 
-// Input field names that commonly carry a filesystem path.
+// Input field names that commonly carry a filesystem path, compared with
+// separators and case removed. Listing the spellings instead meant the same
+// field was missed under a different one: `file_path` and `filePath` were both
+// here, but `filepath` was not, and neither was `filename` or `source_path`.
+// Normalising is a rule where a list of spellings is a list of the ones someone
+// happened to think of.
 const PATH_FIELD_NAMES = new Set([
-  "file_path",
-  "filePath",
+  "filepath",
+  "filename",
+  "filenames",
   "path",
   "paths",
   "file",
-  "absolute_path",
-  "notebook_path",
+  "files",
+  "absolutepath",
+  "notebookpath",
+  "sourcepath",
 ]);
 
-// Depth to which a tool's input object is searched for path-bearing fields.
-const MAX_PATH_FIELD_DEPTH = 2;
+// `file_path`, `filePath`, `FILE_PATH` and `filepath` are one name here.
+function isPathFieldName(key: string): boolean {
+  return PATH_FIELD_NAMES.has(key.replace(/[^A-Za-z0-9]/g, "").toLowerCase());
+}
+
+// Depth to which a tool's input object is searched for path-bearing fields. Two
+// levels left `{ a: { b: { c: { path } } } }` unscanned, which is not a shape a
+// tool has to be perverse to use; four costs nothing on inputs this size, and
+// the bound is here at all so a deeply nested input cannot make the hook walk
+// an arbitrary tree before a tool call.
+const MAX_PATH_FIELD_DEPTH = 4;
 
 export function collectPathFields(
   input: Record<string, unknown>,
@@ -80,9 +105,9 @@ export function collectPathFields(
 
   for (const [key, value] of Object.entries(input)) {
     if (typeof value === "string") {
-      if (PATH_FIELD_NAMES.has(key)) found.push(value);
+      if (isPathFieldName(key)) found.push(value);
     } else if (Array.isArray(value)) {
-      if (PATH_FIELD_NAMES.has(key)) {
+      if (isPathFieldName(key)) {
         found.push(...value.filter((v): v is string => typeof v === "string"));
       }
       // Paths also arrive as objects inside an array, e.g.

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -1,0 +1,105 @@
+// Which tool calls name a file they are about to read.
+//
+// A tool's semantics are not knowable from its input, so this reads the tool's
+// name and the shape of its input object: the fields that carry a path, and the
+// names that say the tool writes rather than reads.
+
+// Tools that never surface the contents of a file they name. Scanning these
+// would block writing to a file that already holds a secret, which is not a leak.
+export const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
+  "Write",
+  "Edit",
+  "MultiEdit",
+  "NotebookEdit",
+  "TodoWrite",
+  "Glob",
+  "WebFetch",
+  "WebSearch",
+  "ExitPlanMode",
+  "AskUserQuestion",
+]);
+
+// A tool whose name says it writes is treated like the built-in Write and Edit:
+// naming a file it does not read is not a leak. Matched on the tool name because
+// an MCP tool's semantics are not otherwise knowable from its input. For MCP
+// tools (`mcp__<server>__<tool>`) only the tool component is matched — a server
+// named "editor" or "readwrite" must not exempt every read tool it offers.
+// The verb has to be the first word of the name, not a substring of it anywhere.
+// As a substring test this exempted reads: "update" sits inside `get_updates`,
+// and "write" inside `read_and_write_file` — a tool that returns contents was
+// treated as one that only writes. Word boundaries are the `_`/`-` in snake and
+// kebab names and the capital in camelCase, so `write_file` and `createPage`
+// still match while `overwrite_file` and `readwrite` no longer do.
+//
+// Erring this way costs a false block on a noun-first write tool (`file_write`),
+// which is the direction to fail in. The built-in write tools are named
+// explicitly in TOOLS_WITHOUT_FILE_OUTPUT, so `TodoWrite` and `MultiEdit` do not
+// depend on this at all.
+const WRITING_TOOL_VERBS = new Set([
+  "write",
+  "create",
+  "edit",
+  "update",
+  "append",
+  "delete",
+  "remove",
+  "move",
+  "rename",
+  "mkdir",
+  "copy",
+]);
+
+export function isWritingTool(tool: string): boolean {
+  const name = tool.startsWith("mcp__")
+    ? (tool.split("__").pop() ?? tool)
+    : tool;
+  const [first] = name.split(/[^A-Za-z0-9]+|(?=[A-Z])/).filter(Boolean);
+  return first !== undefined && WRITING_TOOL_VERBS.has(first.toLowerCase());
+}
+
+// Input field names that commonly carry a filesystem path.
+const PATH_FIELD_NAMES = new Set([
+  "file_path",
+  "filePath",
+  "path",
+  "paths",
+  "file",
+  "absolute_path",
+  "notebook_path",
+]);
+
+// Depth to which a tool's input object is searched for path-bearing fields.
+const MAX_PATH_FIELD_DEPTH = 2;
+
+export function collectPathFields(
+  input: Record<string, unknown>,
+  depth = 0,
+): string[] {
+  if (depth > MAX_PATH_FIELD_DEPTH) return [];
+  const found: string[] = [];
+
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === "string") {
+      if (PATH_FIELD_NAMES.has(key)) found.push(value);
+    } else if (Array.isArray(value)) {
+      if (PATH_FIELD_NAMES.has(key)) {
+        found.push(...value.filter((v): v is string => typeof v === "string"));
+      }
+      // Paths also arrive as objects inside an array, e.g.
+      // `{ paths: [{ path: "…" }] }` — recurse into those elements too.
+      for (const item of value) {
+        if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+          found.push(
+            ...collectPathFields(item as Record<string, unknown>, depth + 1),
+          );
+        }
+      }
+    } else if (value !== null && typeof value === "object") {
+      found.push(
+        ...collectPathFields(value as Record<string, unknown>, depth + 1),
+      );
+    }
+  }
+
+  return found;
+}

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -13,13 +13,19 @@ import {
 } from "./lib/inspector.ts";
 import { enabledCategoriesFromEnv, type Finding, scan } from "./lib/rules.ts";
 import { extractEnvVarNames } from "./lib/shell.ts";
+import {
+  collectPathFields,
+  isWritingTool,
+  TOOLS_WITHOUT_FILE_OUTPUT,
+} from "./lib/tool-inputs.ts";
 
 interface HookInput {
   transcript_path?: string;
   tool_name?: string;
-  tool_input?: {
+  tool_input?: Record<string, unknown> & {
     file_path?: string;
     command?: string;
+    path?: string;
   };
 }
 
@@ -196,6 +202,21 @@ function block(
 
 // ── Core scan logic ───────────────────────────────────────────────────────────
 
+// Scan a candidate only when it names an existing regular file. Tools whose
+// "path" means something else (a URL route, an object key) are left alone.
+function scanIfRegularFile(
+  candidate: string | undefined,
+  allowTags: Set<string>,
+): void {
+  if (!candidate) return;
+  try {
+    if (!fs.statSync(candidate).isFile()) return;
+  } catch {
+    return;
+  }
+  scanFile(candidate, allowTags);
+}
+
 function scanFile(filePath: string, allowTags: Set<string>): void {
   if (shouldBlockEnvFile(filePath)) {
     if (allowTags.size > 0) return;
@@ -312,6 +333,19 @@ process.stdin.on("end", () => {
     }
 
     process.exit(0);
+  }
+
+  if (tool === "Grep") {
+    scanIfRegularFile(input.path, allowTags);
+    process.exit(0);
+  }
+
+  // Any other tool, MCP tools included: those can return file contents the same
+  // way Read does, so a field naming an existing file is scanned before the call.
+  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool) && !isWritingTool(tool)) {
+    for (const candidate of collectPathFields(input)) {
+      scanIfRegularFile(candidate, allowTags);
+    }
   }
 
   process.exit(0);

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -335,13 +335,10 @@ process.stdin.on("end", () => {
     process.exit(0);
   }
 
-  if (tool === "Grep") {
-    scanIfRegularFile(input.path, allowTags);
-    process.exit(0);
-  }
-
-  // Any other tool, MCP tools included: those can return file contents the same
-  // way Read does, so a field naming an existing file is scanned before the call.
+  // Every other tool, Grep and the MCP tools included: those can return file
+  // contents the same way Read does, so a field naming an existing file is
+  // scanned before the call. Grep needs no branch of its own — its `path` is one
+  // of the fields collected here, and it is neither exempt nor named as a writer.
   if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool) && !isWritingTool(tool)) {
     for (const candidate of collectPathFields(input)) {
       scanIfRegularFile(candidate, allowTags);


### PR DESCRIPTION
Fourth of five stacked PRs replacing #163. Stacked on #173.

## Why

`Read` and `Bash` were the only tools inspected, so a tool that returns file contents by another route went unchecked. Both verified against the hook before this change: `Grep` pointed at a file holding a secret, and an MCP tool handed a `path`.

## What changed

Every tool other than `Read` and `Bash` — `Grep` and the MCP tools included — has its input searched for fields naming an existing regular file, and those files are scanned before the call. The fields were `file_path`, `filePath`, `path`, `paths`, `file`, `absolute_path` and `notebook_path`, found up to two levels down and inside arrays of objects.

**Superseded within this PR.** A later commit on this branch replaced that list with ten names compared with separators and case removed (`file_path`, `filePath` and `filepath` becoming one name), and raised the depth to four. The README, the changelog and the code comments describe the final behaviour; this paragraph described the first version and was left behind when the body was updated for test counts alone. #178 then added a second way in, for a value shaped like a path under a field name outside the list.

`Grep` gets no branch of its own: its `path` is one of those fields, and it is neither exempt nor named as a writer, so a branch for it decided the same thing twice.

Only paths that exist as regular files are read, so a `path` that means something else — a URL route, an object key — costs nothing. Directories are left alone: scanning one would mean reading every file underneath.

Exempt are the tools that surface no file contents (`Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`, `AskUserQuestion`) and any tool whose name leads with a write verb, since naming a file they do not read is not a leak. Two things about that second half:

- it matches the **tool** component of `mcp__<server>__<tool>` only, so a server called `editor` does not exempt every read tool it offers;
- the verb has to **lead** the name. As a substring test the exemption covered reads, because "update" sits inside `get_updates` and "write" inside `read_and_write_file`. Erring the other way costs a false block on a noun-first write tool (`file_write`), which is the direction to fail in.

The default matcher in `hooks/hooks.json` becomes `Read|Bash|Grep|mcp__.*`. Which tools reach the hook at all is the matcher's business; the field search applies to whatever arrives.

## Verification

524 tests, 34 new: Grep on a file, on a clean file, on `.env`, on a directory and on a missing path; MCP tools with a path, with a nested path, with a path that is not a file; and the write-name exemption table including the read tools that used to slip through it.

Removing the `Grep` branch was checked by hand as well as by those tests — `Grep` on a secret-bearing file still exits 2, `Grep` on a directory exits 0, `mcp__fs__read_file` exits 2, and `mcp__fs__write_file` and `Write` exit 0.


