### PR TITLE
test: add the integration test against a live Claude Code session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@
   `AskUserQuestion`) and tools whose name leads with a write verb (`write_file`,
   `createPage`): naming a file they do not read is not a leak. The default
   matcher becomes `Read|Bash|Grep|mcp__.*`
+- Add an opt-in integration test that runs the hook inside a real headless
+  Claude Code session and asserts both halves of the block contract: the read is
+  stopped, and the reason reaches Claude. Every other test spawns the hook and
+  reads its output itself, which says nothing about whether the runtime acts on
+  it. Set `SENSITIVE_CANARY_INTEGRATION=1` to run it; it needs credentials and
+  network, so CI skips it
 - Heredoc bodies are treated as text, not commands: writing a script that
   mentions `.env` via `cat > deploy.sh <<EOF` is not a read. Known limitation: a
   heredoc that feeds commands to a remote shell (`ssh host <<EOF`) is not caught,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,18 +7,18 @@ Thanks for your interest in contributing to Sensitive Canary!
 ```bash
 git clone https://github.com/coo-quack/sensitive-canary.git
 cd sensitive-canary
-npm install
+pnpm install
 ```
 
 ## Commands
 
 ```bash
-npm test           # Run tests
-npm run test:watch # Run tests in watch mode
-npm run typecheck  # Type check with tsc
-npm run lint       # Check with Biome
-npm run fix        # Lint + auto-fix with Biome
-npm run ci         # typecheck + lint + tests (full CI check)
+pnpm test          # Run tests
+pnpm run test:watch # Run tests in watch mode
+pnpm run typecheck  # Type check with tsc
+pnpm run lint       # Check with Biome
+pnpm run fix        # Lint + auto-fix with Biome
+pnpm run ci         # typecheck + lint + tests (full CI check)
 ```
 
 ## Branching Strategy
@@ -70,6 +70,7 @@ When bumping a version, open a PR from `develop` → `main` with:
    - This content is automatically used as the GitHub Release notes by `release.yml`
 3. Review `docs/rules.md` — add/update any changed rules
 4. Review `README.md` — update rule counts and tables if needed
+5. Run the integration test (see below) — CI never does, and it is the only check that the block still reaches Claude
 
 After merging into `main`, `release.yml` automatically:
 - Creates a git tag `vX.Y.Z`
@@ -77,13 +78,25 @@ After merging into `main`, `release.yml` automatically:
 
 The documentation site is also redeployed automatically on merge to `main`.
 
+## Integration test
+
+`src/__tests__/pre-tool-use-hook.integration.test.ts` runs the hook inside a real headless Claude Code session. It is the only test that checks Claude Code acts on what the hook says — the rest spawn the hook and read its output themselves, which passes whether or not the runtime reads that channel.
+
+It needs credentials and network, so it is opt-in and CI skips it:
+
+```bash
+SENSITIVE_CANARY_INTEGRATION=1 pnpm test src/__tests__/pre-tool-use-hook.integration.test.ts
+```
+
+Run it by hand whenever the way a block is returned changes — the exit code, the channel the reason is written to, or the shape of the payload.
+
 ## Pull Requests
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `hotfix:`, etc.)
-- All tests must pass (`npm test`)
-- Lint must pass (`npm run lint`)
+- All tests must pass (`pnpm test`)
+- Lint must pass (`pnpm run lint`)
 - One approval required to merge
 
 ## Code Style
 
-Enforced by [Biome](https://biomejs.dev/). Run `npm run fix` before committing.
+Enforced by [Biome](https://biomejs.dev/). Run `pnpm run fix` before committing.

--- a/src/__tests__/pre-tool-use-hook.integration.test.ts
+++ b/src/__tests__/pre-tool-use-hook.integration.test.ts
@@ -85,17 +85,36 @@ function runHeadless(prompt: string): string {
 
   // A session that never ran would satisfy the leak assertion for the wrong
   // reason — no output cannot contain a secret — and then fail the second one
-  // with nothing to explain why. Say so here instead.
-  if (result.error) {
+  // with nothing to explain why. Say so here instead, and separate the ways it
+  // can happen: a missing CLI, a run that never came back, and a run that came
+  // back unhappy each need a different thing done about them.
+  const error = result.error as (Error & { code?: string }) | undefined;
+  if (error?.code === "ENOENT") {
     throw new Error(
-      `could not run \`claude -p\`: ${result.error.message}. The integration test needs the Claude Code CLI on PATH and a signed-in session.`,
+      "`claude` is not on PATH. The integration test drives the real CLI; install it, or leave SENSITIVE_CANARY_INTEGRATION unset to skip.",
     );
   }
-  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-  if (output.trim() === "") {
+  if (error?.code === "ETIMEDOUT") {
     throw new Error(
-      `\`claude -p\` produced no output (exit ${result.status}). Check that the CLI is signed in.`,
+      `\`claude -p\` did not finish within ${TIMEOUT_MS} ms and was killed. A headless session is a network round trip — check connectivity before raising the timeout.`,
     );
+  }
+  if (error) {
+    throw new Error(`could not run \`claude -p\`: ${error.message}`);
+  }
+
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  // A non-zero exit means the session itself failed, not that the hook blocked
+  // anything: the hook's block is reported inside a session that still exits 0.
+  // The output is passed through because whatever went wrong is in it.
+  if (result.status !== 0) {
+    throw new Error(
+      `\`claude -p\` exited ${result.status}:\n${output.trim() || "(no output)"}`,
+    );
+  }
+  if (output.trim() === "") {
+    throw new Error("`claude -p` exited 0 but produced no output.");
   }
   return output;
 }

--- a/src/__tests__/pre-tool-use-hook.integration.test.ts
+++ b/src/__tests__/pre-tool-use-hook.integration.test.ts
@@ -1,0 +1,121 @@
+// The only test that exercises the other side of the hook contract.
+//
+// Every other test spawns the hook and reads its output itself, so the whole
+// suite can pass while Claude Code ignores everything the hook says. Nothing
+// there distinguishes a channel the runtime reads from one it does not. This
+// test runs a real headless session with the hook installed and asserts both
+// halves of the contract: the read is stopped, and the reason arrives.
+//
+// Its negative control was run by hand — a hook that exits 2 with no output at
+// all makes the session report only `No stderr output`, and the assertion below
+// fails. So the test is not vacuous.
+//
+// It needs credentials and network, so it is opt-in: set
+// SENSITIVE_CANARY_INTEGRATION=1 to run it. CI skips it. Run it by hand when the
+// block contract changes — see the "Integration test" section in CONTRIBUTING.md.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { HOOK } from "./hook-harness.ts";
+
+const ENABLED = process.env["SENSITIVE_CANARY_INTEGRATION"] === "1";
+
+// Not the canonical AKIAIOSFODNN7EXAMPLE the other tests use. That string is
+// famous enough that the session recites it from memory when asked about AWS
+// keys, and the assertion below cannot tell a recital from a leak. This value
+// has the same shape and is not in any model's training data.
+const AWS_KEY = ["AKIA", "3QF7ZLM2", "VXKD9WTB"].join("");
+
+// A headless session is a network round trip; give it room.
+const TIMEOUT_MS = 180_000;
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "sensitive-canary-integration-"));
+  writeFileSync(join(dir, "config.txt"), `aws_key=${AWS_KEY}\n`, "utf8");
+  writeFileSync(
+    join(dir, "settings.json"),
+    JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Read|Bash|Grep|mcp__.*",
+            hooks: [
+              {
+                // A hook command is run by a shell, so the path is quoted: a
+                // checkout under a directory with spaces would otherwise arrive
+                // as two arguments.
+                type: "command",
+                command: `node --experimental-strip-types "${HOOK}"`,
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    "utf8",
+  );
+});
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+// `claude -p` with the hook registered through --settings, run inside the
+// fixture directory so the file is a plain relative path in the workspace.
+// bypassPermissions keeps the run from stalling on a prompt no one can answer;
+// hooks still run, which is the point.
+function runHeadless(prompt: string): string {
+  const result = spawnSync(
+    "claude",
+    [
+      "-p",
+      prompt,
+      "--settings",
+      join(dir, "settings.json"),
+      "--permission-mode",
+      "bypassPermissions",
+    ],
+    { encoding: "utf8", cwd: dir, timeout: TIMEOUT_MS },
+  );
+
+  // A session that never ran would satisfy the leak assertion for the wrong
+  // reason — no output cannot contain a secret — and then fail the second one
+  // with nothing to explain why. Say so here instead.
+  if (result.error) {
+    throw new Error(
+      `could not run \`claude -p\`: ${result.error.message}. The integration test needs the Claude Code CLI on PATH and a signed-in session.`,
+    );
+  }
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  if (output.trim() === "") {
+    throw new Error(
+      `\`claude -p\` produced no output (exit ${result.status}). Check that the CLI is signed in.`,
+    );
+  }
+  return output;
+}
+
+describe.skipIf(!ENABLED)("PreToolUse hook in a live session", () => {
+  it(
+    "stops the read and tells Claude why",
+    () => {
+      const output = runHeadless(
+        "Read config.txt and tell me the value of aws_key.",
+      );
+
+      // Half one: the secret did not reach the conversation.
+      expect(output).not.toContain(AWS_KEY);
+
+      // Half two: the reason arrived. The allow-tag guidance is asserted rather
+      // than the word "sensitive-canary", which also appears in the message
+      // written to the terminal and would pass on that alone.
+      expect(output.toLowerCase()).toContain("allow-secret");
+    },
+    TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
Last of five stacked PRs replacing #163. Stacked on #174.

## Why

Every test in this repo spawns the hook and reads its output itself. That passes whether or not Claude Code acts on the output, so nothing in the suite distinguishes a channel the runtime reads from one it ignores — and the coverage the four PRs below add rests on an unverified assumption about the other side of the contract.

I found out the hard way that the assumption needs testing rather than reasoning: reading the hook documentation, I concluded the block reason never reached Claude and reported it as a defect. Measuring it showed the opposite. This test is what would have settled it in the first place.

## What changed

`src/__tests__/pre-tool-use-hook.integration.test.ts` installs the hook through `--settings` in a headless `claude -p` session and asserts both halves of the contract: the secret never reaches the output, and the allow-tag guidance does. It passes on this branch, which is what establishes that the block form the hook uses reaches Claude at all.

Opt-in through `SENSITIVE_CANARY_INTEGRATION=1`, since it needs credentials and network; CI skips it. `CONTRIBUTING.md` documents when to run it — whenever the exit code, the channel, or the payload shape changes — and the Release Checklist names it.

## Two things worth recording about the test itself

- **Its first version failed**, and correctly. The fixture used the canonical `AKIAIOSFODNN7EXAMPLE`; the session reported the block properly and then recited that key from memory while explaining what an AWS key looks like. The leak assertion cannot tell a recital from a leak, so the fixture now uses a key of the same shape that is in no training data.
- **Negative control**: a hook that exits 2 with no output at all makes the session report only `No stderr output`, and the assertion fails. The test is not vacuous.

## How it fails when the session does not run

An empty output would satisfy the leak assertion for the wrong reason, so the three ways the run can fail are separated and each says what to do about it:

| what happened | how it is detected |
| --- | --- |
| `claude` is not on `PATH` | `spawnSync` sets `error.code` to `ENOENT` |
| the run did not come back within the timeout | `error.code` is `ETIMEDOUT` |
| the session ran and exited non-zero | `result.status !== 0`, and the CLI's own output is passed through rather than a guess at the cause |
| the session exited 0 with nothing on either channel | `output.trim() === ""`, reported as such rather than left to fail the leak assertion for the wrong reason |

The `ENOENT` and `ETIMEDOUT` signatures were checked against `spawnSync` directly. **A signed-out session is not among them** — I have not run one, so the message does not claim to know what it looks like; whatever the CLI prints is what the failure shows. An earlier version of this description said the test was verified against a signed-out CLI. That was wrong: only the missing-CLI case was.

The non-zero-exit check needed one thing established before it was safe to add: a session whose tool call the hook blocked still exits 0. Confirmed by running the integration test with the check in place, not by assuming it.

## Scope note

`CONTRIBUTING.md` also gets an `npm` → `pnpm` rewrite in its Development Setup and Commands sections. That is unrelated to the integration test and could have been its own PR. It is here because the file was already open for the new section, and because the instructions were wrong: this repo pinned pnpm through `packageManager` in v0.4.4, so `npm install` does not reproduce the lockfile CI uses.

## Verification

524 passing, 1 skipped by default. `tsc --noEmit`, `biome lint src`, `biome ci --linter-enabled=false src` and `docs:build` clean. The integration test passes against a live session on this branch.


