### PR TITLE
fix: treat a value shaped like a path as one, whatever its field is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,12 @@
   scanned before the call: `path`, `paths`, `file`, `files`, `filepath`,
   `filename`, `filenames`, `absolutepath`, `notebookpath` and `sourcepath`,
   compared with separators and case removed so that `file_path`, `filePath` and
-  `filepath` are one name. Found up to four levels down and inside arrays, of
+  `filepath` are one name. Beyond those names, any value containing a `/` is
+  treated as a path whatever its field is called, which covers a tool carrying
+  one under `target`, `document` or `uri`. The `/` is what keeps a search
+  pattern from being read as a path — `{ "pattern": ".env" }` searches for that
+  text rather than reading the file — at the cost of missing a bare filename
+  under an unlisted name. Found up to four levels down and inside arrays, of
   strings and of objects alike. A field naming a directory is left alone.
   Exempt are the tools that surface no file contents (`Write`, `Edit`, `MultiEdit`,
   `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`,

--- a/README.md
+++ b/README.md
@@ -479,7 +479,13 @@ PreToolUse hook
             secret / PII → blocked
 ```
 
-The field names searched are `path`, `paths`, `file`, `files`, `filepath`, `filename`, `filenames`, `absolutepath`, `notebookpath` and `sourcepath`, compared with separators and case removed — so `file_path`, `filePath` and `filepath` are one name. They are found up to four levels down and inside arrays, both of strings and of objects, so `{ "path": "…" }`, `{ "paths": ["…"] }` and `{ "args": { "paths": [{ "path": "…" }] } }` are all covered. A field naming a directory is left alone.
+A value is scanned when either its field name says path or the value itself is shaped like one.
+
+The field names are `path`, `paths`, `file`, `files`, `filepath`, `filename`, `filenames`, `absolutepath`, `notebookpath` and `sourcepath`, compared with separators and case removed — so `file_path`, `filePath` and `filepath` are one name. Beyond those, any value containing a `/` is treated as a path whatever its field is called, which is what covers a tool carrying its path under `target`, `document` or `uri`.
+
+The `/` is what separates a path from a word, and it is there so that a search pattern is not read as a path: `{ "pattern": ".env" }` is a search for the text `.env`, not a read of the file, and `.env` exists in most checkouts. The cost is that a bare filename under an unlisted field name is still missed.
+
+Values are found up to four levels down and inside arrays, both of strings and of objects, so `{ "path": "…" }`, `{ "paths": ["…"] }`, `{ "args": ["/abs/…"] }` and `{ "args": { "paths": [{ "path": "…" }] } }` are all covered. A field naming a directory is left alone.
 
 Which tools reach the hook at all is the matcher's business, and the default (`Read|Bash|Grep|mcp__.*`) sends it `Read`, `Bash`, `Grep` and every MCP tool. Widen the matcher and the same field search applies to whatever else arrives.
 
@@ -495,7 +501,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **Heredoc bodies** — a heredoc body is treated as text, not as commands, so `cat > deploy.sh <<'EOF'` writing a script that mentions `.env` is not itself a read. The trade-off is that a heredoc which *feeds* commands to another shell (`ssh host <<'EOF'` with a `cat /etc/secrets` in the body) is not inspected either.
 - **Directory targets** — nothing that names a directory rather than a file is scanned. That covers the Grep tool's `path` and a recursive search such as `grep -r pattern src/`, both of which would otherwise mean reading every file underneath.
 - **A write-named tool that also returns contents** — the exemption reads a tool's name, and assumes a name led by a write verb means the tool surfaces no file contents. `update` and `copy` are where those two things come apart: `mcp__*__update_file` and `mcp__*__copy_file` open a file to do their work, and one that returned the result would not be scanned. Scanning them instead would block writing to a file that already holds a secret, which is not a leak, so the exemption stays as it is.
-- **Field names not on the list** — a tool that carries its path under a name outside the list above (`target`, `document`, `uri`) is not scanned. The names are compared with separators and case removed, so spelling variants of a listed name are covered, but a different word is not.
+- **A bare filename under an unlisted field name** — a value is treated as a path when its field name says so or when it contains a `/`. A tool passing `{ "target": "secrets.txt" }` satisfies neither, so it is not scanned. Requiring the `/` is deliberate: without it, a search for the text `.env` would be blocked as though the file had been read.
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
 - **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
 - **`.env.*` is blocked by name** — the filename guard covers every `.env.*`, so a template like `.env.example` is blocked as well, now through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` for those.

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -129,6 +129,41 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    // The field-name list can only hold names someone thought of, so a value
+    // shaped like a path is collected whatever its field is called.
+    it.each(["target", "document", "uri", "input", "attachment"])(
+      "mcp tool naming an absolute path under %s should block",
+      (field) => {
+        const file = writeFixture(`shape_${field}.txt`, `key=${AWS_KEY}`);
+        const result = runToolHook("mcp__example__tool", { [field]: file });
+        expect(result.exitCode).toBe(2);
+        expect(result.blocked).toBe(true);
+      },
+    );
+
+    it("mcp tool with an unlisted field holding an array of paths should block", () => {
+      const file = writeFixture("shape_array.txt", `secret=${TOKEN_VALUE}`);
+      const result = runToolHook("mcp__example__tool", { args: [file] });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // The other half of that rule, and the reason it is not "any string": a
+    // search pattern is not a path. `.env` exists in most checkouts, so
+    // collecting every string would block a search for the text `.env` as
+    // though it were a read of the file.
+    it("a search pattern that names an existing file should allow", () => {
+      writeFixture(".env", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__example__search", { pattern: ".env" });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a bare word under an unlisted field should allow", () => {
+      writeFixture("secrets", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__example__search", { query: "secrets" });
+      expect(result.exitCode).toBe(0);
+    });
+
     it("mcp tool with nonexistent path should allow", () => {
       const result = runToolHook("mcp__example__tool", {
         path: "/api/v1/users",

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -316,6 +316,16 @@ function isWrapperTarget(name: string): boolean {
 // still walks past those. That is the direction to be wrong in: it collects
 // paths that are not read rather than missing a read, and `sudo -u root cat f`
 // depends on it, because `root` is not distinguishable from a command name.
+//
+// Treat this as a stopgap rather than a list to grow. Each name added buys one
+// more false positive and leaves the general case untouched, and a list that
+// accumulates one report at a time is the shape of a rule nobody wrote down. The
+// real fix is to model each wrapper's own arguments — the flags that take a
+// value, and the leading operand of `timeout` and `flock` — so the command
+// position is determinate and no allowlist is needed. That was not done here
+// because an incomplete table of those flags fails the other way, missing reads
+// instead of over-reporting them. If a third false positive of this shape turns
+// up, do that instead of adding a sixth name.
 const ARGUMENT_ONLY_COMMANDS = new Set([
   "echo",
   "printf",

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -89,6 +89,26 @@ function isPathFieldName(key: string): boolean {
   return PATH_FIELD_NAMES.has(key.replace(/[^A-Za-z0-9]/g, "").toLowerCase());
 }
 
+// A value that names a path whatever its field is called. The list above can
+// only hold names someone thought of, so a tool carrying its path under `target`
+// or `document` went unscanned; this is the second way in.
+//
+// It is deliberately not "any string". Collecting every string would read a
+// search pattern as a path: `grep` for the literal `.env` arrives as
+// `{ pattern: ".env" }`, `.env` exists, and the name guard would then block a
+// search for that text as though it were a read of the file. A separator is the
+// cheapest test that tells a path from a word, and the cost of using it is that
+// a bare filename under an unlisted field name is still missed.
+function looksLikePath(value: string): boolean {
+  return value.includes("/");
+}
+
+// Whether a value is worth statting: either its field name says path, or the
+// value is shaped like one.
+function isPathCandidate(key: string, value: string): boolean {
+  return isPathFieldName(key) || looksLikePath(value);
+}
+
 // Depth to which a tool's input object is searched for path-bearing fields. Two
 // levels left `{ a: { b: { c: { path } } } }` unscanned, which is not a shape a
 // tool has to be perverse to use; four costs nothing on inputs this size, and
@@ -105,15 +125,19 @@ export function collectPathFields(
 
   for (const [key, value] of Object.entries(input)) {
     if (typeof value === "string") {
-      if (isPathFieldName(key)) found.push(value);
+      if (isPathCandidate(key, value)) found.push(value);
     } else if (Array.isArray(value)) {
-      if (isPathFieldName(key)) {
-        found.push(...value.filter((v): v is string => typeof v === "string"));
-      }
-      // Paths also arrive as objects inside an array, e.g.
-      // `{ paths: [{ path: "…" }] }` — recurse into those elements too.
       for (const item of value) {
-        if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+        if (typeof item === "string") {
+          // An element inherits the array's field name: `{ paths: ["…"] }`.
+          if (isPathCandidate(key, item)) found.push(item);
+        } else if (
+          // Paths also arrive as objects inside an array, e.g.
+          // `{ paths: [{ path: "…" }] }` — recurse into those elements too.
+          item !== null &&
+          typeof item === "object" &&
+          !Array.isArray(item)
+        ) {
           found.push(
             ...collectPathFields(item as Record<string, unknown>, depth + 1),
           );


### PR DESCRIPTION
Follow-up to the review of #174 and #173, taking the two recommendations that came out of it. Both were judgement calls rather than defects, so the reasoning matters more than the diff.

## The field-name list could only hold names someone thought of

`collectPathFields` collected a value when its field name was one of ten known spellings. A tool carrying its path under `target`, `document` or `uri` went unscanned — a miss, and one that grows quietly as MCP servers pick their own names.

A value containing a `/` is now collected whatever its field is called.

**Not every string, and that is the whole design.** My first proposal was to drop the list and scan every string value, since only paths that exist as regular files are ever read, so a non-path costs nothing. Implementing it surfaced a case I had not considered: `grep` for the literal `.env` arrives as `{ "pattern": ".env" }`, `.env` exists in most checkouts, and the name-based guard would then block a search for that text as though the file had been read. The `/` is the cheapest test that separates a path from a word.

What it costs: a bare filename under an unlisted field name (`{ "target": "secrets.txt" }`) is still missed. That is now a Known Limitations bullet rather than an unstated gap.

| tool input | before | after |
| --- | --- | --- |
| `{ target: <abs path> }` | 0 | 2 |
| `{ document: <abs path> }` | 0 | 2 |
| `{ uri: <abs path> }` | 0 | 2 |
| `{ args: [<abs path>] }` | 0 | 2 |
| `{ pattern: ".env" }` with `.env` present | 0 | 0 |
| `{ query: "secrets" }` with `secrets` present | 0 | 0 |
| `{ path: <abs path> }` | 2 | 2 |
| `Write` / `mcp__*__write_file` on the same file | 0 | 0 |

The array branch also stops walking the same array twice — one pass now handles both the string elements and the object elements.

## ARGUMENT_ONLY_COMMANDS is a stopgap

No behaviour change; the second commit is a comment.

The set stops the wrapper search at a command that only prints its arguments, which is what fixed `sudo echo cat f`. It does nothing for the general case — `sudo mycmd cat f` still resolves to `cat` — and every name added to it buys exactly one more false positive.

The real fix is to model each wrapper's own arguments: the flags that take a value, and the leading operand of `timeout` and `flock`. Then the command position is determinate and no allowlist is needed. It was not taken because an incomplete table of those flags fails the dangerous way, missing reads rather than over-reporting them. The comment now says that, and sets the trigger: a third false positive of this shape, rather than a sixth name.

## Verification

536 passing, 1 skipped. `tsc --noEmit`, `biome lint src`, `biome ci --linter-enabled=false src` and `docs:build` clean.

New tests: five field names outside the list (`target`, `document`, `uri`, `input`, `attachment`) with an absolute path, an unlisted field holding an array of paths, and the two that must stay allowed — a `pattern` naming an existing `.env`, and a bare word naming an existing file.
