### PR TITLE
docs: catch the README up, and drop a set that never got asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,15 @@
   not, because only four of the family were listed. `sha224sum`, `sha384sum`,
   `sha512sum`, `b2sum`, `shasum`, `md5` and `sum` join them
 
+### Documentation
+
+- The file structure in `README.md` listed two files under `src/lib/`, from
+  before this release added three more and moved the rules into JSON
+- The development commands in `README.md` were `npm`, while `CONTRIBUTING.md`
+  and every CI job are `pnpm`. The lockfile is pnpm's, so following the README
+  ignored it, wrote a second lockfile, and resolved a different tree from the one
+  that is tested
+
 ### CI
 
 - Add a `versions` job that fails when `package.json` and

--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ src/
   lib/
     inspector.ts               allow tag parsing, message scanning
     rules.ts                   secret and PII detection rule definitions
+    default-config.json        the rules themselves, as data
+    shell.ts                   shell syntax: tokens, quoting, heredocs, substitutions
+    bash-commands.ts           what each command does with the files it is given
+    tool-inputs.ts             which input fields of a tool name a file
 ```
 
 ---
@@ -576,12 +580,16 @@ src/
 ## Development
 
 ```bash
-npm install        # install dependencies
+pnpm install        # install dependencies
 
-npm test           # run tests
-npm run test:watch # run tests in watch mode
-npm run typecheck  # type check (tsc)
-npm run lint       # lint with Biome (no changes)
-npm run fix        # lint + auto-fix with Biome
-npm run ci         # typecheck + lint + tests (for CI)
+pnpm test           # run tests
+pnpm run test:watch # run tests in watch mode
+pnpm run typecheck  # type check (tsc)
+pnpm run lint       # lint with Biome (no changes)
+pnpm run fix        # lint + auto-fix with Biome
+pnpm run ci         # typecheck + lint + tests (for CI)
 ```
+
+The lockfile is pnpm's, and every CI job installs with pnpm, so `npm install`
+here ignores it, writes a second lockfile, and resolves a different tree from the
+one that is tested. `CONTRIBUTING.md` has the rest of the workflow.

--- a/src/lib/__tests__/bash-commands.test.ts
+++ b/src/lib/__tests__/bash-commands.test.ts
@@ -66,6 +66,18 @@ describe("wrappers", () => {
       expect(paths(`${wrapper} cat secrets.txt`)).toContain("secrets.txt");
     },
   );
+
+  // `timeout` and `flock` take an operand of their own before the wrapped
+  // command. The case above never writes one, so it says nothing about the form
+  // people actually type — and these two are why the search steps forward to the
+  // first name it can classify rather than assuming the next token.
+  it.each([
+    "timeout 5 cat secrets.txt",
+    "timeout --preserve-status 5 cat secrets.txt",
+    "flock /tmp/lock cat secrets.txt",
+  ])("%s reaches the wrapped command", (command) => {
+    expect(paths(command)).toContain("secrets.txt");
+  });
 });
 
 describe("commands that print their arguments rather than open them", () => {
@@ -253,12 +265,14 @@ describe("the tables", () => {
       "doas",
       "env",
       "exec",
+      "flock",
       "ionice",
       "nice",
       "nohup",
       "stdbuf",
       "sudo",
       "time",
+      "timeout",
       "xargs",
     ]);
   });

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -156,6 +156,12 @@ export const INLINE_CODE_READS_OPERANDS = new Set(["perl", "ruby"]);
 
 // Commands that run another command. They are stripped so the wrapped command
 // is classified instead: `sudo cat secrets` is treated as `cat secrets`.
+//
+// `timeout` and `flock` take an operand of their own first (`timeout 5 cat f`,
+// `flock /tmp/lock cat f`) and sat in a set of their own for a while. Nothing
+// ever asked which set a name came from — the one place that read them ORed the
+// two — because the search does not need to know: it walks forward to the first
+// name it can classify, which steps over an operand as readily as over a flag.
 export const WRAPPER_COMMANDS = new Set([
   "sudo",
   "doas",
@@ -169,11 +175,9 @@ export const WRAPPER_COMMANDS = new Set([
   "stdbuf",
   "xargs",
   "env",
+  "timeout",
+  "flock",
 ]);
-
-// Wrappers that take one operand of their own before the wrapped command
-// (`timeout 5 cat f`, `flock /tmp/lock cat f`).
-const WRAPPER_COMMANDS_WITH_OPERAND = new Set(["timeout", "flock"]);
 
 // Interpreters that accept inline program text, which is scanned both as a
 // nested command line and for quoted path literals.
@@ -469,12 +473,7 @@ function findCommandIndex(tokens: ShellToken[]): number {
   if (lead === -1) return 0;
 
   const leadName = path.basename(tokens[lead]?.value ?? "");
-  if (
-    !WRAPPER_COMMANDS.has(leadName) &&
-    !WRAPPER_COMMANDS_WITH_OPERAND.has(leadName)
-  ) {
-    return lead;
-  }
+  if (!WRAPPER_COMMANDS.has(leadName)) return lead;
 
   for (let i = lead + 1; i < tokens.length; i++) {
     const tok = tokens[i];

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -33,14 +33,19 @@ interface QuoteStep {
   consumed: boolean;
 }
 
-// The one place the quoting rule is written down: a quote character opens a run
-// and its twin closes it, and a backslash escapes the next character everywhere
-// except inside single quotes, where it is literal.
+// The quoting rule, for the scanners that only need to step over it: a quote
+// character opens a run and its twin closes it, and a backslash escapes the next
+// character everywhere except inside single quotes, where it is literal.
 //
-// Three scanners each spelled that rule out for themselves — as
-// `quote === '"' && ch === "\\"`, as `ch === "\\" && quote !== "'"`, and as
-// `i += quote === "'" ? 1 : 2`. They agreed, which is the point: three spellings
-// of one rule agree until someone corrects one of them.
+// Three of them spelled that out for themselves — as `quote === '"' && ch ===
+// "\\"`, as `ch === "\\" && quote !== "'"`, and as `i += quote === "'" ? 1 : 2`.
+// They agreed, which is the point: three spellings of one rule agree until
+// someone corrects one of them.
+//
+// `tokenizeCommand` is not one of the three and keeps its own reading, because
+// it does not step over a quoted run — it builds the token's text out of it,
+// dropping the quotes, decoding `$'…'` escapes and keeping a backslash literal
+// inside single quotes. Returning a position cannot say what the text became.
 function stepQuote(s: string, i: number, quote: string | null): QuoteStep {
   const ch = s[i] as string;
 


### PR DESCRIPTION
Stacked on #186. Step 3 of the release review: the documentation and cleanup findings.

## README's file structure was two releases behind

```
   lib/
     inspector.ts               allow tag parsing, message scanning
     rules.ts                   secret and PII detection rule definitions
+    default-config.json        the rules themselves, as data
+    shell.ts                   shell syntax: tokens, quoting, heredocs, substitutions
+    bash-commands.ts           what each command does with the files it is given
+    tool-inputs.ts             which input fields of a tool name a file
```

Release checklist step 4 in `CONTRIBUTING.md` asks for a README review. I did one for #183 and checked only the rule counts, so I reported it as done while this was wrong.

## README said `npm`, CONTRIBUTING and CI say `pnpm`

Not just a spelling difference: the lockfile is pnpm's and CI installs with `--frozen-lockfile`, so a contributor following the README resolved a different dependency tree from the one that is tested, and wrote a second lockfile doing it. The global-install instructions stay on `npm` — those are for using the published package, not for working on it.

## `WRAPPER_COMMANDS_WITH_OPERAND` never got asked which set a name came from

```ts
-  if (
-    !WRAPPER_COMMANDS.has(leadName) &&
-    !WRAPPER_COMMANDS_WITH_OPERAND.has(leadName)
-  ) {
-    return lead;
-  }
+  if (!WRAPPER_COMMANDS.has(leadName)) return lead;
```

The set existed to say that `timeout` and `flock` take an operand before the wrapped command. Its only reader ORed the two sets, so the distinction was never used — and does not need to be: the search walks forward to the first name it can classify, and that steps over an operand as readily as over a flag. `timeout` and `flock` move into `WRAPPER_COMMANDS`, which the generated wrapper cases in #186 then cover per entry.

No behaviour change. The equality assertion for the merged set is updated in the same commit, so the two cannot drift apart.

## `stepQuote`'s comment claimed something untrue

It called itself "the one place the quoting rule is written down" while `tokenizeCommand`, in the same file, spells the rule out again. It has to: it builds the token's *text* out of a quoted run — dropping the quotes, decoding `$'…'` escapes, keeping a backslash literal inside single quotes — and a function that returns a position cannot say what the text became. The comment now says which scanners it unified and why the tokenizer is not one of them.

## Also in here

`sha512sum < secrets` was scanned while `sha256sum < secrets` was not — found by the generated cases in #186 and fixed there; the changelog entry for it is here, with the README and pnpm entries under `### Documentation`.

## Not in here, and why

Four findings from the same review are judgement calls I am leaving:

- **The `collectSegmentRefs` loop is a state machine** with eight booleans. The suggested shape — one `if (optionsEnded)` branch jumping to operand collection — breaks `git log -p -- file`, because it would skip the git and dd branches and the pathspec's file would stop being collected. Measured: `git log -p -- <secret>` is exit 2 today.
- **`env`'s argument grammar is spelled out in two functions**, and the two know `-S` / `--split-string` separately.
- **`findCommandIndex` → `basename` runs twice per segment**, once in each of two callers.
- **`IN_PLACE_EDITORS`' value is a string of switch letters** with no type saying so.

Each is a real observation about shape rather than behaviour, and none is worth a refactor between a release review and the release. `pnpm run ci` passes: 826 tests.