### PR TITLE
fix: close three ways a read went unscanned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,12 @@
   `/dev/zero` never reaches the end of the file, so the hook did not return and
   Claude Code's PreToolUse timeout killed it — and a killed hook does not block
   the call, which made the hang a way through. The tool-input side already
-  stat'd first; the Bash side now does too. `.env` and `.env.*` are still
-  blocked on the name alone, before anything is opened
+  stat'd first; the Bash side now does too. On the paths that name a file
+  outright — `Read` and a Bash command — `.env` and `.env.*` are still blocked
+  on the name alone, before anything is opened. A tool input naming no existing
+  file is left alone as before, since its "path" may be a URL route or an object
+  key. What is no longer read is a FIFO, a process substitution or `/dev/stdin`,
+  which is now listed under Known Limitations
 - Read `--` as the end of option parsing. `grep -- -aws secrets` searches for
   `-aws` in `secrets`, but `-aws` was taken for a flag, so nothing marked the
   pattern as supplied and `secrets` was consumed in its place rather than
@@ -104,7 +108,11 @@
   is the pattern and the command reads stdin
 - Scan a variable named inside another expansion's suffix. `${A:-$TOKEN}` prints
   `$TOKEN` whenever `A` is unset, but each expansion was matched whole, so the
-  skip to the closing brace swallowed the suffix and the name in it
+  skip to the closing brace swallowed the suffix and the name in it. Every `$` a
+  name follows now counts, which also takes in an unclosed `${TOKEN`: searching
+  a checkout for template references with `grep -rn '${TOKEN' .` is blocked when
+  that variable holds a secret. A false block, and the same direction the hook
+  already errs in for `echo '$TOKEN'`
 - `.claude-plugin/plugin.json` declared `0.5.1` while `package.json` declared
   `0.7.0`: the release checklist asks for both, and the bump was missed for
   0.6.0 and 0.7.0. The plugin manifest now matches the released version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@
   recognised, so nothing marked the pattern as supplied and the file that
   followed was consumed as the pattern. The separate (`grep -e aws`) and `=`
   (`--regexp=aws`) spellings were already handled
+- Stop reading a path that names something other than a regular file. Reading
+  `/dev/zero` never reaches the end of the file, so the hook did not return and
+  Claude Code's PreToolUse timeout killed it — and a killed hook does not block
+  the call, which made the hang a way through. The tool-input side already
+  stat'd first; the Bash side now does too. `.env` and `.env.*` are still
+  blocked on the name alone, before anything is opened
+- Read `--` as the end of option parsing. `grep -- -aws secrets` searches for
+  `-aws` in `secrets`, but `-aws` was taken for a flag, so nothing marked the
+  pattern as supplied and `secrets` was consumed in its place rather than
+  scanned. Without the `--` the same tokens mean what they did before: the file
+  is the pattern and the command reads stdin
+- Scan a variable named inside another expansion's suffix. `${A:-$TOKEN}` prints
+  `$TOKEN` whenever `A` is unset, but each expansion was matched whole, so the
+  skip to the closing brace swallowed the suffix and the name in it
 - `.claude-plugin/plugin.json` declared `0.5.1` while `package.json` declared
   `0.7.0`: the release checklist asks for both, and the bump was missed for
   0.6.0 and 0.7.0. The plugin manifest now matches the released version

--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
 - **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
 - **`.env.*` is blocked by name** — the filename guard covers every `.env.*`, so a template like `.env.example` is blocked as well, now through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` for those.
+- **Anything that is not a regular file** — a FIFO, a process substitution (`/dev/fd/63`) and `/dev/stdin` are not read, so `cat` of one is not scanned. Reading them can never reach the end of the file: `cat /dev/zero` held the hook open until Claude Code's PreToolUse timeout killed it, and a killed hook does not block the call. Not scanning them is the lesser of the two, since a hang lets the call through as well.
 - **Paths held in shell variables** — a path is only scanned when it appears literally in the command. `f=.env; cat "$f"` resolves at run time, after the hook has already decided.
 - **Paths arriving over a pipe** — `find . -name '.env' | xargs cat` names no file the hook can see.
 - **Programs that read files themselves** — `python script.py` is not scanned, because running a script does not print its source; whatever the script opens at run time is beyond the hook's reach.

--- a/src/__tests__/hook-harness.ts
+++ b/src/__tests__/hook-harness.ts
@@ -44,12 +44,20 @@ export interface HookResult {
   reason: string | null;
 }
 
+// A hook that never returns is a fail-open in production, where Claude Code's
+// PreToolUse timeout kills it and lets the call through. `spawnSync` blocks the
+// worker, so without a limit here the same hang stops the test run rather than
+// failing it, and vitest's per-test timeout cannot interrupt it. A killed run
+// reports no status, which becomes -1 and fails whatever the test expected.
+const HOOK_TIMEOUT_MS = 15_000;
+
 // Spawn the hook with a raw stdin payload and assemble its verdict.
 function spawnHook(input: string, opts?: RunOptions): HookResult {
   const result = spawnSync("node", [...NODE_FLAGS, HOOK], {
     input,
     encoding: "utf8",
     env: opts?.replaceEnv ? (opts.env ?? {}) : { ...process.env, ...opts?.env },
+    timeout: HOOK_TIMEOUT_MS,
   });
   const exitCode = result.status ?? -1;
   return {

--- a/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
+++ b/src/__tests__/pre-tool-use-hook-command-coverage.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
   AWS_KEY,
@@ -259,6 +260,31 @@ describe("pre-tool-use-hook — command classification", () => {
       expect(result.blocked).toBe(true);
     });
 
+    // `--` ends option parsing, so what follows is the pattern and the file
+    // after it is a file. Read as a flag, `-aws` marked nothing as supplying the
+    // pattern, and the file was consumed in its place — the same hole the
+    // attached spelling above had, reached a different way.
+    it.each([
+      ["grep -- -aws", "dashdash_grep.txt"],
+      ["grep -- -e", "dashdash_grep_e.txt"],
+      ["sed -- s/a/b/", "dashdash_sed.txt"],
+    ])("%s should block the file after the pattern", (prefix, fixture) => {
+      const file = writeFixture(fixture, `key=${AWS_KEY}`);
+      const result = runBashHook(`${prefix} ${file}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // Without the `--`, the same tokens mean something else: `-aws` is a bundle
+    // of flags, the file is the pattern, and grep reads stdin. Nothing is read,
+    // so nothing is scanned — the pair is what says the `--` is being read
+    // rather than every `-`-shaped token being waved through.
+    it("the same command without -- reads stdin, not the file", () => {
+      const file = writeFixture("no_dashdash.txt", `key=${AWS_KEY}`);
+      const result = runBashHook(`grep -aws ${file}`);
+      expect(result.exitCode).toBe(0);
+    });
+
     // The separate-value spelling still consumes the next token, so a pattern
     // that happens to name a secret-bearing file is not scanned as an operand.
     it("grep -e with a separate value does not scan that value", () => {
@@ -391,6 +417,70 @@ describe("pre-tool-use-hook — command classification", () => {
         replaceEnv: true,
       });
       expect(result.exitCode).toBe(0);
+    });
+
+    // A name inside another expansion's suffix is a reference like any other:
+    // `${A:-$SECRET}` prints the secret whenever `A` is unset. Matching each
+    // expansion whole meant the suffix was skipped over to reach the closing
+    // brace, and the name in it went unread.
+    it.each([
+      "echo ${A:-$SECRET}",
+      'echo ${A:-"$SECRET"}',
+      "echo ${A:-${B:-$SECRET}}",
+      "echo ${A:+$SECRET}",
+      "echo ${A#$SECRET}",
+    ])("%s should block on the name inside the expansion", (command) => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook(command, {
+        env: { PATH: pathVal, SECRET: TOKEN_VALUE },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // The outer name is still read, so an expansion naming a clean variable
+    // around a secret-free suffix stays allowed.
+    it("an expansion naming no secret-bearing variable is allowed", () => {
+      const pathVal = process.env["PATH"] ?? "";
+      const result = runBashHook("echo ${A:-${B:-fallback}}", {
+        env: { PATH: pathVal, SECRET: TOKEN_VALUE },
+        replaceEnv: true,
+      });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  // Opening a path that is not a regular file can block forever: reading
+  // `/dev/zero` never reaches EOF. The hook then hung until Claude Code's
+  // PreToolUse timeout killed it, and a killed hook does not block the call —
+  // so the hang was a fail-open. The tool-input side has always stat'd first;
+  // the Bash side did not.
+  describe("targets that are not regular files", () => {
+    it("a character device is not read", () => {
+      const result = runBashHook("cat /dev/zero");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a fifo is not read", () => {
+      const fifo = writeFixture("fifo_placeholder.txt", "");
+      execFileSync("mkfifo", [`${fifo}.pipe`]);
+      const result = runBashHook(`cat ${fifo}.pipe`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a directory is not read", () => {
+      const result = runBashHook(`cat ${writeFixture.path()}`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    // The name guard runs before the file is opened, so it still applies to a
+    // path that names nothing. That is what keeps `cat .env.production` blocked
+    // on a machine where the file is absent.
+    it("a .env name is still blocked when no such file exists", () => {
+      const result = runBashHook(`cat ${writeFixture.path(".env.missing")}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
     });
   });
 

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -634,6 +634,7 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
   let patternSkipped = false;
   let gitSubcommandSeen = false;
   let gitReadsFiles = false;
+  let optionsEnded = false;
 
   for (const tok of operands) {
     if (skipNext) {
@@ -668,12 +669,25 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
       continue;
     }
 
-    if (behaviour.takesInlineCode && isInlineCodeFlag(cmd, tok.value)) {
+    // `--` ends option parsing: every token after it is an operand, whatever it
+    // is spelled like. `grep -- -aws secrets` searches for `-aws` in `secrets`,
+    // so the file is a file — read as a flag, `-aws` left the pattern
+    // unaccounted for and `secrets` was consumed in its place.
+    if (!optionsEnded && tok.value === "--") {
+      optionsEnded = true;
+      continue;
+    }
+
+    if (
+      !optionsEnded &&
+      behaviour.takesInlineCode &&
+      isInlineCodeFlag(cmd, tok.value)
+    ) {
       codeNext = true;
       continue;
     }
 
-    if (tok.value.startsWith("-")) {
+    if (!optionsEnded && tok.value.startsWith("-")) {
       // A global git flag with a separate value consumes the next token too:
       // in `git -C repo show f`, `repo` is not the subcommand.
       if (

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -60,11 +60,16 @@ function stepQuote(s: string, i: number, quote: string | null): QuoteStep {
 
 // Variable names referenced by the command, including expansion forms that carry
 // a suffix such as `${TOKEN:-fallback}` or `${TOKEN#prefix}`.
+//
+// Every `$` that a name follows counts, rather than each expansion being matched
+// whole. Matching `${NAME…}` as a unit meant the suffix was consumed by the
+// pattern that skipped to the closing brace, and a name inside the suffix went
+// with it: `${A:-$TOKEN}` prints `$TOKEN` when `A` is unset, and named only `A`.
+// An unclosed `${NAME` now yields its name too, which errs towards scanning.
 export function extractEnvVarNames(command: string): string[] {
   const names = new Set<string>();
-  const re = /\$\{([A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
-  for (const match of command.matchAll(re)) {
-    const name = match[1] ?? match[2];
+  for (const match of command.matchAll(/\$\{?([A-Za-z_][A-Za-z0-9_]*)/g)) {
+    const name = match[1];
     if (name) names.add(name);
   }
   return [...names];

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -210,18 +210,30 @@ function block(
 
 // ── Core scan logic ───────────────────────────────────────────────────────────
 
+// Whether a path names something whose bytes can be read to the end.
+//
+// A character device or a FIFO can be opened and read from forever: `cat
+// /dev/zero` never returns, and neither did the hook, until Claude Code's
+// PreToolUse timeout killed it. A killed hook does not block the call, so a hang
+// is a fail-open — the one failure mode worth spending a `stat` on every path to
+// avoid.
+function isRegularFile(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
 // Scan a candidate only when it names an existing regular file. Tools whose
-// "path" means something else (a URL route, an object key) are left alone.
+// "path" means something else (a URL route, an object key) are left alone —
+// including from the `.env` name guard, which a tool input has no business
+// tripping over a value that names no file at all.
 function scanIfRegularFile(
   candidate: string | undefined,
   allowTags: Set<string>,
 ): void {
-  if (!candidate) return;
-  try {
-    if (!fs.statSync(candidate).isFile()) return;
-  } catch {
-    return;
-  }
+  if (!candidate || !isRegularFile(candidate)) return;
   scanFile(candidate, allowTags);
 }
 
@@ -236,6 +248,10 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
       buildAllowHints(`please read ${filePath}`, [], true),
     );
   }
+
+  // The name guard above runs first and on the name alone, so `cat .env.missing`
+  // is still blocked. Everything past here opens the file.
+  if (!isRegularFile(filePath)) return;
 
   let content: string;
   try {


### PR DESCRIPTION
Three fail-opens, found by reviewing the release as a whole rather than any single change. Each let a file reach the model unscanned; none was caught by the 636 tests already in the tree.

## 1. A path that is not a regular file was opened anyway

`readFileSync` on a character device or a FIFO never reaches the end of the file. The hook did not return, Claude Code's PreToolUse timeout killed it, and **a killed hook does not block the call** — so the hang was a way through, not a stall.

```
before:  cat /dev/zero  ->  no exit (killed at 15s)
after:   cat /dev/zero  ->  exit 0 in under a second
```

`src/pre-tool-use-hook.ts:339` called `scanFile` directly, while the tool-input side (`:351`) went through `scanIfRegularFile` and its `statSync(...).isFile()` guard. The guard now lives inside `scanFile`, after the `.env` name check and before the open, so both sides get it and `cat .env.missing` is still blocked on the name alone.

## 2. `--` was read as a flag

```
before:  grep -- -aws secrets  ->  exit 0
after:   grep -- -aws secrets  ->  exit 2
         grep -aws secrets     ->  exit 0   (unchanged, and correct)
```

After `--`, `-aws` is the pattern and `secrets` is a file. Taken for a flag, nothing marked the pattern as supplied, so `secrets` was consumed in its place. The same hole PR #181 closed for the attached spelling (`grep -eaws`), reached a different way.

Both directions are tested: without the `--`, `-aws` really is a bundle of flags, the file really is the pattern, and grep really does read stdin — so `exit 0` there is the right answer, and the pair is what says the `--` is being read rather than every `-`-shaped token being waved through.

## 3. A variable inside another expansion's suffix went unread

```
before:  echo ${A:-$SECRET}  ->  exit 0     (echo $SECRET was already exit 2)
after:   echo ${A:-$SECRET}  ->  exit 2
```

`${A:-$SECRET}` prints the secret whenever `A` is unset. `extractEnvVarNames` matched each expansion whole, so `[^}]*` skipped to the closing brace over the name in the suffix. It now counts every `$` a name follows, which is both shorter and nesting-proof.

## Tests

+14 cases, and each was checked against the code it guards by putting the defect back:

| mutation | result |
| --- | --- |
| `--` recognition removed | 2 failed |
| `extractEnvVarNames` restored to its pre-fix form exactly | 5 failed, 135 passed |
| regular-file guard removed | 2 failed (character device, FIFO) |

The directory case passed under that last mutation — `readFileSync` on a directory already threw — so it is documented as covering a different path, not as evidence for the guard.

**The harness now gives the hook a 15s limit.** `spawnSync` blocks the worker, so a hanging hook stopped the whole run rather than failing one test, and vitest's per-test timeout cannot interrupt it. Without this, the first fix above would have had no test that could report.

650 tests pass (was 636). `pnpm run ci` and `pnpm docs:build` pass locally.

## Not addressed here

Held for the follow-ups already planned: `WRITING_TOOL_VERBS` has no equality assertion (deleting an entry passes the suite), `src/lib/shell.ts` has no unit tests at all, and several table entries are unreferenced by any test. Documentation fixes (README's file tree and its `npm`/`pnpm` split) are a third PR.