### PR TITLE
ci: build the commit that merging makes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,28 @@
 name: CI
 
-# No `branches` filter: it matches the *base* branch, so a stacked PR whose base
-# is another feature branch got no CI at all — exactly the changes that most want
-# checking, since nobody has seen them yet.
+# `pull_request` carries no `branches` filter: there it matches the *base*
+# branch, so a stacked PR whose base is another feature branch got no CI at all —
+# exactly the changes that most want checking, since nobody has seen them yet.
+#
+# `push` is filtered, and its filter is a different one: it matches the branch
+# pushed to. Feature branches are covered by the trigger above, so naming them
+# here would only run all seven jobs a second time for every push. What the
+# trigger above does not cover is the commit that merging makes: it exists on no
+# PR, and `06a5223` reached `develop` having never been built. Two branches green
+# apart can still be red together.
+#
+# The same shape as `codeql.yml`, and for the same reason.
 on:
   pull_request:
+  push:
+    branches: [main, develop]
 
 permissions: {}
 
+# A push run and a PR run never cancel each other: one groups by ref, the other
+# by number. Two merges in quick succession do, and the survivor builds the tree
+# the cancelled one was working towards, so the tip of `develop` stays covered.
+# The merge commit skipped over does not, and nothing branches from it.
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@
 - Add a `versions` job that fails when `package.json` and
   `.claude-plugin/plugin.json` declare different versions, or when either
   declares nothing that looks like one
+- Run CI on pushes to `main` and `develop`, not only on pull requests. The
+  commit a merge makes belongs to no PR, so nothing built it: two branches that
+  are green apart can still be red together
 
 ---
 


### PR DESCRIPTION
## What

Add a `push` trigger to `ci.yml`, filtered to `main` and `develop`.

```yaml
on:
  pull_request:
  push:
    branches: [main, develop]
```

## Why

Every CI run so far has been against a PR head. The commit a merge produces belongs to no PR, so nothing builds it — `06a5223` reached `develop` unverified, and so did every merge commit before it. Two branches that are green apart can still be red together.

## Why the filter is on `push` and not `pull_request`

Under `pull_request`, `branches` matches the **base** branch. Adding it there would take CI away from a PR stacked on another feature branch, which is what the existing comment in this file warns about. Under `push` it matches the branch pushed to, so the two are unrelated.

Measured on this repo: `codeql.yml` already carries exactly this shape, and #181 — whose base was `fix/in-place-per-command`, not `develop` — got its CodeQL analyses through the `pull_request` trigger.

```
pull_request | fix/attached-pattern-flags | 6bd76a9 | success
pull_request | fix/in-place-per-command   | 7024df6 | success
push         | develop                    | 06a5223 | success
```

A wildcard (`branches: ['**']`) would instead run all seven jobs twice for every push to a branch with a PR open, since the push and PR runs group differently and neither cancels the other. `['*']` would match nothing here at all, as `*` does not cross a `/` and every branch in this repo has one.

## Concurrency

Left as it is, with the behaviour written down: a push run and a PR run never cancel each other, but two merges in quick succession do, and the merge commit skipped over stays unbuilt. `37a79af`'s CodeQL run was cancelled by `06a5223` today for exactly this reason. The tip of `develop` is what stays covered.

## Checks

- `ci.yml` parses; triggers are `pull_request` and `push.branches: [main, develop]`; all seven jobs (`audit`, `versions`, `typecheck`, `lint`, `format`, `test`, `docs`) unchanged
- No job in `ci.yml` reads `github.event.pull_request.*`, so none of them depends on PR context
- `pnpm docs:build` passes (`docs/changelog.md` is a symlink to `CHANGELOG.md`)

Not verifiable before merge: a workflow's triggers take effect once the file is on the target branch, so this PR itself runs under `pull_request` only. Whether the `push` run appears is confirmed after it lands on `develop`.