### PR TITLE
fix: recognise a pattern flag with its value written against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@
 
 ### Fixes
 
+- Scan the file operand of a pattern-first command when the pattern flag carries
+  its value written against it. `grep -eaws secrets`, `grep -faws secrets` and
+  `sed -e's/a/b/' secrets` scanned nothing: the attached spelling was not
+  recognised, so nothing marked the pattern as supplied and the file that
+  followed was consumed as the pattern. The separate (`grep -e aws`) and `=`
+  (`--regexp=aws`) spellings were already handled
 - `.claude-plugin/plugin.json` declared `0.5.1` while `package.json` declared
   `0.7.0`: the release checklist asks for both, and the bump was missed for
   0.6.0 and 0.7.0. The plugin manifest now matches the released version

--- a/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
@@ -245,6 +245,13 @@ describe("pre-tool-use-hook — command classification", () => {
       ["grep -faws", "attached_grep_f.txt"],
       ["sed -e's/a/b/'", "attached_sed_e.txt"],
       ["sed -ei\\hello", "attached_sed_insert.txt"],
+      // A one-character attached value. Every other case here uses several, and
+      // the test for "is there anything after the flag" is a length comparison:
+      // off by one and `grep -e. secrets` stops being scanned while these pass.
+      ["grep -e.", "attached_one_char.txt"],
+      ["grep -ex", "attached_one_letter.txt"],
+      ["grep -fp", "attached_f_one.txt"],
+      ["sed -ep", "attached_sed_one.txt"],
     ])("%s should block the file it is given", (prefix, fixture) => {
       const file = writeFixture(fixture, `key=${AWS_KEY}`);
       const result = runBashHook(`${prefix} ${file}`);

--- a/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
@@ -93,7 +93,7 @@ describe("pre-tool-use-hook — command classification", () => {
 
     // The five inputs a previous version of the in-place check changed without
     // meaning to. The letters themselves are covered per command in
-    // pre-tool-use-hook-flag-coverage.test.ts; these are here because that is
+    // src/lib/__tests__/flag-and-verb-tables.test.ts; these are here because that is
     // where the mistake showed up — as an exit code, on commands people type.
     it.each([
       ["sed -Ei 's/a/b/'", "sed_Ei.txt"],
@@ -117,8 +117,7 @@ describe("pre-tool-use-hook — command classification", () => {
       expect(result.blocked).toBe(true);
     });
 
-    // `-e` introduces a script and a sed script uses `i` to insert, so reading
-    // past it would find an `i` in the program text.
+    // See IN_PLACE_EDITORS for why `-e` stops the bundle being read.
     it("sed -e with an insert command should block", () => {
       const file = writeFixture("sed_e_insert.txt", `secret=${TOKEN_VALUE}`);
       const result = runBashHook(`sed -e 'i\\hello' ${file}`);

--- a/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
@@ -236,6 +236,31 @@ describe("pre-tool-use-hook — command classification", () => {
       expect(result.exitCode).toBe(2);
     });
 
+    // A short flag can carry its value written against it, and that spelling was
+    // not recognised: the flag looked like a plain flag, nothing marked the
+    // pattern as supplied, and the file that followed was consumed as the pattern
+    // instead of being scanned. Present since before this work, in all three of
+    // these forms.
+    it.each([
+      ["grep -eaws", "attached_grep_e.txt"],
+      ["grep -faws", "attached_grep_f.txt"],
+      ["sed -e's/a/b/'", "attached_sed_e.txt"],
+      ["sed -ei\\hello", "attached_sed_insert.txt"],
+    ])("%s should block the file it is given", (prefix, fixture) => {
+      const file = writeFixture(fixture, `key=${AWS_KEY}`);
+      const result = runBashHook(`${prefix} ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // The separate-value spelling still consumes the next token, so a pattern
+    // that happens to name a secret-bearing file is not scanned as an operand.
+    it("grep -e with a separate value does not scan that value", () => {
+      const file = writeFixture("sep_value.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`grep -e ${file} /dev/null`);
+      expect(result.exitCode).toBe(0);
+    });
+
     it("sort -o should allow: its value is written, not read", () => {
       const out = writeFixture("sort_out.txt", `key=${AWS_KEY}`);
       const input = writeFixture("sort_in.txt", "clean");

--- a/src/__tests__/pre-tool-use-hook-flag-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-flag-coverage.test.ts
@@ -11,10 +11,16 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  IN_PLACE_EDIT_COMMANDS,
   isInPlaceFlag,
   VALUELESS_SHORT_SWITCHES,
 } from "../lib/bash-commands.ts";
-import { isWritingTool, WRITING_TOOL_VERBS } from "../lib/tool-inputs.ts";
+import {
+  collectPathFields,
+  isWritingTool,
+  PATH_FIELD_NAMES,
+  WRITING_TOOL_VERBS,
+} from "../lib/tool-inputs.ts";
 
 const VERBS = [...WRITING_TOOL_VERBS];
 const IN_PLACE_COMMANDS = Object.keys(VALUELESS_SHORT_SWITCHES);
@@ -111,5 +117,84 @@ describe("in-place flags, per command and per switch letter", () => {
     ["ruby", "-pi"],
   ])("%s %s is an in-place edit", (cmd, flag) => {
     expect(isInPlaceFlag(cmd, flag)).toBe(true);
+  });
+});
+
+// Invariants of the tables themselves.
+//
+// The generated cases above guarantee that every entry has a case. They cannot
+// say whether an entry belongs: they assert what the table says, so a wrong entry
+// is asserted as correct. Measured — injecting `e` into `sed`'s valueless
+// switches, which would read a sed script's insert command as the in-place flag,
+// passed all of them.
+//
+// These are the properties that hold regardless of what the tables contain, so
+// they fail on a wrong entry rather than agreeing with it.
+describe("table invariants", () => {
+  // `e` introduces a script for all three commands. Reading past it walks into
+  // program text, where `i` is sed's insert command.
+  it.each(Object.keys(VALUELESS_SHORT_SWITCHES))(
+    "%s does not treat -e as valueless",
+    (cmd) => {
+      expect(VALUELESS_SHORT_SWITCHES[cmd]).not.toContain("e");
+    },
+  );
+
+  // A digit begins a value for `perl -0777` and is not a switch for the others.
+  it.each(Object.keys(VALUELESS_SHORT_SWITCHES))(
+    "%s treats no digit as valueless",
+    (cmd) => {
+      expect(VALUELESS_SHORT_SWITCHES[cmd]).not.toMatch(/[0-9]/);
+    },
+  );
+
+  // Two tables decide in-place editing together: one says which commands do it,
+  // the other how to read their bundles. A command in the first without a line in
+  // the second reaches `-i` through an empty set, so a bare `-i` still counts and
+  // a bundle never does. Adding `awk` to the first alone passed every other test.
+  it("every in-place command has a line of valueless switches", () => {
+    expect([...IN_PLACE_EDIT_COMMANDS].sort()).toEqual(
+      Object.keys(VALUELESS_SHORT_SWITCHES).sort(),
+    );
+  });
+});
+
+// The two ways a value becomes a path candidate are independent, and a test that
+// uses an absolute path exercises only the second. Removing `path` from the name
+// list passed every hook-level case, because every fixture path contains a `/`
+// and the shape rule collected it anyway.
+describe("path fields are found by name, not only by shape", () => {
+  it.each([...PATH_FIELD_NAMES])("%s collects a bare filename", (field) => {
+    expect(collectPathFields({ [field]: "secrets.txt" })).toContain(
+      "secrets.txt",
+    );
+  });
+
+  it("a name outside the list does not collect a bare filename", () => {
+    for (const field of ["target", "document", "uri", "query", "pattern"]) {
+      expect(collectPathFields({ [field]: "secrets.txt" })).toEqual([]);
+    }
+  });
+});
+
+// Names the list must contain, written out rather than derived.
+//
+// The generated cases above walk `PATH_FIELD_NAMES`, so deleting an entry deletes
+// its case and nothing fails — measured: removing `path` passed every test in the
+// repository. A generated case catches a wrong entry once an invariant pins the
+// shape; it can never catch a missing one. So this duplicates the list on
+// purpose, and the duplication is the point: two copies that must agree.
+describe("path field names that must not be dropped", () => {
+  it.each([
+    "path",
+    "paths",
+    "file",
+    "files",
+    "filepath",
+    "filename",
+    "absolutepath",
+    "notebookpath",
+  ])("%s is still a path field name", (name) => {
+    expect(PATH_FIELD_NAMES.has(name)).toBe(true);
   });
 });

--- a/src/lib/__tests__/flag-and-verb-tables.test.ts
+++ b/src/lib/__tests__/flag-and-verb-tables.test.ts
@@ -10,20 +10,16 @@
 // removes its case rather than leaving a stale assertion behind.
 
 import { describe, expect, it } from "vitest";
-import {
-  IN_PLACE_EDIT_COMMANDS,
-  isInPlaceFlag,
-  VALUELESS_SHORT_SWITCHES,
-} from "../lib/bash-commands.ts";
+import { IN_PLACE_EDITORS, isInPlaceFlag } from "../bash-commands.ts";
 import {
   collectPathFields,
   isWritingTool,
   PATH_FIELD_NAMES,
   WRITING_TOOL_VERBS,
-} from "../lib/tool-inputs.ts";
+} from "../tool-inputs.ts";
 
 const VERBS = [...WRITING_TOOL_VERBS];
-const IN_PLACE_COMMANDS = Object.keys(VALUELESS_SHORT_SWITCHES);
+const IN_PLACE_COMMANDS = Object.keys(IN_PLACE_EDITORS);
 
 describe("every write verb is exempt in every spelling", () => {
   it.each(VERBS)("%s", (verb) => {
@@ -72,17 +68,16 @@ describe("in-place flags, per command and per switch letter", () => {
   // Every letter the table calls valueless must let the reading reach the `i`,
   // in both orders, since a bundle can put it either side.
   it.each(IN_PLACE_COMMANDS)("%s: every valueless letter reaches -i", (cmd) => {
-    for (const ch of VALUELESS_SHORT_SWITCHES[cmd] ?? "") {
+    for (const ch of IN_PLACE_EDITORS[cmd] ?? "") {
       expect(isInPlaceFlag(cmd, `-${ch}i`), `${cmd} -${ch}i`).toBe(true);
       expect(isInPlaceFlag(cmd, `-i${ch}`), `${cmd} -i${ch}`).toBe(true);
     }
   });
 
   // A letter outside the table stops the reading, so the command counts as one
-  // that prints and its operands are scanned. `e` is the case that matters: it
-  // introduces a script, and a sed script uses `i` to insert.
+  // that prints and its operands are scanned.
   it.each(IN_PLACE_COMMANDS)("%s: an unlisted letter stops the read", (cmd) => {
-    const valueless = VALUELESS_SHORT_SWITCHES[cmd] ?? "";
+    const valueless = IN_PLACE_EDITORS[cmd] ?? "";
     for (const ch of "eEMmIFDCAKrz0123456789") {
       if (valueless.includes(ch)) continue;
       expect(isInPlaceFlag(cmd, `-${ch}i`), `${cmd} -${ch}i`).toBe(false);
@@ -131,31 +126,38 @@ describe("in-place flags, per command and per switch letter", () => {
 // These are the properties that hold regardless of what the tables contain, so
 // they fail on a wrong entry rather than agreeing with it.
 describe("table invariants", () => {
-  // `e` introduces a script for all three commands. Reading past it walks into
-  // program text, where `i` is sed's insert command.
-  it.each(Object.keys(VALUELESS_SHORT_SWITCHES))(
+  // See IN_PLACE_EDITORS for why `-e` must not be valueless.
+  it.each(Object.keys(IN_PLACE_EDITORS))(
     "%s does not treat -e as valueless",
     (cmd) => {
-      expect(VALUELESS_SHORT_SWITCHES[cmd]).not.toContain("e");
+      expect(IN_PLACE_EDITORS[cmd]).not.toContain("e");
     },
   );
 
   // A digit begins a value for `perl -0777` and is not a switch for the others.
-  it.each(Object.keys(VALUELESS_SHORT_SWITCHES))(
+  it.each(Object.keys(IN_PLACE_EDITORS))(
     "%s treats no digit as valueless",
     (cmd) => {
-      expect(VALUELESS_SHORT_SWITCHES[cmd]).not.toMatch(/[0-9]/);
+      expect(IN_PLACE_EDITORS[cmd]).not.toMatch(/[0-9]/);
     },
   );
 
-  // Two tables decide in-place editing together: one says which commands do it,
-  // the other how to read their bundles. A command in the first without a line in
-  // the second reaches `-i` through an empty set, so a bare `-i` still counts and
-  // a bundle never does. Adding `awk` to the first alone passed every other test.
-  it("every in-place command has a line of valueless switches", () => {
-    expect([...IN_PLACE_EDIT_COMMANDS].sort()).toEqual(
-      Object.keys(VALUELESS_SHORT_SWITCHES).sort(),
-    );
+  // Which commands edit in place, written out. The generated cases walk the
+  // table's keys, so they follow it wherever it goes; this is what notices a
+  // command being added to it or dropped from it.
+  it("the in-place editors are sed, perl and ruby", () => {
+    expect(Object.keys(IN_PLACE_EDITORS).sort()).toEqual([
+      "perl",
+      "ruby",
+      "sed",
+    ]);
+  });
+
+  // A command not in the table is not an in-place editor, so no flag of it counts.
+  it.each(["grep", "awk", "cat", "rg"])("%s never edits in place", (cmd) => {
+    for (const flag of ["-i", "-i.bak", "--in-place", "-pi"]) {
+      expect(isInPlaceFlag(cmd, flag), `${cmd} ${flag}`).toBe(false);
+    }
   });
 });
 
@@ -177,24 +179,31 @@ describe("path fields are found by name, not only by shape", () => {
   });
 });
 
-// Names the list must contain, written out rather than derived.
+// The whole list, written out rather than derived.
 //
 // The generated cases above walk `PATH_FIELD_NAMES`, so deleting an entry deletes
 // its case and nothing fails — measured: removing `path` passed every test in the
 // repository. A generated case catches a wrong entry once an invariant pins the
-// shape; it can never catch a missing one. So this duplicates the list on
-// purpose, and the duplication is the point: two copies that must agree.
-describe("path field names that must not be dropped", () => {
-  it.each([
-    "path",
-    "paths",
-    "file",
-    "files",
-    "filepath",
-    "filename",
-    "absolutepath",
-    "notebookpath",
-  ])("%s is still a path field name", (name) => {
-    expect(PATH_FIELD_NAMES.has(name)).toBe(true);
+// shape; it can never catch a missing one.
+//
+// So this duplicates the list, and the duplication is the point: two copies that
+// must agree. It is an equality rather than a set of "must contain" assertions,
+// because the first version of this listed eight of the ten names and left
+// `filenames` and `sourcepath` free to be deleted — a hole in the very test
+// written to close one.
+describe("the path field names", () => {
+  it("are exactly these ten", () => {
+    expect([...PATH_FIELD_NAMES].sort()).toEqual([
+      "absolutepath",
+      "file",
+      "filename",
+      "filenames",
+      "filepath",
+      "files",
+      "notebookpath",
+      "path",
+      "paths",
+      "sourcepath",
+    ]);
   });
 });

--- a/src/lib/__tests__/flag-and-verb-tables.test.ts
+++ b/src/lib/__tests__/flag-and-verb-tables.test.ts
@@ -10,7 +10,11 @@
 // removes its case rather than leaving a stale assertion behind.
 
 import { describe, expect, it } from "vitest";
-import { IN_PLACE_EDITORS, isInPlaceFlag } from "../bash-commands.ts";
+import {
+  IN_PLACE_EDITORS,
+  isInPlaceFlag,
+  PATTERN_SUPPLYING_FLAGS,
+} from "../bash-commands.ts";
 import {
   collectPathFields,
   isWritingTool,
@@ -59,9 +63,19 @@ describe("every write verb is exempt in every spelling", () => {
 });
 
 describe("in-place flags, per command and per switch letter", () => {
-  it.each(IN_PLACE_COMMANDS)("%s: -i and its long forms", (cmd) => {
-    for (const flag of ["-i", "-i.bak", "--in-place", "--in-place=.bak"]) {
+  it.each(IN_PLACE_COMMANDS)("%s: -i and -i with a suffix", (cmd) => {
+    for (const flag of ["-i", "-i.bak"]) {
       expect(isInPlaceFlag(cmd, flag), `${cmd} ${flag}`).toBe(true);
+    }
+  });
+
+  // The long form is sed's alone. perl and ruby spell it `-i` and would reject
+  // `--in-place`, so accepting it from them left their files unscanned.
+  it("only sed accepts the long form", () => {
+    for (const flag of ["--in-place", "--in-place=.bak"]) {
+      expect(isInPlaceFlag("sed", flag), `sed ${flag}`).toBe(true);
+      expect(isInPlaceFlag("perl", flag), `perl ${flag}`).toBe(false);
+      expect(isInPlaceFlag("ruby", flag), `ruby ${flag}`).toBe(false);
     }
   });
 
@@ -142,14 +156,32 @@ describe("table invariants", () => {
     },
   );
 
-  // Which commands edit in place, written out. The generated cases walk the
-  // table's keys, so they follow it wherever it goes; this is what notices a
-  // command being added to it or dropped from it.
-  it("the in-place editors are sed, perl and ruby", () => {
-    expect(Object.keys(IN_PLACE_EDITORS).sort()).toEqual([
-      "perl",
-      "ruby",
-      "sed",
+  // The table written out, letters and all. The generated cases walk it, so they
+  // follow it wherever it goes: a deleted letter deletes its own case and a new
+  // command brings its own. Measured — dropping `u` from `sed` passed everything.
+  //
+  // Deleting a letter is the fail-closed direction (the file gets scanned) and
+  // adding one is not, so this matters in both, and an equality covers both.
+  it("is exactly this", () => {
+    expect(IN_PLACE_EDITORS).toEqual({
+      sed: "anszEru",
+      perl: "aclnpsStTuUvwWX",
+      ruby: "acdlnpsSTUvwWy",
+    });
+  });
+
+  // The other table this file's subject depends on. A pattern flag deleted from
+  // it stops marking the pattern as supplied, and the file that follows is eaten
+  // as the pattern instead of being scanned — measured: deleting `--from-file`
+  // passed every test.
+  it("the pattern-supplying flags are exactly these", () => {
+    expect([...PATTERN_SUPPLYING_FLAGS].sort()).toEqual([
+      "--expression",
+      "--file",
+      "--from-file",
+      "--regexp",
+      "-e",
+      "-f",
     ]);
   });
 

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -90,7 +90,7 @@ const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
 // `sed --expression='s/a/b/' secrets` consumed the file as the pattern and never
 // scanned it. The separate-value forms name a pattern or a pattern file, neither
 // of which is printed, so their value is skipped rather than collected.
-const PATTERN_SUPPLYING_FLAGS = new Set([
+export const PATTERN_SUPPLYING_FLAGS = new Set([
   "-e",
   "--regexp",
   "--expression",
@@ -261,16 +261,21 @@ export const IN_PLACE_EDITORS: Record<string, string> = {
 };
 
 // True when `cmd` edits in place given `value` as one of its flags: `-i`,
-// `-i.bak`, a bundle reaching `i` past that command's valueless switches
-// (`-pi`, `-lpi`, `-Ei`), or the long form with or without a backup suffix.
+// `-i.bak`, or a bundle reaching `i` past that command's valueless switches
+// (`-pi`, `-lpi`, `-Ei`).
 //
 // A command absent from the table is not an in-place editor at all, so no flag of
 // it counts — `grep -i` and `grep --in-place` alike.
+//
+// `--in-place` is sed's alone. Accepting it from every command in the table meant
+// `perl --in-place=.bak -pe 'x' secrets` and the same for `ruby` were treated as
+// in-place edits and their files went unscanned, though neither interpreter has
+// that flag: perl and ruby spell it `-i`, and would reject the long form.
 export function isInPlaceFlag(cmd: string, value: string): boolean {
   const valueless = IN_PLACE_EDITORS[cmd];
   if (valueless === undefined) return false;
 
-  if (value === "--in-place" || value.startsWith("--in-place=")) return true;
+  if (cmd === "sed" && value.replace(/=.*/, "") === "--in-place") return true;
   if (!value.startsWith("-") || value.startsWith("--")) return false;
 
   for (const ch of value.slice(1)) {

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -99,6 +99,30 @@ const PATTERN_SUPPLYING_FLAGS = new Set([
   "--from-file",
 ]);
 
+// Whether a flag token supplies the pattern, and whether its value is already
+// attached to it.
+//
+// Three spellings carry a value: separate (`-e aws`, `--regexp aws`), attached
+// after `=` (`--regexp=aws`), and attached directly to a short flag
+// (`-eaws`, `sed -e's/a/b/'`). Only the first two were recognised, so an attached
+// short value left `patternSkipped` unset and the file that followed was eaten as
+// the pattern — `grep -eaws secrets` and `sed -e's/a/b/' secrets` scanned nothing.
+function patternSupplyingFlag(
+  token: string,
+): { valueAttached: boolean } | null {
+  const [beforeEquals] = token.split("=", 1) as [string];
+  if (PATTERN_SUPPLYING_FLAGS.has(beforeEquals)) {
+    return { valueAttached: token.includes("=") };
+  }
+  // A short flag with its value written against it. Long flags are excluded:
+  // `--file-name` is not `--file` with `-name` attached.
+  if (!token.startsWith("--") && token.length > 2) {
+    const short = token.slice(0, 2);
+    if (PATTERN_SUPPLYING_FLAGS.has(short)) return { valueAttached: true };
+  }
+  return null;
+}
+
 // Flags of a read command whose separate value names a file to write, not one to
 // read: `sort -o out.txt in.txt` prints nothing of `out.txt`, and scanning it
 // blocked a command that only ever writes there.
@@ -210,7 +234,7 @@ function gitSubcommandPrintsFiles(
 // Commands whose `-i` rewrites the files it is handed instead of printing them.
 // Not every `-i` means that: `grep -i` matches case-insensitively and still
 // prints, which is why this is a list rather than a check on the flag alone.
-const IN_PLACE_EDIT_COMMANDS = new Set(["sed", "perl", "ruby"]);
+export const IN_PLACE_EDIT_COMMANDS = new Set(["sed", "perl", "ruby"]);
 
 // Short switches each of these commands accepts without a value, so a bundle of
 // them can be read one letter at a time in search of the `i`.
@@ -652,14 +676,15 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
       // The value of an output flag is written, not read.
       if (WRITE_TARGET_FLAGS[cmd]?.has(tok.value)) skipNext = true;
 
-      // The pattern arrived as a flag, so no operand stands in for it. An
-      // attached value (`--regexp=aws`) is already part of this token; a
-      // separate one is a pattern or a pattern file, and neither is printed.
+      // The pattern arrived as a flag, so no operand stands in for it.
       if (behaviour.firstOperandIsPatternOrScript) {
-        const [flag] = tok.value.split("=", 1) as [string];
-        if (PATTERN_SUPPLYING_FLAGS.has(flag)) {
+        const supply = patternSupplyingFlag(tok.value);
+        if (supply !== null) {
           patternSkipped = true;
-          if (!tok.value.includes("=")) skipNext = true;
+          // Only a flag still waiting for its value consumes the next token. A
+          // value already attached — `--regexp=aws`, or `-eaws` — is part of
+          // this one.
+          if (!supply.valueAttached) skipNext = true;
         }
       }
       continue;

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -107,18 +107,16 @@ const PATTERN_SUPPLYING_FLAGS = new Set([
 // (`-eaws`, `sed -e's/a/b/'`). Only the first two were recognised, so an attached
 // short value left `patternSkipped` unset and the file that followed was eaten as
 // the pattern — `grep -eaws secrets` and `sed -e's/a/b/' secrets` scanned nothing.
-function patternSupplyingFlag(
-  token: string,
-): { valueAttached: boolean } | null {
-  const [beforeEquals] = token.split("=", 1) as [string];
+function patternSupplyingFlag(token: string): "attached" | "separate" | null {
+  const equals = token.indexOf("=");
+  const beforeEquals = equals === -1 ? token : token.slice(0, equals);
   if (PATTERN_SUPPLYING_FLAGS.has(beforeEquals)) {
-    return { valueAttached: token.includes("=") };
+    return equals === -1 ? "separate" : "attached";
   }
   // A short flag with its value written against it. Long flags are excluded:
   // `--file-name` is not `--file` with `-name` attached.
   if (!token.startsWith("--") && token.length > 2) {
-    const short = token.slice(0, 2);
-    if (PATTERN_SUPPLYING_FLAGS.has(short)) return { valueAttached: true };
+    if (PATTERN_SUPPLYING_FLAGS.has(token.slice(0, 2))) return "attached";
   }
   return null;
 }
@@ -231,13 +229,17 @@ function gitSubcommandPrintsFiles(
   return GIT_READ_SUBCOMMANDS.has(subcommand);
 }
 
-// Commands whose `-i` rewrites the files it is handed instead of printing them.
-// Not every `-i` means that: `grep -i` matches case-insensitively and still
-// prints, which is why this is a list rather than a check on the flag alone.
-export const IN_PLACE_EDIT_COMMANDS = new Set(["sed", "perl", "ruby"]);
-
-// Short switches each of these commands accepts without a value, so a bundle of
-// them can be read one letter at a time in search of the `i`.
+// Commands whose `-i` rewrites the files it is handed instead of printing them,
+// each with the short switches it accepts without a value.
+//
+// Being on this list at all is what makes `-i` mean in-place: `grep -i` matches
+// case-insensitively and still prints. The letters are what let a bundle be read
+// one at a time in search of the `i`.
+//
+// One table rather than two. A separate set of command names said the same thing
+// as these keys, and the two could disagree — adding `awk` to the set alone made
+// `awk -i` an in-place edit, which a test had to be written to catch. Nothing can
+// disagree with itself.
 //
 // Per command, because the letters differ and sharing one set got it wrong in
 // both directions: `E`, `r` and `z` are valueless for `sed` but absent from a
@@ -252,20 +254,25 @@ export const IN_PLACE_EDIT_COMMANDS = new Set(["sed", "perl", "ruby"]);
 // `e` is absent from every line on purpose: it introduces a script for all three,
 // and a sed script contains `i` as its insert command, so reading past `-e` would
 // find an `i` in the program text and call the command an in-place edit.
-export const VALUELESS_SHORT_SWITCHES: Record<string, string> = {
+export const IN_PLACE_EDITORS: Record<string, string> = {
   sed: "anszEru",
   perl: "aclnpsStTuUvwWX",
   ruby: "acdlnpsSTUvwWy",
 };
 
-// True when a token is the in-place flag for `cmd`: `-i`, `-i.bak`, a bundle
-// reaching `i` past that command's valueless switches (`-pi`, `-lpi`, `-Ei`), or
-// the long form with or without a backup suffix.
+// True when `cmd` edits in place given `value` as one of its flags: `-i`,
+// `-i.bak`, a bundle reaching `i` past that command's valueless switches
+// (`-pi`, `-lpi`, `-Ei`), or the long form with or without a backup suffix.
+//
+// A command absent from the table is not an in-place editor at all, so no flag of
+// it counts — `grep -i` and `grep --in-place` alike.
 export function isInPlaceFlag(cmd: string, value: string): boolean {
+  const valueless = IN_PLACE_EDITORS[cmd];
+  if (valueless === undefined) return false;
+
   if (value === "--in-place" || value.startsWith("--in-place=")) return true;
   if (!value.startsWith("-") || value.startsWith("--")) return false;
 
-  const valueless = VALUELESS_SHORT_SWITCHES[cmd] ?? "";
   for (const ch of value.slice(1)) {
     if (ch === "i") return true;
     if (!valueless.includes(ch)) return false;
@@ -274,7 +281,6 @@ export function isInPlaceFlag(cmd: string, value: string): boolean {
 }
 
 function editsInPlace(cmd: string, operands: ShellToken[]): boolean {
-  if (!IN_PLACE_EDIT_COMMANDS.has(cmd)) return false;
   return operands.some(({ value }) => isInPlaceFlag(cmd, value));
 }
 
@@ -684,7 +690,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
           // Only a flag still waiting for its value consumes the next token. A
           // value already attached — `--regexp=aws`, or `-eaws` — is part of
           // this one.
-          if (!supply.valueAttached) skipNext = true;
+          if (supply === "separate") skipNext = true;
         }
       }
       continue;

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -88,7 +88,7 @@ export function isWritingTool(tool: string): boolean {
 // here, but `filepath` was not, and neither was `filename` or `source_path`.
 // Normalising is a rule where a list of spellings is a list of the ones someone
 // happened to think of.
-const PATH_FIELD_NAMES = new Set([
+export const PATH_FIELD_NAMES = new Set([
   "filepath",
   "filename",
   "filenames",


### PR DESCRIPTION
Stacked on #180. Closes a fail-open that predates this release cycle, and fixes the tests that let it hide.

## The fail-open

`grep -eaws secrets` and `sed -e's/a/b/' secrets` scanned nothing.

The pattern-flag match read `token.split("=", 1)`, which recognises `-e aws` and `--regexp=aws` but not a short flag with its value written against it. Nothing marked the pattern as supplied, so the file that followed was consumed as the pattern instead of being read.

| command | main | now |
| --- | --- | --- |
| `grep -eaws <file>` | 0 | **2** |
| `grep -faws <file>` | 0 | **2** |
| `sed -e's/a/b/' <file>` | 0 | **2** |
| `sed -ei\hello <file>` | 0 | **2** |
| `sed -ei <file>` | 0 | **2** |
| `sed -fi <file>` | 0 | **2** |
| `grep -e. <file>` | 0 | **2** |

Present in `main`. The separate and `=` spellings were fixed earlier in this cycle, which left the attached one as the only way through.

## How it was found, and what that says about the tests

Not by reading the diff. By **mutation-testing the existing suite**: injecting a plausible wrong value into each table and asking whether anything failed.

The first injection was `e` into `sed`'s valueless switches — a wrong entry that would read a sed script's insert command as the in-place flag. **All 165 tests passed.** Following that up turned over three more gaps, all the same shape: a test that restates the implementation cannot disagree with it.

Of 13 mutations, 9 were caught and 4 survived. All four are now caught:

| mutation | before | now |
| --- | --- | --- |
| `sed` valueless switches gain `e` | survived | caught |
| `awk` added to `IN_PLACE_EDIT_COMMANDS` only | survived | caught |
| `path` removed from `PATH_FIELD_NAMES` | survived | caught |
| attached pattern flag not recognised | survived | caught |

(A fifth, adding `log` back to `GIT_READ_SUBCOMMANDS`, survives because the `log` special case is evaluated first — the entry is dead either way. An equivalent mutant, not a gap.)

## The three test weaknesses

- **Generated cases assert what a table says.** A case per entry guarantees coverage of the mapping, not that the mapping is right. Fixed with invariants that hold whatever the tables contain: `e` is valueless for none of the three commands, no digit is, and `IN_PLACE_EDIT_COMMANDS` and `VALUELESS_SHORT_SWITCHES` cover the same commands. The last one catches `awk` in one table alone, which made `awk -i` an in-place edit and passed everything else.

- **A generated case cannot catch a deleted entry** — it deletes its own case. Removing `path` from `PATH_FIELD_NAMES` passed the whole repository. The core names are now written out a second time; the duplication is the point, two copies that must agree.

- **Two independent rules, one of them never exercised alone.** A path field is collected by name or by shape, and every fixture path contains a `/`, so the shape rule collected everything and hid whether the name list works at all. Bare filenames now exercise the name rule on its own.

## Verification

633 passing, 1 skipped (602 before). `tsc --noEmit`, `biome lint src`, `biome ci --linter-enabled=false src`, `docs:build` clean.

Every row in the table above was measured by running `main` and this branch against the same fixture. The mutation results were produced by applying each mutation, running the suite, and restoring — not by inspection.



---

## Two further rounds on this branch

A two-axis review of #180 and #181 found more, and the fixes are here rather than in another PR.

**A fail-open this branch's parent introduced.** `perl --in-place=.bak -pe 'x' <file>` and the same for `ruby` exited 0 — their files went unscanned. Neither interpreter has that flag; both spell it `-i` and would reject the long form. It is sed's, and only sed accepts it now.

**A one-character attached pattern value had no case.** Every example above uses several characters, and the test for "is there anything after the flag" is a length comparison, so an off-by-one there stops `grep -e. secrets` being scanned while every case passes. Four one-character cases now cover it.

**Two tables had no equality assertion.** Deleting `--from-file` from `PATTERN_SUPPLYING_FLAGS` passed everything, and so did dropping a letter from the in-place table — the weakness this PR named and then fixed for `PATH_FIELD_NAMES` alone. Both are written out now.

**One table where there were two.** `IN_PLACE_EDIT_COMMANDS` and the keys of the switch table said the same thing and could disagree; this PR answered that with a test asserting they agree. They are now one record, so nothing can disagree, and both that test and an `?? ""` fallback go.

**The generated-case file moved** to `src/lib/__tests__/`, where the repository keeps unit tests of `src/lib` and where `CONTRIBUTING.md` points.

Also corrected: the hand-written duplicate of `PATH_FIELD_NAMES` listed eight of ten names, leaving `filenames` and `sourcepath` free to be deleted — a hole in the test written to close that kind of hole.

Mutations re-run after all of it: `token.length > 2` → `> 3`, deleting `--from-file`, dropping a letter from sed's switches, accepting the long form from every command, and adding `awk` to the table are all caught. 636 passing, 1 skipped.
