### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "coo-quack"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.8.0 (2026-08-14)
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coo-quack/sensitive-canary",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
   "homepage": "https://coo-quack.github.io/sensitive-canary/",
   "type": "module",


### PR DESCRIPTION
Rebuilt on the current `develop`. Stacked on #189, so the changelog heading closes a section that includes everything in the release.

The first version of this PR was cut before #184 through #189 landed. Its heading would have closed a `## Unreleased` that has since gained five fail-open fixes, a test suite that went from 650 to 1,445 cases, and the documentation corrections those turned up. Renaming the heading is the whole point of the PR, so it had to be redone rather than rebased.

## The change

- `package.json` and `.claude-plugin/plugin.json`: `0.7.0` → `0.8.0`
- `CHANGELOG.md`: `## Unreleased` → `## v0.8.0 (2026-08-14)`

Minor rather than patch: the release adds behaviour, not only fixes.

## Release checklist, from CONTRIBUTING.md

**1. Both manifests bumped** ✔ — the `versions` job fails when they disagree.

**2. `## Unreleased` renamed** ✔ — `docs/changelog.md` is a symlink and needs no separate edit. The extraction `release.yml` runs is

```
awk "/^## v0.8.0/{found=1; next} found && /^## v/{exit} found{print}" CHANGELOG.md
```

Run against this file it yields 194 lines and stops before `## v0.7.0`.

**3. `docs/rules.md` reviewed** ✔ — every rule id in `src/lib/default-config.json` appears in it. It also gained, this release, the note on why three patterns carry length bounds and what each bound costs.

**4. `README.md` reviewed** ✔ — the config holds 64 rules, 39 secret and 25 PII; README states 64, 39 and 25. The Known Limitations list was gone through in #189 and again here: it now carries the non-regular-file entry, the NUL truncation, the 1 MiB cap and the glob expansion, each added by the change that created it.

**5. Integration test run** ✔ — `SENSITIVE_CANARY_INTEGRATION=1 pnpm test src/__tests__/pre-tool-use-hook.integration.test.ts`, 1 passed in 17.36s. CI never runs it, and it is the only check that Claude Code acts on what the hook writes. This is the first time it has been run since #184–#189 merged.

## Other checks

- `pnpm run ci`: 1,443 passed, 2 skipped
- `pnpm docs:build` passes
- No `v0.8.0` tag exists on the remote, so `release.yml`'s `check` job will proceed

## Merge order

#189 first, then this, then the release PR from `develop` to `main`.

## What is not covered by any check here

`required_status_checks` is still unset on this repository — the ruleset PATCH returns 404 with the token available to me. Every PR in this release was merged with `--admin`. They were all green, but nothing enforced that.