### PR TITLE
fix: address the two-axis review of main...HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@
   `join`, `look`, plus a second class whose first non-flag argument is a pattern
   or script and whose remaining arguments are files (`sed`, `awk`, `grep`, `rg`,
   `ag`, `jq`, `yq`). In-place editing is exempt: `sed -i`, `perl -i` and
-  `ruby -i` (including bundled forms such as `perl -pi -e`) send the result back
-  to the file and write nothing to stdout. `grep -i` is unaffected — its `-i` is
-  case-insensitive matching, and it still prints
+  `ruby -i` (including bundled forms such as `perl -pi -e` and `perl -lpi`) send
+  the result back to the file and write nothing to stdout. A bundle is read
+  letter by letter and stops at the first switch that carries a value, so
+  `perl -Ilib -pe` and `perl -MList::Util -pe` are reads rather than in-place
+  edits. `grep -i` is unaffected — its `-i` is case-insensitive matching, and it
+  still prints
 - Locate the command past a wrapper (`sudo`, `env VAR=1`, `timeout N`, `nice`,
   `xargs`, `stdbuf`) and past a leading `VAR=value` assignment, so the wrapped
   command is classified instead of the wrapper

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,17 +26,23 @@ pnpm run ci         # typecheck + lint + tests (full CI check)
 ```
 main
  ├── develop          ← integration branch
- │    └── feature/*  ← new features and non-urgent fixes
+ │    └── <type>/*   ← everything that is not an urgent production fix
  └── hotfix/*        ← urgent production fixes
 ```
+
+Name the branch for the kind of change, using the same `<type>` vocabulary as the
+Conventional Commits requirement below: `feat/`, `fix/`, `refactor/`, `test/`,
+`docs/`, `ci/`, `chore/`. `feature/` is accepted as a synonym of `feat/`. What
+matters is that the prefix says what sort of change it is, so that a list of open
+branches reads the way the commit history does.
 
 ### Normal development
 
 ```
-feature/your-feature  →  develop  →  main (release)
+<type>/short-description  →  develop  →  main (release)
 ```
 
-1. Branch from `develop`: `git checkout -b feature/your-feature develop`
+1. Branch from `develop`: `git checkout -b feat/your-feature develop`
 2. Open a PR targeting `develop`
 3. After review and approval, merge into `develop`
 4. When ready to release, open a PR from `develop` → `main`
@@ -60,12 +66,21 @@ If the backport PR has conflicts, resolve them manually before merging.
 4. Update `docs/rules.md` — add full reference entry
 5. Update `CHANGELOG.md` — note the new rule under the next version
 
+## Changelog
+
+Changes land under a `## Unreleased` heading at the top of `CHANGELOG.md`, in the
+same `### Features` / `### Fixes` / `### CI` sections a released version uses. The
+release turns that heading into `## vX.Y.Z (YYYY-MM-DD)` rather than writing the
+notes from scratch, so an entry is written by the PR that makes the change, while
+the reason for it is still at hand.
+
 ## Release Checklist
 
 When bumping a version, open a PR from `develop` → `main` with:
 
-1. Update `version` in `package.json` and `.claude-plugin/plugin.json` — the `versions` job in CI fails when the two disagree
-2. Update `CHANGELOG.md` with a new `## vX.Y.Z (YYYY-MM-DD)` section
+1. Update `version` in `package.json` and `.claude-plugin/plugin.json` — the `versions` job in CI fails when the two disagree, or when either declares no version
+   - Correcting a mismatch is the one version edit that does not need a release PR: the two files disagreeing is a bug, and CI is red until it is fixed
+2. Rename `## Unreleased` in `CHANGELOG.md` to `## vX.Y.Z (YYYY-MM-DD)`
    - `docs/changelog.md` is a symlink to `CHANGELOG.md` — do not edit it separately
    - This content is automatically used as the GitHub Release notes by `release.yml`
 3. Review `docs/rules.md` — add/update any changed rules

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ Which tools reach the hook at all is the matcher's business, and the default (`R
 
 Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Neither are the tools that surface no file contents — `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`, `AskUserQuestion` — nor any tool whose name leads with a write verb, such as `mcp__fs__write_file` or `createPage`.
 
-Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` included) edit in place and write nothing to stdout. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `--patch` or `-U<n>`.
+Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` and `perl -lpi` included) edit in place and write nothing to stdout. A bundle is read letter by letter and stops at the first switch carrying a value, so `perl -Ilib -pe` and `perl -MList::Util -pe` are reads. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `--patch` or `-U<n>`.
 
 When blocked, the hook exits 2, which stops the tool call, and writes the reason to stderr, which is where Claude reads it from. The reason names what was detected and which allow tag lifts the block, and asks Claude to pass that on to the user.
 The terminal also receives a direct message (via `/dev/tty`).

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -1,9 +1,14 @@
-// Shared way to run the PreToolUse hook as a child process and read its verdict.
-// Both hook test files use it so that "run the hook" has one meaning and one
-// options shape, rather than a same-named helper per file.
+// Shared way to run the PreToolUse hook as a child process and read its verdict,
+// and to give it a file to read. The hook test files use these so that "run the
+// hook" and "write a fixture" each have one meaning and one options shape, rather
+// than a same-named helper per file.
 
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll } from "vitest";
 
 // fileURLToPath rather than `.pathname`, which leaves a checkout under a path
 // with spaces percent-encoded and hands `node` a filename that does not exist.
@@ -92,3 +97,48 @@ export function runBashHook(command: string, opts?: RunOptions): HookResult {
 export function runGrepHook(searchPath: string, opts?: RunOptions): HookResult {
   return runToolHook("Grep", { pattern: "foo", path: searchPath }, opts);
 }
+
+// A temp directory for one test file's fixtures, made before its tests and
+// removed after them, with the `writeFixture` that belongs to it.
+//
+// Three test files opened with the same twenty lines, differing only in the
+// mkdtemp prefix. This module already exists so that running the hook has one
+// meaning rather than one per file; writing a file for it to scan is the same
+// kind of thing.
+export interface FixtureWriter {
+  // Write a fixture and return its absolute path.
+  (name: string, content: string): string;
+  // A path inside the directory without writing anything — the directory itself
+  // when no name is given. For the cases that need a target which is not a
+  // regular file: a directory, or a name that does not exist.
+  path(name?: string): string;
+}
+
+export function useFixtureDir(label: string): FixtureWriter {
+  let dir = "";
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), `sensitive-canary-${label}-`));
+  });
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, content: string): string => {
+    const p = join(dir, name);
+    writeFileSync(p, content, "utf8");
+    return p;
+  };
+  return Object.assign(write, {
+    path: (name?: string) => (name === undefined ? dir : join(dir, name)),
+  });
+}
+
+// Assembled so the full strings never appear in a test file's source. The
+// integration test deliberately uses neither: a canonical key is recited from
+// memory by a live session, which its leak assertion cannot tell from a leak.
+export const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
+export const TOKEN_VALUE = [
+  "ghp_",
+  "1234567890abcdefghij",
+  "klmnopqrstuvwxyz",
+].join("");

--- a/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
@@ -59,6 +59,47 @@ describe("pre-tool-use-hook — command classification", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("perl -pi.bak -e should allow", () => {
+      const file = writeFixture("perl_pi_bak.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`perl -pi.bak -e 's/a/b/' ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("perl -lpi -e should allow", () => {
+      const file = writeFixture("perl_lpi.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`perl -lpi -e 's/a/b/' ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // A flag whose value is attached ends the bundle: the letters after it are
+    // the value, not more switches. Reading the whole token for an `i` found one
+    // inside `-MList::Util`, `-Mstrict` and `-Ilib`, and took an ordinary
+    // `perl -pe` for an in-place edit — a missed read.
+    it.each([
+      ["-MList::Util", "perl_m_list.txt"],
+      ["-Mstrict", "perl_m_strict.txt"],
+      ["-Ilib", "perl_i_lib.txt"],
+    ])("perl %s -pe should block", (flag, fixture) => {
+      const file = writeFixture(fixture, `key=${AWS_KEY}`);
+      const result = runBashHook(`perl ${flag} -pe 'print' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("ruby -Ilib -pe should block", () => {
+      const file = writeFixture("ruby_i_lib.txt", `secret=${TOKEN_VALUE}`);
+      const result = runBashHook(`ruby -Ilib -pe 'print' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    it("perl -e with an i in the program should block", () => {
+      const file = writeFixture("perl_e_if.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`perl -e 'print if 1' ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
     it("perl -pe without -i should block", () => {
       const file = writeFixture("perl_pe.txt", `secret=${TOKEN_VALUE}`);
       const result = runBashHook(`perl -pe 's/a/b/' ${file}`);

--- a/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
@@ -1,28 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { runBashHook } from "./hook-harness.ts";
+import { describe, expect, it } from "vitest";
+import {
+  AWS_KEY,
+  runBashHook,
+  TOKEN_VALUE,
+  useFixtureDir,
+} from "./hook-harness.ts";
 
-let tmpDir: string;
-beforeAll(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-commands-"));
-});
-afterAll(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-});
-
-function writeFixture(name: string, content: string) {
-  const p = join(tmpDir, name);
-  writeFileSync(p, content, "utf8");
-  return p;
-}
-
-// Assembled so the full strings never appear in this file's source.
-const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
-const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
-  "",
-);
+const writeFixture = useFixtureDir("commands");
 
 describe("pre-tool-use-hook — command classification", () => {
   describe("expanded read commands", () => {

--- a/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
+++ b/src/__tests__/pre-tool-use-hook-shell-parsing.test.ts
@@ -1,28 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { runBashHook } from "./hook-harness.ts";
+import { describe, expect, it } from "vitest";
+import {
+  AWS_KEY,
+  runBashHook,
+  TOKEN_VALUE,
+  useFixtureDir,
+} from "./hook-harness.ts";
 
-let tmpDir: string;
-beforeAll(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-shell-"));
-});
-afterAll(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-});
-
-function writeFixture(name: string, content: string) {
-  const p = join(tmpDir, name);
-  writeFileSync(p, content, "utf8");
-  return p;
-}
-
-// Assembled so the full strings never appear in this file's source.
-const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
-const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
-  "",
-);
+const writeFixture = useFixtureDir("shell");
 
 describe("pre-tool-use-hook — shell parsing", () => {
   describe("command substitution", () => {

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -220,6 +220,25 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
       expect(result.blocked).toBe(true);
     });
 
+    // A run of capitals is one word. Splitting on every capital left
+    // `WRITE_FILE` as single letters, so its first word was `W` and a write tool
+    // was scanned like a read.
+    it.each(["WRITE_FILE", "UPDATE-FILE", "copyFile"])(
+      "%s should allow",
+      (tool) => {
+        const file = writeFixture(`caps_${tool}.txt`, `key=${AWS_KEY}`);
+        const result = runToolHook(`mcp__fs__${tool}`, { path: file });
+        expect(result.exitCode).toBe(0);
+      },
+    );
+
+    it("mcp__fs__READ_FILE should still block", () => {
+      const file = writeFixture("caps_read.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__fs__READ_FILE", { path: file });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
     // The write-name heuristic matches the tool component only: a server named
     // "editor" or "readwrite" must not exempt the read tools it offers.
     it("mcp__editor__read_file should block (server name is not the tool name)", () => {

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -1,28 +1,13 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { runGrepHook, runToolHook } from "./hook-harness.ts";
+import { describe, expect, it } from "vitest";
+import {
+  AWS_KEY,
+  runGrepHook,
+  runToolHook,
+  TOKEN_VALUE,
+  useFixtureDir,
+} from "./hook-harness.ts";
 
-let tmpDir: string;
-beforeAll(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "sensitive-canary-tool-inputs-"));
-});
-afterAll(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-});
-
-function writeFixture(name: string, content: string) {
-  const p = join(tmpDir, name);
-  writeFileSync(p, content, "utf8");
-  return p;
-}
-
-// Assembled so the full strings never appear in this file's source.
-const AWS_KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
-const TOKEN_VALUE = ["ghp_", "1234567890abcdefghij", "klmnopqrstuvwxyz"].join(
-  "",
-);
+const writeFixture = useFixtureDir("tool-inputs");
 
 describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
   describe("Grep tool", () => {
@@ -47,12 +32,12 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
     });
 
     it("should allow on directory path (known limitation)", () => {
-      const result = runGrepHook(tmpDir);
+      const result = runGrepHook(writeFixture.path());
       expect(result.exitCode).toBe(0);
     });
 
     it("should allow on non-existent path", () => {
-      const result = runGrepHook(join(tmpDir, "nonexistent.txt"));
+      const result = runGrepHook(writeFixture.path("nonexistent.txt"));
       expect(result.exitCode).toBe(0);
     });
   });

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -300,6 +300,21 @@ interface CommandBehaviour {
 
 // Single place where a command name becomes a behaviour, so a name added to one
 // list cannot silently disagree with another.
+//
+// Not every per-command decision belongs here, and two deliberately stay out.
+// isClassifiableCommand below reads this record generically — any truthy field
+// means "operands understood" — which is what lets a new field be added without
+// updating it, and also what a field has to respect to live here:
+//
+//   - `WRITE_TARGET_FLAGS[cmd]` would arrive as a Set, truthy even when empty,
+//     making every command classifiable and stopping the wrapper search at the
+//     first operand it meets.
+//   - `cmd === "env"` for the `-S` string would make `env` classifiable, and
+//     `env` is left out on purpose: it is a wrapper as often as a command.
+//
+// Both are therefore read from their tables at the point of use rather than
+// folded in here. Anything added to this record must be a boolean that means
+// "this hook understands what the command does with its operands".
 function classifyCommand(cmd: string): CommandBehaviour {
   return {
     printsOperands: FILE_READ_COMMANDS.has(cmd),

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -10,7 +10,6 @@ import {
   extractQuotedLiterals,
   extractSubstitutions,
   isNonCommandToken,
-  isRedirectionOperator,
   type ShellToken,
   stripHeredocBodies,
   tokenizeCommand,
@@ -426,7 +425,7 @@ function inspectEnvironmentCommand(tokens: ShellToken[]): {
     for (let j = 0; j < rest.length; j++) {
       const t = rest[j];
       if (t === undefined) continue;
-      if (isRedirectionOperator(t)) {
+      if (t.redirect) {
         j++; // its target, or a heredoc delimiter
         continue;
       }
@@ -457,7 +456,7 @@ function inspectEnvironmentCommand(tokens: ShellToken[]): {
       ignoreEnvironment = true;
       continue;
     }
-    if (isRedirectionOperator(t)) {
+    if (t.redirect) {
       j++; // redirection operator: its target is env's own argument here
       continue;
     }

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -270,6 +270,16 @@ export interface CommandRefs {
   dumpsEnvironment: boolean;
 }
 
+// Fold one set of refs into another. A command line yields refs from several
+// places — its substitutions, each of its segments, the inline code it carries,
+// an `env -S` string — and combining them is the same three lines each time,
+// which is how it came to be written out three times with a closure alongside.
+function mergeRefs(into: CommandRefs, refs: CommandRefs): void {
+  into.paths.push(...refs.paths);
+  into.envVars.push(...refs.envVars);
+  into.dumpsEnvironment = into.dumpsEnvironment || refs.dumpsEnvironment;
+}
+
 // What this hook knows about how a command treats its operands.
 interface CommandBehaviour {
   // Every non-flag operand is a file written to stdout.
@@ -493,51 +503,41 @@ function isInlineCodeFlag(cmd: string, token: string): boolean {
 // Everything a Bash command reveals that the hook can inspect before it runs:
 // the files whose contents it may print, and the environment it may expose.
 export function extractCommandRefs(command: string, depth = 0): CommandRefs {
-  const paths: string[] = [];
-  const envVars: string[] = [];
-  let dumpsEnvironment = false;
+  const refs: CommandRefs = { paths: [], envVars: [], dumpsEnvironment: false };
 
-  if (depth > MAX_NESTING_DEPTH) return { paths, envVars, dumpsEnvironment };
-
-  const merge = (refs: CommandRefs): void => {
-    paths.push(...refs.paths);
-    envVars.push(...refs.envVars);
-    dumpsEnvironment = dumpsEnvironment || refs.dumpsEnvironment;
-  };
+  if (depth > MAX_NESTING_DEPTH) return refs;
 
   // Heredoc bodies are text, not commands; strip them before any other pass.
   const text = stripHeredocBodies(command);
 
   // `echo $(cat secrets)` reads secrets just as `cat secrets` does.
   for (const inner of extractSubstitutions(text)) {
-    merge(extractCommandRefs(inner, depth + 1));
+    mergeRefs(refs, extractCommandRefs(inner, depth + 1));
   }
 
   for (const tokens of tokenizeCommand(text)) {
     const environment = inspectEnvironmentCommand(tokens);
-    if (environment.dumps) dumpsEnvironment = true;
-    envVars.push(...environment.named);
+    if (environment.dumps) refs.dumpsEnvironment = true;
+    refs.envVars.push(...environment.named);
 
-    merge(collectSegmentRefs(tokens, depth));
+    mergeRefs(refs, collectSegmentRefs(tokens, depth));
   }
 
   return {
-    paths: [...new Set(paths)],
-    envVars: [...new Set(envVars)],
-    dumpsEnvironment,
+    paths: [...new Set(refs.paths)],
+    envVars: [...new Set(refs.envVars)],
+    dumpsEnvironment: refs.dumpsEnvironment,
   };
 }
 
 // File paths one segment of a command line may print, plus anything found inside
 // inline program text it carries.
 function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
-  const paths: string[] = [];
-  const envVars: string[] = [];
-  let dumpsEnvironment = false;
+  const refs: CommandRefs = { paths: [], envVars: [], dumpsEnvironment: false };
 
   const start = findCommandIndex(tokens);
   const cmdToken = tokens[start];
-  if (cmdToken === undefined) return { paths, envVars, dumpsEnvironment };
+  if (cmdToken === undefined) return refs;
 
   const cmd = path.basename(cmdToken.value);
   const operands = tokens.slice(start + 1);
@@ -545,7 +545,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
   // In-place editing sends the result back to the file, so nothing reaches
   // stdout and nothing is read into the conversation.
   if (editsInPlace(cmd, operands)) {
-    return { paths, envVars, dumpsEnvironment };
+    return refs;
   }
 
   // `env -S "cmd args"` splits the string into the command it runs, so scan
@@ -556,10 +556,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
       if (t !== "-S" && t !== "--split-string") continue;
       const script = operands[k + 1]?.value;
       if (script === undefined) continue;
-      const inner = extractCommandRefs(script, depth + 1);
-      paths.push(...inner.paths);
-      envVars.push(...inner.envVars);
-      dumpsEnvironment = dumpsEnvironment || inner.dumpsEnvironment;
+      mergeRefs(refs, extractCommandRefs(script, depth + 1));
       k++;
     }
   }
@@ -581,7 +578,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
     }
     if (collectNext) {
       collectNext = false;
-      paths.push(tok.value);
+      refs.paths.push(tok.value);
       continue;
     }
     if (codeNext) {
@@ -590,10 +587,8 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
       // script `perl file` would have run.
       patternSkipped = true;
       if (behaviour.inlineCodeReadsOperands) inlineCodeSeen = true;
-      const inner = extractCommandRefs(tok.value, depth + 1);
-      paths.push(...inner.paths, ...extractQuotedLiterals(tok.value));
-      envVars.push(...inner.envVars);
-      dumpsEnvironment = dumpsEnvironment || inner.dumpsEnvironment;
+      mergeRefs(refs, extractCommandRefs(tok.value, depth + 1));
+      refs.paths.push(...extractQuotedLiterals(tok.value));
       continue;
     }
 
@@ -647,7 +642,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
         gitReadsFiles = gitSubcommandPrintsFiles(tok.value, operands);
         continue;
       }
-      if (gitReadsFiles) paths.push(tok.value);
+      if (gitReadsFiles) refs.paths.push(tok.value);
       continue;
     }
 
@@ -656,7 +651,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
     if (behaviour.isDd) {
       const ddInput = /^if=(.+)$/.exec(tok.value);
       if (ddInput?.[1]) {
-        paths.push(ddInput[1]);
+        refs.paths.push(ddInput[1]);
         continue;
       }
     }
@@ -671,9 +666,9 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
       behaviour.firstOperandIsPatternOrScript ||
       inlineCodeSeen
     ) {
-      paths.push(tok.value);
+      refs.paths.push(tok.value);
     }
   }
 
-  return { paths, envVars, dumpsEnvironment };
+  return refs;
 }

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -211,15 +211,34 @@ function gitSubcommandPrintsFiles(
 // Commands whose `-i` rewrites the files it is handed instead of printing them.
 // Not every `-i` means that: `grep -i` matches case-insensitively and still
 // prints, which is why this is a list rather than a check on the flag alone.
-// `perl` and `ruby` bundle their short flags, so the in-place flag arrives as
-// `-pi` as often as `-i`, and `perl -i.bak` carries its backup suffix attached.
 const IN_PLACE_EDIT_COMMANDS = new Set(["sed", "perl", "ruby"]);
+
+// Short switches that carry no value, so a bundle of them can be read letter by
+// letter. `perl` and `ruby` bundle: the in-place flag arrives as `-pi` as often
+// as `-i`. Anything outside this set ends the reading, because the letters after
+// it are its value rather than more switches — which is the whole point of the
+// set. `-[A-Za-z]*i` looked like it covered the bundles, and did, but it also
+// matched the `i` inside `-MList::Util`, `-Mstrict` and `-Ilib`, so an ordinary
+// `perl -Ilib -pe 'print' secrets` was taken for an in-place edit and the file
+// went unscanned. That is a missed read, the direction that costs something.
+const VALUELESS_SHORT_SWITCHES = new Set("0aclnpsStuvwCVWX");
+
+// True when a token is the in-place flag: `-i`, `-i.bak`, a bundle reaching `i`
+// through valueless switches only (`-pi`, `-lpi`, `-pie`), or the long form.
+function isInPlaceFlag(value: string): boolean {
+  if (value === "--in-place" || value.startsWith("--in-place=")) return true;
+  if (!value.startsWith("-") || value.startsWith("--")) return false;
+
+  for (const ch of value.slice(1)) {
+    if (ch === "i") return true;
+    if (!VALUELESS_SHORT_SWITCHES.has(ch)) return false;
+  }
+  return false;
+}
 
 function editsInPlace(cmd: string, operands: ShellToken[]): boolean {
   if (!IN_PLACE_EDIT_COMMANDS.has(cmd)) return false;
-  return operands.some(
-    ({ value }) => value === "--in-place" || /^-[A-Za-z]*i/.test(value),
-  );
+  return operands.some(({ value }) => isInPlaceFlag(value));
 }
 
 // Global git flags that carry a separate value before the subcommand

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -15,6 +15,10 @@
 // unscanned. Only the source form separates the two.
 export interface ShellToken {
   value: string;
+  // True for a redirection operator the tokenizer read from the source: `<`,
+  // `>`, `<<`, `>>`, `<<<`, each emitted on its own with any file-descriptor
+  // prefix dropped. The token after one is a target or a heredoc delimiter
+  // rather than an operand.
   redirect: boolean;
 }
 
@@ -412,15 +416,6 @@ export function extractSubstitutions(command: string): string[] {
   }
 
   return found;
-}
-
-// True for a redirection operator the tokenizer read from the source: `<`, `>`,
-// `<<`, `>>`, `<<<`, each emitted on its own with any file-descriptor prefix
-// dropped. The token after one is a target or a heredoc delimiter rather than an
-// operand. A quoted word reading `>` is not one of these, which is the whole
-// point of carrying `redirect` on the token rather than testing its text.
-export function isRedirectionOperator(token: ShellToken): boolean {
-  return token.redirect;
 }
 
 // Shell keywords and the brace-group delimiters. They stand where a command

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -22,6 +22,42 @@ export interface ShellToken {
   redirect: boolean;
 }
 
+// Where reading continues after `s[i]`, and the quote state there.
+//
+// `consumed` marks a position that was quoting syntax rather than content: an
+// opening or closing quote, or a backslash and the character it escapes. A
+// caller skips those and inspects only the rest.
+interface QuoteStep {
+  next: number;
+  quote: string | null;
+  consumed: boolean;
+}
+
+// The one place the quoting rule is written down: a quote character opens a run
+// and its twin closes it, and a backslash escapes the next character everywhere
+// except inside single quotes, where it is literal.
+//
+// Three scanners each spelled that rule out for themselves — as
+// `quote === '"' && ch === "\\"`, as `ch === "\\" && quote !== "'"`, and as
+// `i += quote === "'" ? 1 : 2`. They agreed, which is the point: three spellings
+// of one rule agree until someone corrects one of them.
+function stepQuote(s: string, i: number, quote: string | null): QuoteStep {
+  const ch = s[i] as string;
+
+  if (ch === "\\" && quote !== "'") {
+    return { next: i + 2, quote, consumed: true };
+  }
+  if (quote !== null) {
+    return ch === quote
+      ? { next: i + 1, quote: null, consumed: true }
+      : { next: i + 1, quote, consumed: false };
+  }
+  if (ch === "'" || ch === '"') {
+    return { next: i + 1, quote: ch, consumed: true };
+  }
+  return { next: i + 1, quote: null, consumed: false };
+}
+
 // Variable names referenced by the command, including expansion forms that carry
 // a suffix such as `${TOKEN:-fallback}` or `${TOKEN#prefix}`.
 export function extractEnvVarNames(command: string): string[] {
@@ -251,22 +287,13 @@ function findHeredocDelimiters(line: string): HeredocDelimiter[] {
   let i = 0;
 
   while (i < line.length) {
+    const step = stepQuote(line, i, quote);
+    quote = step.quote;
+    if (step.consumed || quote !== null) {
+      i = step.next;
+      continue;
+    }
     const ch = line[i] as string;
-    if (quote !== null) {
-      if (quote === '"' && ch === "\\") i++;
-      else if (ch === quote) quote = null;
-      i++;
-      continue;
-    }
-    if (ch === "'" || ch === '"') {
-      quote = ch;
-      i++;
-      continue;
-    }
-    if (ch === "\\") {
-      i += 2;
-      continue;
-    }
     if (ch === "<" && line[i + 1] === "<") {
       let j = i + 2;
       let allowTabs = false;
@@ -339,27 +366,24 @@ function findSubstitutionEnd(
   let depth = 0;
   let quote: string | null = null;
 
-  for (let i = from; i < command.length; i++) {
+  let i = from;
+  while (i < command.length) {
+    const step = stepQuote(command, i, quote);
+    quote = step.quote;
+    if (step.consumed || quote !== null) {
+      i = step.next;
+      continue;
+    }
     const ch = command[i] as string;
-    if (ch === "\\" && quote !== "'") {
-      i++;
-      continue;
-    }
-    if (quote !== null) {
-      if (ch === quote) quote = null;
-      continue;
-    }
-    if (ch === "'" || ch === '"') {
-      quote = ch;
-      continue;
-    }
+    const at = i;
+    i = step.next;
     if (close === "`") {
-      if (ch === "`") return i;
+      if (ch === "`") return at;
       continue;
     }
     if (ch === "(") depth++;
     else if (ch === ")") {
-      if (depth === 0) return i;
+      if (depth === 0) return at;
       depth--;
     }
   }
@@ -376,36 +400,24 @@ export function extractSubstitutions(command: string): string[] {
   let quote: string | null = null;
   let i = 0;
 
+  // Unlike the scanners above, this one has to look inside double quotes: a
+  // command substitution expands there. So it skips only what `stepQuote` calls
+  // consumed, and asks the quote state whether an opener counts where it stands.
   while (i < command.length) {
-    const ch = command[i] as string;
-
-    if (ch === "\\") {
-      i += quote === "'" ? 1 : 2;
-      continue;
-    }
-    if (quote === "'") {
-      if (ch === quote) quote = null;
-      i++;
-      continue;
-    }
-    if (quote === '"' && ch === '"') {
-      quote = null;
-      i++;
-      continue;
-    }
-    if (quote === null && (ch === "'" || ch === '"')) {
-      quote = ch;
-      i++;
+    const step = stepQuote(command, i, quote);
+    quote = step.quote;
+    if (step.consumed) {
+      i = step.next;
       continue;
     }
 
     const opener = SUBSTITUTIONS.find(
       (s) =>
         command.startsWith(s.open, i) &&
-        (quote === null || s.expandsInDoubleQuotes),
+        (quote === null || (quote === '"' && s.expandsInDoubleQuotes)),
     );
     if (opener === undefined) {
-      i++;
+      i = step.next;
       continue;
     }
 

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -28,8 +28,9 @@ export const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
 // As a substring test this exempted reads: "update" sits inside `get_updates`,
 // and "write" inside `read_and_write_file` — a tool that returns contents was
 // treated as one that only writes. Word boundaries are the `_`/`-` in snake and
-// kebab names and the capital in camelCase, so `write_file` and `createPage`
-// still match while `overwrite_file` and `readwrite` no longer do.
+// kebab names and, in camelCase, a capital that follows a lowercase letter — so
+// `write_file`, `createPage` and `WRITE_FILE` all match while `overwrite_file`
+// and `readwrite` no longer do.
 //
 // Erring this way costs a false block on a noun-first write tool (`file_write`),
 // which is the direction to fail in. The built-in write tools are named
@@ -57,11 +58,24 @@ const WRITING_TOOL_VERBS = new Set([
   "copy",
 ]);
 
+// The first word of a tool name. Splitting on every capital broke the all-caps
+// spelling: `WRITE_FILE` came apart into single letters and its first word was
+// `W`, so a write tool was scanned as a read. A capital only starts a new word
+// when it follows a lowercase letter or a digit, which is what camelCase means;
+// a run of capitals is one word.
+function firstWord(name: string): string | undefined {
+  const [first] = name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean);
+  return first;
+}
+
 export function isWritingTool(tool: string): boolean {
   const name = tool.startsWith("mcp__")
     ? (tool.split("__").pop() ?? tool)
     : tool;
-  const [first] = name.split(/[^A-Za-z0-9]+|(?=[A-Z])/).filter(Boolean);
+  const first = firstWord(name);
   return first !== undefined && WRITING_TOOL_VERBS.has(first.toLowerCase());
 }
 

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -25,7 +25,6 @@ interface HookInput {
   tool_input?: Record<string, unknown> & {
     file_path?: string;
     command?: string;
-    path?: string;
   };
 }
 


### PR DESCRIPTION
Fixes everything the two-axis review of `main...HEAD` turned up. Stacked on #178 — review that first.

The one that matters is first; the rest are the Standards axis.

## A missed read: in-place detection matched too much

`editsInPlace` tested each flag with `/^-[A-Za-z]*i/`. That covered the bundled forms it was written for (`-pi`, `-pie`, `-lpi`) and also matched the `i` sitting inside `-MList::Util`, `-Mstrict` and `-Ilib` — so an ordinary `perl -Ilib -pe 'print' secrets` was taken for an in-place edit and the file went unscanned.

A missed read is the direction that costs something, and it is the same mistake the exemption exists to avoid: `grep -i` is why in-place is a list of commands rather than a check on the flag alone, and the letter `i` means something else inside a flag just as it does across commands.

A bundle is now read letter by letter and stops at the first switch carrying a value, since the letters after such a switch are its value.

| command | before | after |
| --- | --- | --- |
| `perl -MList::Util -pe 'print' <file>` | 0 | **2** |
| `perl -Mstrict -pe 'print' <file>` | 0 | **2** |
| `perl -Ilib -pe 'print' <file>` | 0 | **2** |
| `ruby -Ilib -pe 'print' <file>` | 0 | **2** |
| `perl -e 'print if 1' <file>` | 2 | 2 |
| `perl -i -pe` / `-pi -e` / `-pi.bak -e` / `-lpi -e` | 0 | 0 |
| `ruby -i -pe` / `sed -i` / `sed --in-place` | 0 | 0 |
| `perl -pe` / `grep -i` | 2 | 2 |

## A write tool scanned as a read

Splitting a tool name on every capital took `WRITE_FILE` apart into single letters, so its first word was `W` and the write-name exemption did not apply. A capital starts a word only when it follows a lowercase letter or a digit; a run of capitals is one word. Four of the eleven write verbs are asserted here (`write`, `move`, `update`, `copy`). #180 replaces that with cases generated from the verb list itself.

## Duplication

- **The quoting rule was written three times** — as `quote === '"' && ch === "\\"`, as `ch === "\\" && quote !== "'"`, and as `i += quote === "'" ? 1 : 2`. They agreed, which is the risk. `stepQuote` now answers where reading continues and what the quote state is there. `extractSubstitutions` gains something from the move: its "single quotes suppress everything" is now written into the condition rather than implied by an earlier `continue`.
- **Folding refs together** was three copies of the same three lines, one of them a closure. `mergeRefs` replaces all three.
- **Three test files opened with the same twenty lines.** `useFixtureDir` in the harness replaces them; the harness exists because "run the hook" should have one meaning, and "write a file for it to scan" is the same kind of thing.

## Two findings answered with a comment instead of a change

- **`ARGUMENT_ONLY_COMMANDS`** stays a stopgap. The comment now names the real fix, says why it was not taken, and sets the trigger for doing it.
- **`classifyCommand` is not the only dispatch on a command name**, and two of the four remaining ones cannot move. `isClassifiableCommand` reads the behaviour record generically, so a `Set` field is truthy even when empty and makes every command classifiable, and an `env` field makes `env` classifiable when it is deliberately excluded. Trying it is how I found out; the constraint is now written where the next person will look.

## Dead weight

`HookInput.tool_input.path` was declared and never read. `isRedirectionOperator` wrapped a public field of an interface from the same module, with two callers using it and a third reading the field directly.

## Documented standards that had drifted

The review flagged the branch prefix as a hard violation of `CONTRIBUTING.md`, which documented `feature/*` while all eight branches of this release cycle used a Conventional Commits type. The rule was what was wrong. Also documented now: the `## Unreleased` heading every recent PR writes, and the fact that correcting a `package.json`/`plugin.json` mismatch does not need a release PR.

## Verification

547 passing, 1 skipped. `tsc --noEmit`, `biome lint src`, `biome ci --linter-enabled=false src` and `docs:build` clean.

The two refactors that touch how a command line is read were checked past the suite: `$(…)`, `"$(…)"`, `'$(…)'`, backticks, `<(…)`, nesting, `$(python3 -c "…")`, `awk '{print $(NF)}'`, a heredoc writing a script that mentions `.env`, `<<EOF` inside double quotes, a `<<EOF-1` body followed by a real read, an unbalanced `$(`, `env -S "cat <file>"`, a repeated operand, and a bare `env` with a secret in the environment all decide as before.

One thing the first pass of the quote extraction got wrong and the checks caught: `findSubstitutionEnd` returns the index **of** the closing character, not the one after it.

Two merged PR descriptions were also corrected — #174's field list had been superseded by a later commit on its own branch, and #175's failure table was missing a fourth path.



---

## Corrections after review

A two-axis review of this PR against `01b1b08f` found three things wrong with it, fixed in #180:

- **It introduced a fail-open.** `sed -0i <file>` went from exit 2 to exit 0 — a file that had been scanned was no longer. Closing one fail-open opened another.
- **It blocked `sed -Ei`, `sed -ri`, `sed -zi` and `perl -Ti`**, which had all been allowed. The valueless-switch set was chosen from `perl`'s manual and shared with `sed`, whose `-E`, `-r` and `-z` were missing from it.
- **The table row for `perl -e 'print if 1'` claimed 0 → 2. It was 2 → 2**, corrected above. The old regex required a leading `-`, so `-e` never matched it; I asserted a before-value I had not measured. The test added for that row fixes behaviour this PR did not change.

The "whole exemption matrix" claim was also an overstatement, corrected above.
