### PR TITLE
fix: what a third-party audit found, including a fourth hole of mine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,28 @@
   recognised, so nothing marked the pattern as supplied and the file that
   followed was consumed as the pattern. The separate (`grep -e aws`) and `=`
   (`--regexp=aws`) spellings were already handled
+- Resolve a relative path against the directory the tool runs in. The payload
+  carries a `cwd` and nothing read it, so `cat secrets.txt` named a path relative
+  to wherever the hook process happened to start and was dropped as a file that
+  is not there. A literal `cd` earlier in the same command moves the base too,
+  which is what `cd build && cat secrets` needs
+- Read an assignment written with `:` and with a lower-case name. The rule wanted
+  `[A-Z_]` and `=`, so a `docker-compose.yml` full of `POSTGRES_PASSWORD: …`, an
+  `appsettings.json` with `"client_secret": …` and an `~/.aws/credentials` with
+  `aws_secret_access_key = …` all passed — the three file shapes this tool exists
+  to guard
+- Keep a substitution among the operands instead of ending the segment at it.
+  `cat <(echo hi) secrets` left `secrets` in a segment of its own, where it was
+  read as a command name; the comment at that line said the only cost was
+  reaching the inner command twice
+- Bound the work of one tool call at 8 MiB across every file it reads, and skip a
+  file already read. A glob naming three hundred large files took half a minute,
+  and five overlapping globs read the same files five times
+- Lift the `.env` name block only for a tag that allows secrets. `parseAllowTags`
+  reads `[allow-<anything>]`, and the guard asked only whether any tag was
+  present, so `[allow-pii]` and a mistyped `[allow-pi]` both turned it off. It no
+  longer skips the content scan either: a tag for one category was silently
+  covering the other
 - Expand `~` and `~/…` to the home directory. `cat ~/.aws/credentials` named a
   path that exists on no disk, so it was dropped as a file that is not there —
   and `~/.ssh/id_rsa`, `~/.npmrc` and `~/.netrc` went the same way

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ Claude Code is a powerful development tool, but file reads and command execution
 |--------------------------|----------------------|
 | `cat .env` → full contents sent to Claude ❌ | Blocked by name before Claude reads it ✅ |
 | Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
-| Tool result contains user@email.com ❌ | PII detected and blocked ✅ |
+| `Read customers.csv` full of email addresses ❌ | PII detected before Claude sees the file ✅ |
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
+| `cat docker-compose.yml` with `POSTGRES_PASSWORD:` ❌ | Assignment detected in YAML and JSON too ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
 - **64 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE, KR RRN/BRN, CN Resident ID)
-- **Context gating** — phone numbers, postal codes, and public IP addresses require a nearby label, reducing false positives on bare digit sequences
+- **Context gating** — the noisiest rules (French, Italian, German, Spanish, Korean and Chinese phone numbers, ZIP and EU/KR postal codes, public IPv4 and IPv6) only fire when a label such as `phone` or `ZIP` is nearby. US and Japanese phone numbers, Japanese postal codes and private IPv4 are matched without one, since their shapes are specific enough
 - **Entropy filtering** — reduces false positives on low-entropy values
 - **Local only** — all scanning runs in your terminal; nothing is sent anywhere
 
@@ -225,7 +226,7 @@ To intentionally bypass a block, include the appropriate tag in your **current p
 | `[allow-pii]` | Skip all PII-category checks |
 | `[allow-all]` | Skip all sensitive-canary checks |
 
-> **Note:** Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass. Tags are case-insensitive. `[allow-secret]` does not bypass PII blocks (and vice versa). The name-based block on `.env`/`.env.*` files can be bypassed by any of the three allow tags.
+> **Note:** Tags are read from the **current user message only**. Tags in previous messages are ignored — there is no risk of an accidental persistent bypass. Tags are case-insensitive. `[allow-secret]` does not bypass PII blocks (and vice versa). The name-based block on `.env`/`.env.*` files is a secret guard, so `[allow-secret]` and `[allow-all]` lift it and `[allow-pii]` does not.
 
 ---
 
@@ -491,7 +492,7 @@ Which tools reach the hook at all is the matcher's business, and the default (`R
 
 Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Neither are the tools that surface no file contents — `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`, `AskUserQuestion` — nor any tool whose name leads with a write verb, such as `mcp__fs__write_file` or `createPage`.
 
-Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` and `perl -lpi` included) edit in place and write nothing to stdout. A bundle is read one letter at a time, continuing only past switches that command is known to accept without a value — so `sed -Ei` and `perl -lpi` are in-place edits, while `perl -Ilib -pe` and `perl -MList::Util -pe` are reads. A letter the list does not know stops the reading and the file is scanned, which is the safe way to be wrong. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `--patch` or `-U<n>`.
+Neither is a command that sends its result back to the file it was handed. `sed -i`, `perl -i` and `ruby -i` (bundled forms such as `perl -pi -e` and `perl -lpi` included) edit in place and write nothing to stdout. A bundle is read one letter at a time, continuing only past switches that command is known to accept without a value — so `sed -Ei` and `perl -lpi` are in-place edits, while `perl -Ilib -pe` and `perl -MList::Util -pe` are reads. A letter the list does not know stops the reading and the file is scanned, which is the safe way to be wrong. `git log <file>` is not a read either — it prints who changed the file and when — unless a patch is asked for with `-p`, `-u`, `--patch`, `-U<n>`, `--unified=<n>`, one of the merge-diff forms (`-c`, `-m`, `--cc`, `--diff-merges`), or `-L`, which prints the lines of one named file.
 
 When blocked, the hook exits 2, which stops the tool call, and writes the reason to stderr, which is where Claude reads it from. The reason names what was detected and which allow tag lifts the block, and asks Claude to pass that on to the user.
 The terminal also receives a direct message (via `/dev/tty`).
@@ -510,6 +511,8 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **`~user/…` is not expanded** — `~` and `~/…` are resolved to the home directory, but the form naming another user needs the password database, and guessing would name the wrong file.
 - **A file whose text is not bytes the scanner reads as text** — scanning stops at the first NUL byte, so a UTF-16 file is read as far as its first character and no further. That is the same rule that keeps a binary from being ground through every pattern.
 - **A shell construct that names the file only at run time** — `for f in secrets; do cat "$f"; done` and `find . -name secrets -exec cat {} +` both name the file in the command line, but the hook classifies the command it can see, and in these the reading command is `cat` reached through a loop or through `find`'s own argument list.
+- **At most 8 MiB is read across one tool call** — the per-file cut bounds one file; this bounds the call. A glob naming three hundred large files took half a minute, which is long enough for the PreToolUse timeout to kill the hook, and a killed hook does not block. Files past the budget are not scanned.
+- **A relative path is resolved against the directory Claude Code reports** — and against the last literal `cd` in the same command. A `cd` whose argument is a variable, or a directory change made some other way, leaves the hook resolving against the wrong place.
 - **A glob is expanded by the hook, not by the shell** — `cat *.env` is expanded here to decide what to scan, a moment before the shell expands it and against the hook's own working directory. A file created in between is missed, and at most 256 matches of one pattern are scanned.
 - **Paths held in shell variables** — a path is only scanned when it appears literally in the command. `f=.env; cat "$f"` resolves at run time, after the hook has already decided.
 - **Paths arriving over a pipe** — `find . -name '.env' | xargs cat` names no file the hook can see.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,10 +35,11 @@ sensitive-canary is a best-effort guard, not a guaranteed security boundary:
 - **Pattern coverage** — Only secrets matching defined rules are detected. Unknown or novel credential formats may not be caught.
 - **Entropy filtering** — Generic rules use Shannon entropy thresholds to reduce false positives. Low-entropy values that happen to be real secrets may pass through.
 - **Allow tags** — Any block can be bypassed by the user with `[allow-secret]`, `[allow-pii]`, or `[allow-all]`. This is intentional — the tool assists, not enforces.
-- **Hook execution** — If the Node.js process fails to start (e.g., wrong Node version), the hook exits 0 (pass) to avoid blocking Claude entirely.
+- **Hook execution** — If the Node.js process fails to start, the hook does not block the call. It does not exit 0 to do so: node exits with its own status (9 for an unknown flag), and Claude Code treats anything other than 2 as "do not block". A hook killed by the PreToolUse timeout is the same case, which is why the scan bounds what it reads and what its patterns can cost.
 - **Parse errors** — If the hook input cannot be parsed (malformed JSON from Claude Code), the hook exits 0 (pass) as a fail-open fallback.
 - **Binary files** — Binary files are detected by the presence of a NUL byte. Only the text portion before the first NUL is scanned; content after the NUL is not checked.
-- **Scope** — Only `Read` and `Bash` tool calls are intercepted. Other tool types are not scanned.
+- **Scope** — The default matcher is `Read|Bash|Grep|mcp__.*`, so `Read`, `Bash`, `Grep` and every MCP tool are intercepted. A tool outside the matcher is not scanned at all, and a tool inside it is scanned for the input fields that name a file — see Known Limitations in the README for what that does not reach.
+- **Tool results are not scanned** — there is no `PostToolUse` hook. What a tool returns, having been allowed, is not inspected.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,12 +50,12 @@ Claude Code is a powerful development tool, but file reads and command execution
 |--------------------------|----------------------|
 | `cat .env` → full contents sent to Claude ❌ | Blocked by name by default before Claude reads it ✅ |
 | Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
-| Tool result contains user@email.com ❌ | PII detected and blocked ✅ |
+| `Read customers.csv` full of email addresses ❌ | PII detected before Claude sees the file ✅ |
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
 - **64 detection rules** — sourced from gitleaks and TruffleHog detector definitions
-- **Context gating** — noisy PII rules (phone, postal, IP) only fire when a relevant label is nearby
+- **Context gating** — the noisiest PII rules (non-US/JP phone numbers, postal codes, public IP addresses) only fire when a relevant label is nearby; US and JP phone numbers and JP postal codes are matched without one
 - **Entropy filtering** — reduces false positives on low-entropy values
 - **Luhn validation** — credit card numbers are validated, not just pattern-matched
 - **Local only** — all scanning runs in your terminal; nothing is sent anywhere

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,7 +54,7 @@ Add the following to `~/.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -111,7 +111,7 @@ Add the following to `~/.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash",
+        "matcher": "Read|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -165,7 +165,7 @@ To allow, add a tag to your prompt:
 
 ### PreToolUse hook
 
-Runs before Claude uses the `Read` or `Bash` tool. It blocks:
+Runs before Claude uses `Read`, `Bash`, `Grep` or any MCP tool. It blocks:
 
 - `.env` and `.env.*` files by filename (a secret guard; only while the `secret` category is enabled)
 - Any file whose contents contain secrets or PII

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,7 +98,7 @@ Sensitive Canary scans text against the following rules. Patterns are sourced fr
 | `generic-secret` | `api_key`, `secret_key`, `access_token`, `api_secret` assignments | 3.5 |
 | `env-assignment` | `.env`-style assignments for `SECRET`, `PASSWORD`, `PASSWD`, `TOKEN`, `API_KEY`, `PRIVATE_KEY`, with up to 64 capitals either side of the keyword | 3.0 |
 
-The entropy threshold filters out low-entropy values (e.g. `API_KEY=placeholder`) that are unlikely to be real secrets. Entropy is calculated using the Shannon entropy formula.
+The entropy threshold filters out low-entropy values that are unlikely to be real secrets — `API_KEY=aaaaaaaa` scores 0 and is dropped. It is a weak filter, not a classifier: `placeholder` scores 3.096 and clears the 3.0 threshold, so `API_KEY=placeholder` is reported. Entropy is the Shannon entropy of the value.
 
 ## PII
 
@@ -183,6 +183,8 @@ All blocks can be bypassed by including an allow tag in your prompt. Allow tags 
 
 Tags are **case-insensitive**: `[ALLOW-SECRET]` and `[Allow-Secret]` work the same as `[allow-secret]`.
 
+The name-based block on `.env`/`.env.*` files is a secret guard, so `[allow-secret]` and `[allow-all]` lift it and `[allow-pii]` does not.
+
 ### Mask Tags
 
 `[mask-secret]`, `[mask-pii]`, and `[mask-all]` are recognised but **not supported**. Claude Code hooks cannot rewrite prompt content before it is sent to the API.
@@ -235,7 +237,7 @@ When Claude uses the `Bash` tool, sensitive-canary checks three things:
 
 1. **Environment variables** — any `$VAR` or `${VAR}` references in the command are looked up in the current environment; if their values contain secrets or PII, the command is blocked.
 2. **Command string** — the raw command is scanned (catches inline secrets like `echo AKIAIOSFODNN7EXAMPLE`).
-3. **File-reading commands** — for `cat`, `head`, `tail`, `less`, `more`, `bat`, `nl`, the target files are read and scanned before the command runs. Compound commands using `|`, `;`, `&&`, `||` are split and each segment is checked independently.
+3. **File-reading commands** — the target files are read and scanned before the command runs. The set is the one in `src/lib/bash-commands.ts`: around forty commands that print their operands (`cat`, `head`, `xxd`, `zcat`, `iconv`, `comm`, …), a second class whose first argument is a pattern and whose rest are files (`grep`, `sed`, `awk`, `jq`, `zgrep`, …), the git subcommands that print contents, `dd if=`, and inline program text. Compound commands using `|`, `;`, `&&`, `||` are split and each segment is checked independently. README's "How it works" has the full picture.
 
 ## Custom Rules
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,7 +25,7 @@ If legitimate content is being blocked:
 
 ## .env file blocking
 
-This is by design. `.env` and `.env.*` files are blocked by filename, regardless of their contents, but only while the `secret` category is enabled (the default). Any allow tag (`[allow-secret]`, `[allow-pii]`, or `[allow-all]`) will bypass this block if you need Claude to read an `.env` file intentionally.
+This is by design. `.env` and `.env.*` files are blocked by filename, regardless of their contents, but only while the `secret` category is enabled (the default). `[allow-secret]` or `[allow-all]` will lift this block if you need Claude to read an `.env` file intentionally. `[allow-pii]` will not: the block is a secret guard.
 
 ## Plugin not found after marketplace registration
 

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -343,6 +343,56 @@ describe("pre-tool-use-hook — large file head read (1 MiB)", () => {
   );
 });
 
+// The `.env` name block is a secret guard — `shouldBlockEnvFile` asks whether the
+// secret category is on — so the tag that lifts it has to allow secrets. Any tag
+// at all used to lift it, and `parseAllowTags` reads `[allow-<anything>]`, so a
+// mistyped `[allow-pi]` turned off the guard the README leads with.
+describe("pre-tool-use-hook — which allow tag lifts the .env block", () => {
+  const writeFixture = useFixtureDir("env-allow-tags");
+
+  const withTag = (tag: string, file: string): number => {
+    const transcript = writeFixture(
+      `t-${tag}.jsonl`,
+      `${JSON.stringify({ message: { role: "user", content: `[allow-${tag}] read it` } })}\n`,
+    );
+    return runHook("Read", file, { transcriptPath: transcript }).exitCode;
+  };
+
+  it.each(["secret", "all"])("[allow-%s] lifts it", (tag) => {
+    const file = writeFixture(".env", "TOKEN=whatever");
+    expect(withTag(tag, file)).toBe(0);
+  });
+
+  it.each(["pii", "banana", "pi"])("[allow-%s] does not lift it", (tag) => {
+    const file = writeFixture(".env", "TOKEN=whatever");
+    expect(withTag(tag, file)).toBe(2);
+  });
+});
+
+// README states these as contracts, and each survived being changed: the depth
+// limit set to 1, the glob match cap set to 1, the transcript tail cut to 1 KB.
+describe("pre-tool-use-hook — the documented limits", () => {
+  const writeFixture = useFixtureDir("limits");
+
+  // Four levels of inline text are inspected; the fifth is not.
+  it("inline code is followed four levels deep and no further", () => {
+    const file = writeFixture("depth.txt", `key=${AWS_KEY}`);
+    const four = `sh -c "sh -c \\"sh -c 'cat ${file}'\\""`;
+    expect(runBashHook(four).exitCode).toBe(2);
+    const five = `sh -c "sh -c \\"sh -c 'sh -c \\\\"cat ${file}\\\\"'\\""`;
+    expect(runBashHook(five).exitCode).toBe(0);
+  });
+
+  // A glob's matches are scanned up to the cap. Two files, both secret-bearing,
+  // in a directory of their own: at a cap of 1 the second would go unread.
+  it("more than one match of a pattern is scanned", () => {
+    const dir = writeFixture.path();
+    writeFixture("g-clean.txt", "nothing here");
+    writeFixture("g-secret.txt", `key=${AWS_KEY}`);
+    expect(runBashHook(`cat ${dir}/g-*.txt`).exitCode).toBe(2);
+  });
+});
+
 // ── path shapes the shell expands ────────────────────────────────────────────
 
 // Each of these names a real file once the shell is done with it, and each was
@@ -506,9 +556,20 @@ describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
     expect(blocked).toBe(true);
   });
 
-  it("[allow-pii] bypasses cat on a .env.* file", () => {
+  // The `.env` block is a secret guard, so the PII tag does not lift it. It used
+  // to, along with every other bracketed word beginning `allow-`.
+  it("[allow-pii] does not bypass cat on a .env.* file", () => {
     const transcript = writeTranscript(["[allow-pii] show me the env"]);
     const p = writeFixture(".env.bash-pii", "DEBUG=true\n");
+    const { exitCode } = runBashHook(`cat ${p}`, {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  it("[allow-secret] bypasses cat on a .env.* file", () => {
+    const transcript = writeTranscript(["[allow-secret] show me the env"]);
+    const p = writeFixture(".env.bash-secret", "DEBUG=true\n");
     const { exitCode } = runBashHook(`cat ${p}`, {
       transcriptPath: transcript,
     });
@@ -537,11 +598,11 @@ describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("[allow-pii] also bypasses .env name block", () => {
+  it("[allow-pii] does not bypass the .env name block", () => {
     const transcript = writeTranscript(["[allow-pii] read the env file"]);
     const p = writeFixture(".env.bypass-pii", "KEY=value");
     const { exitCode } = runHook("Read", p, { transcriptPath: transcript });
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(2);
   });
 
   it("[allow-secret] bypasses secrets in content scan", () => {

--- a/src/__tests__/user-prompt-submit-hook.test.ts
+++ b/src/__tests__/user-prompt-submit-hook.test.ts
@@ -17,6 +17,30 @@ function runHook(prompt: string, opts?: { env?: Record<string, string> }) {
   };
 }
 
+// Every case in this file used a one-line prompt, so a cap on how much of it is
+// scanned would not have shown up. A pasted log or `.env` is the case the hook
+// exists for, and it is long.
+describe("user-prompt-submit-hook — how much of the prompt is scanned", () => {
+  const KEY = ["AKIA", "IOSFODNN7", "EXAMPLE"].join("");
+
+  it.each([
+    ["8 KB", 8 * 1024],
+    ["64 KB", 64 * 1024],
+    ["256 KB", 256 * 1024],
+  ])("finds a key after %s of text", (_label, padding) => {
+    const { exitCode } = runHook(
+      `${"lorem ipsum ".repeat(padding / 12)}${KEY}`,
+    );
+    expect(exitCode).toBe(2);
+  });
+
+  it("finds a key on the last line of a pasted file", () => {
+    const lines = Array.from({ length: 5000 }, (_, i) => `line ${i}`);
+    const { exitCode } = runHook(`${lines.join("\n")}\nkey=${KEY}\n`);
+    expect(exitCode).toBe(2);
+  });
+});
+
 describe("user-prompt-submit-hook — allow (exit 0)", () => {
   it("passes a clean prompt", () => {
     const { exitCode } = runHook("hello, can you help me?");

--- a/src/lib/__tests__/bash-commands.test.ts
+++ b/src/lib/__tests__/bash-commands.test.ts
@@ -30,6 +30,50 @@ import {
 
 const paths = (command: string): string[] => extractCommandRefs(command).paths;
 
+const FILE_READ_EXPECTED = [
+  "base64",
+  "bat",
+  "bzcat",
+  "bzless",
+  "cat",
+  "column",
+  "comm",
+  "cut",
+  "diff",
+  "expand",
+  "fmt",
+  "fold",
+  "gzcat",
+  "head",
+  "hexdump",
+  "iconv",
+  "join",
+  "less",
+  "look",
+  "lz4cat",
+  "lzcat",
+  "more",
+  "nl",
+  "od",
+  "paste",
+  "pr",
+  "rev",
+  "shuf",
+  "sort",
+  "strings",
+  "tac",
+  "tail",
+  "unexpand",
+  "uniq",
+  "xxd",
+  "xzcat",
+  "xzless",
+  "zcat",
+  "zless",
+  "zmore",
+  "zstdcat",
+];
+
 describe("commands that print the files they are given", () => {
   it.each([...FILE_READ_COMMANDS])("%s names its operand", (cmd) => {
     expect(paths(`${cmd} secrets.txt`)).toContain("secrets.txt");
@@ -230,6 +274,49 @@ describe("holes an adversarial pass found", () => {
   });
 });
 
+// A substitution standing among the operands is one word to the command. Ending
+// the segment there cut the operand list in two, and the file after it was read
+// as a command name — a fail-open behind a comment that called it harmless.
+// A leading `VAR=value` is not the command. The pattern accepts a lower-case
+// name, and every case in the suite used an upper-case one, so narrowing it to
+// `[A-Z_]` went unnoticed — `foo=1 cat secrets` then classified `foo=1` as the
+// command and collected nothing.
+describe("a leading assignment", () => {
+  it.each([
+    "FOO=1 cat secrets.txt",
+    "foo=1 cat secrets.txt",
+    "_x=1 cat secrets.txt",
+    "a1=1 cat secrets.txt",
+    "foo=1 bar=2 cat secrets.txt",
+  ])("%s still reaches the command", (command) => {
+    expect(paths(command)).toContain("secrets.txt");
+  });
+});
+
+describe("a substitution among the operands", () => {
+  it.each([
+    "cat <(echo hi) secrets.txt",
+    "cat $(echo hi) secrets.txt",
+    "diff <(sort a.txt) secrets.txt",
+    "paste <(echo 1) secrets.txt",
+    "grep pat <(echo x) secrets.txt",
+  ])("%s still names the file after it", (command) => {
+    expect(paths(command)).toContain("secrets.txt");
+  });
+
+  // The inner command is still walked, by extractSubstitutions.
+  it("the command inside the substitution is read too", () => {
+    expect(paths("diff <(cat inner.txt) outer.txt")).toEqual(
+      expect.arrayContaining(["inner.txt", "outer.txt"]),
+    );
+  });
+
+  // A subshell is a command line of its own and still ends the segment.
+  it("a subshell is still its own segment", () => {
+    expect(paths("(cat secrets.txt)")).toContain("secrets.txt");
+  });
+});
+
 describe("git log -L", () => {
   // `-L` prints the lines themselves, and the file is written inside the range
   // spec after the last `:`, where neither the flag branch nor the operand
@@ -286,47 +373,12 @@ describe("the tables", () => {
   // one still passed all 820 cases. Deleting a read command is the fail-open
   // direction — the command stops being one whose operands are scanned.
   it("commands that print their file operands are exactly these", () => {
-    expect([...FILE_READ_COMMANDS].sort()).toEqual([
-      "base64",
-      "bat",
-      "bzcat",
-      "cat",
-      "column",
-      "comm",
-      "cut",
-      "diff",
-      "expand",
-      "fmt",
-      "fold",
-      "gzcat",
-      "head",
-      "hexdump",
-      "iconv",
-      "join",
-      "less",
-      "look",
-      "more",
-      "nl",
-      "od",
-      "paste",
-      "pr",
-      "rev",
-      "shuf",
-      "sort",
-      "strings",
-      "tac",
-      "tail",
-      "unexpand",
-      "uniq",
-      "xxd",
-      "xzcat",
-      "zcat",
-      "zstdcat",
-    ]);
+    expect([...FILE_READ_COMMANDS].sort()).toEqual(FILE_READ_EXPECTED);
   });
 
   it("pattern-first commands are exactly these", () => {
     expect([...PATTERN_OR_SCRIPT_FIRST_COMMANDS].sort()).toEqual([
+      "ack",
       "ag",
       "awk",
       "egrep",
@@ -336,7 +388,11 @@ describe("the tables", () => {
       "jq",
       "rg",
       "sed",
+      "ugrep",
       "yq",
+      "zegrep",
+      "zfgrep",
+      "zgrep",
     ]);
   });
 
@@ -428,6 +484,15 @@ describe("the tables", () => {
   // The inline-code branch does not mark a pattern as supplied, because there is
   // no command where both would apply. If that stops being true, the branch
   // needs the mark back and this is where it says so.
+  // A name in both tables would be read as printing its operands in one place
+  // and as printing nothing in another, and the two disagree at the point of use.
+  it("no command both prints its operands and only measures them", () => {
+    const both = [...FILE_READ_COMMANDS].filter((c) =>
+      COUNT_ONLY_COMMANDS.has(c),
+    );
+    expect(both).toEqual([]);
+  });
+
   it("no command takes inline code and a leading pattern", () => {
     const both = [...INLINE_CODE_COMMANDS].filter((c) =>
       PATTERN_OR_SCRIPT_FIRST_COMMANDS.has(c),

--- a/src/lib/__tests__/flag-and-verb-tables.test.ts
+++ b/src/lib/__tests__/flag-and-verb-tables.test.ts
@@ -271,6 +271,24 @@ describe("the tools exempt by name", () => {
   });
 });
 
+// The shape rule is "contains a `/`", not "starts with one". Every fixture path
+// in the suite is absolute, so narrowing it to `startsWith` went unnoticed — and
+// an MCP tool passing `{"target":"config/prod.env"}` would stop being scanned.
+describe("a path found by its shape", () => {
+  it.each([
+    "/abs/config/prod.env",
+    "config/prod.env",
+    "./config/prod.env",
+    "../config/prod.env",
+  ])("%s is collected under an unlisted field name", (value) => {
+    expect(collectPathFields({ target: value })).toContain(value);
+  });
+
+  it("a value with no separator is not", () => {
+    expect(collectPathFields({ target: "prod.env" })).toEqual([]);
+  });
+});
+
 // An array inside an array. The element is neither a string nor a plain object,
 // so it fell between the two branches and the path in it was never looked at.
 describe("paths nested inside arrays", () => {

--- a/src/lib/__tests__/inspector.test.ts
+++ b/src/lib/__tests__/inspector.test.ts
@@ -10,6 +10,33 @@ import {
 
 // ── parseAllowTags ────────────────────────────────────────────────────────────
 
+// A tag is the bracketed form and nothing else. Without a case saying so, the
+// brackets could be made optional and prose that merely mentions `allow-all`
+// would turn the hook off.
+describe("what is not a tag", () => {
+  it.each([
+    "allow-all",
+    "allow-secret without brackets",
+    "the allow-pii option",
+    "(allow-all)",
+    "{allow-all}",
+    "allow-all]",
+    "[allow-all",
+  ])("%s is not a tag", (text) => {
+    expect(parseAllowTags([{ role: "user", content: text }]).size, text).toBe(
+      0,
+    );
+  });
+
+  it("the bracketed form is", () => {
+    expect(
+      parseAllowTags([{ role: "user", content: "[allow-all] please" }]).has(
+        "all",
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("parseAllowTags", () => {
   it("returns empty set when no tags are present", () => {
     const tags = parseAllowTags([{ role: "user", content: "hello" }]);

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -902,6 +902,121 @@ describe("scan — adversarial inputs", () => {
   });
 });
 
+// The shipped rules, written out.
+//
+// This is the largest table in the product and had neither an equality nor a
+// case per entry. Measured: deleting `mapbox-token` and `sentry-org-token` whole
+// left the suite green — 1,459 cases instead of 1,467, because the only thing
+// walking the rules is the timing matrix, and a rule that matches nothing passes
+// all eight of its shapes. A rule silently dropped from a release is the worst
+// version of that.
+// The boundary between a reserved range and a public address. One public case
+// (`8.8.8.8`) left the 224 edge free to move: at 200 the whole 200–223 block
+// stops being PII.
+describe("the reserved IPv4 boundary", () => {
+  it.each(["223.255.255.255", "199.0.0.1", "126.0.0.1"])(
+    "%s is public",
+    (ip) => {
+      expect(isReservedIpv4(ip)).toBe(false);
+    },
+  );
+
+  it.each(["224.0.0.1", "239.255.255.255", "240.0.0.1", "127.0.0.1"])(
+    "%s is reserved",
+    (ip) => {
+      expect(isReservedIpv4(ip)).toBe(true);
+    },
+  );
+});
+
+describe("the shipped rules", () => {
+  it("are exactly these sixty-four", () => {
+    expect(DEFAULT_RULES.map((r) => r.id).sort()).toEqual([
+      "anthropic-key",
+      "atlassian-token",
+      "aws-access-key",
+      "connection-string",
+      "digitalocean-pat",
+      "discord-webhook",
+      "env-assignment",
+      "gcp-api-key",
+      "generic-secret",
+      "github-fine-grained",
+      "github-pat",
+      "gitlab-pat",
+      "groq-key",
+      "huggingface-token",
+      "jwt",
+      "linear-key",
+      "mailchimp-key",
+      "mailgun-key",
+      "mapbox-token",
+      "npm-token",
+      "openai-key",
+      "openai-project-key",
+      "openrouter-key",
+      "perplexity-key",
+      "pii-brn-kr",
+      "pii-codice-fiscale-it",
+      "pii-credit-card",
+      "pii-dni-nie-es",
+      "pii-email",
+      "pii-ipv4",
+      "pii-ipv4-public",
+      "pii-ipv6",
+      "pii-mynumber-jp",
+      "pii-nir-fr",
+      "pii-phone-cn",
+      "pii-phone-de",
+      "pii-phone-es",
+      "pii-phone-fr",
+      "pii-phone-it",
+      "pii-phone-jp",
+      "pii-phone-kr",
+      "pii-phone-us",
+      "pii-postal-cn",
+      "pii-postal-code",
+      "pii-postal-jp",
+      "pii-resident-id-cn",
+      "pii-rrn-kr",
+      "pii-ssn",
+      "pii-steuer-id-de",
+      "postman-key",
+      "private-key",
+      "replicate-token",
+      "sendgrid-key",
+      "sentry-org-token",
+      "sentry-user-token",
+      "slack-token",
+      "slack-webhook",
+      "square-access-token",
+      "stripe-restricted-key",
+      "stripe-secret-key",
+      "supabase-key",
+      "telegram-bot-token",
+      "twilio-sid",
+      "xai-key",
+    ]);
+  });
+
+  it("are split as the README says: 39 secret, 25 PII", () => {
+    const byCategory = DEFAULT_RULES.reduce<Record<string, number>>(
+      (acc, r) => ({ ...acc, [r.category]: (acc[r.category] ?? 0) + 1 }),
+      {},
+    );
+    expect(byCategory).toEqual({ secret: 39, pii: 25 });
+  });
+
+  it("each declare the fields the loader needs", () => {
+    for (const rule of DEFAULT_RULES) {
+      expect(typeof rule.id, rule.id).toBe("string");
+      expect(typeof rule.description, rule.id).toBe("string");
+      expect(["secret", "pii"], rule.id).toContain(rule.category);
+      expect(() => new RegExp(rule.regex), rule.id).not.toThrow();
+    }
+  });
+});
+
 // ── the two rules whose patterns were rewritten for speed ────────────────────
 
 // Both were changed by bounding a quantifier, which is a change to what they
@@ -1510,7 +1625,14 @@ describe("user config — custom rules", () => {
     expect(dupes[0]?.description).toBe("Last Definition");
 
     // Only the last regex is active, and a match produces a single finding.
-    expect(scan("token: MYSVC-abcdefghijklmnopqrst")).toHaveLength(0);
+    // Filtered by rule id: the built-in `env-assignment` reads `token: <value>`
+    // as an assignment of its own, which is a finding about the text rather than
+    // about which custom regex is loaded.
+    expect(
+      scan("token: MYSVC-abcdefghijklmnopqrst").filter(
+        (f) => f.ruleId === "custom-token",
+      ),
+    ).toHaveLength(0);
     const findings = scan("token: MYSVC2-abcdefghijklmnopqrst");
     expect(findings.filter((f) => f.ruleId === "custom-token")).toHaveLength(1);
   });

--- a/src/lib/__tests__/shell.test.ts
+++ b/src/lib/__tests__/shell.test.ts
@@ -25,6 +25,7 @@ import {
   extractSubstitutions,
   isNonCommandToken,
   MAX_QUOTED_LITERAL_LENGTH,
+  SHELL_KEYWORD_TOKENS,
   type ShellToken,
   stripHeredocBodies,
   tokenizeCommand,
@@ -232,6 +233,38 @@ describe("isNonCommandToken", () => {
       expect(isNonCommandToken(word(value))).toBe(false);
     },
   );
+});
+
+// A keyword cannot name a command, and a keyword missing from the set becomes
+// one: dropping `else` made `if x; then :; else cat secrets; fi` classify `else`
+// as the command and collect nothing. Ten of the seventeen entries had no case
+// and the set had no equality.
+describe("shell keywords", () => {
+  it.each([...SHELL_KEYWORD_TOKENS])("%s cannot name a command", (value) => {
+    expect(isNonCommandToken({ value, redirect: false })).toBe(true);
+  });
+
+  it("are exactly these", () => {
+    expect([...SHELL_KEYWORD_TOKENS].sort()).toEqual([
+      "!",
+      "case",
+      "do",
+      "done",
+      "elif",
+      "else",
+      "esac",
+      "fi",
+      "for",
+      "if",
+      "in",
+      "select",
+      "then",
+      "until",
+      "while",
+      "{",
+      "}",
+    ]);
+  });
 });
 
 describe("extractQuotedLiterals", () => {

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -49,6 +49,12 @@ export const FILE_READ_COMMANDS = new Set([
   "bzcat",
   "xzcat",
   "zstdcat",
+  "lz4cat",
+  "lzcat",
+  "zless",
+  "zmore",
+  "bzless",
+  "xzless",
   "diff",
   "comm",
   "join",
@@ -96,6 +102,11 @@ export const PATTERN_OR_SCRIPT_FIRST_COMMANDS = new Set([
   "ag",
   "jq",
   "yq",
+  "zgrep",
+  "zegrep",
+  "zfgrep",
+  "ack",
+  "ugrep",
 ]);
 
 // Flags that hand a pattern-first command its pattern or script, so no operand

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -230,7 +230,8 @@
     {
       "id": "env-assignment",
       "description": ".env style secret assignment",
-      "regex": "\\b[A-Z_]{0,64}(SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|PRIVATE_KEY)[A-Z_0-9]{0,64}\\s*=\\s*(\\S{8,})",
+      "regex": "\\b[A-Za-z_]{0,64}(SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Za-z_0-9]{0,64}\"?\\s*[:=]\\s*\"?([^\\s\"]{8,})",
+      "flags": "gi",
       "category": "secret",
       "secretGroup": 2,
       "entropyThreshold": 3

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -158,12 +158,24 @@ export function tokenizeCommand(command: string): ShellToken[][] {
       continue;
     }
 
+    // A substitution standing among the operands is one word to the command, so
+    // it is consumed whole and no token is emitted for it. Ending the segment
+    // here instead cut the operand list in two: `cat <(echo hi) secrets` left
+    // `secrets` in a segment of its own, where it was read as a command name and
+    // its own reading went unseen. The comment that used to sit here said the
+    // only cost was reaching the inner command twice, which was wrong.
+    //
+    // The inner command is still reached: extractSubstitutions walks the raw
+    // string for these forms, and the paths are deduplicated.
+    if ((ch === "$" || ch === "<" || ch === ">") && command[i + 1] === "(") {
+      endToken();
+      i = findSubstitutionEnd(command, i + 2, ")") + 1;
+      continue;
+    }
+
     // A subshell holds a command line of its own. Without this, `(cat secrets)`
     // tokenized as `(cat` and `secrets)`, naming neither a command this hook
-    // classifies nor a path that exists, and the read went unseen. The opening
-    // paren of `$(`, `<(` and `>(` lands here too, which only means the inner
-    // command is reached twice — extractSubstitutions already recurses into it,
-    // and the paths are deduplicated.
+    // classifies nor a path that exists, and the read went unseen.
     if (ch === "(" || ch === ")") {
       endSegment();
       i++;
@@ -447,7 +459,7 @@ export function extractSubstitutions(command: string): string[] {
 // file nothing noticed. The keywords that open a condition (`if`, `while`,
 // `until`) matter as much as the ones that open a body: the command being tested
 // runs too.
-const SHELL_KEYWORD_TOKENS = new Set([
+export const SHELL_KEYWORD_TOKENS = new Set([
   "{",
   "}",
   "!",

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -13,7 +13,7 @@ import {
   randomBird,
 } from "./lib/inspector.ts";
 import { enabledCategoriesFromEnv, type Finding, scan } from "./lib/rules.ts";
-import { extractEnvVarNames } from "./lib/shell.ts";
+import { extractEnvVarNames, tokenizeCommand } from "./lib/shell.ts";
 import {
   collectPathFields,
   isWritingTool,
@@ -22,6 +22,10 @@ import {
 
 interface HookInput {
   transcript_path?: string;
+  // The directory Claude Code runs the tool in. A relative path in a command is
+  // relative to this, and reading it is the difference between scanning
+  // `cat secrets.txt` and dropping it as a file that is not there.
+  cwd?: string;
   tool_name?: string;
   tool_input?: Record<string, unknown> & {
     file_path?: string;
@@ -45,7 +49,24 @@ const MAX_TRANSCRIPT_TAIL_BYTES = 65_536; // 64 KB
 // cut is missed; the transcript read above makes the same trade for its tail.
 const MAX_FILE_SCAN_BYTES = 1_048_576; // 1 MiB
 
+// Total bytes one hook invocation will read across every file it scans. The
+// per-file cap bounds one file; nothing bounded the number of files, and a glob
+// naming three hundred of them took half a minute — long enough for the
+// PreToolUse timeout to kill the hook, which does not block the call. Files past
+// the budget are not scanned, which is the same trade the per-file cap makes.
+const MAX_TOTAL_SCAN_BYTES = 8 * 1_048_576; // 8 MiB
+
 const ENABLED_CATEGORIES = enabledCategoriesFromEnv();
+
+// Mutable for one run of the process: what has been read, and what has already
+// been looked at. Overlapping globs named the same file five times over.
+const scanned = new Set<string>();
+let bytesScanned = 0;
+
+// The directory a relative path is relative to. Set from the payload before any
+// scanning; `process.cwd()` is where the hook was started, which is not
+// necessarily where the command will run.
+let baseDirectory = process.cwd();
 
 // ── Transcript ────────────────────────────────────────────────────────────────
 
@@ -239,8 +260,13 @@ const MAX_GLOB_MATCHES = 256;
 // Expanded here rather than in the tokenizer because it needs the filesystem,
 // which is also why it can differ from what the shell will do a moment later.
 function expandCandidate(candidate: string): string[] {
-  const literal = expandTilde(candidate);
+  const literal = path.resolve(baseDirectory, expandTilde(candidate));
   if (!GLOB_METACHARACTERS.test(literal)) return [literal];
+  // Only the last segment may be a pattern, so the expansion costs one directory
+  // listing. `globSync` builds its whole result before anything can trim it, and
+  // `cat ~/**/*` walked the home directory until the hook was killed — which is
+  // the failure this file spends a `stat` per path to avoid.
+  if (GLOB_METACHARACTERS.test(path.dirname(literal))) return [literal];
   let matches: string[] = [];
   try {
     matches = fs.globSync(literal).slice(0, MAX_GLOB_MATCHES);
@@ -298,19 +324,33 @@ function scanIfRegularFile(
 
 function scanFile(filePath: string, allowTags: Set<string>): void {
   if (shouldBlockEnvFile(filePath)) {
-    if (allowTags.size > 0) return;
-    block(
-      filePath,
-      [
-        "🚫 Blocked: .env and .env.* files contain secrets and must not be read into the conversation.",
-      ],
-      buildAllowHints(`please read ${filePath}`, [], true),
-    );
+    // The guard is a secret guard — `shouldBlockEnvFile` already asks whether the
+    // secret category is on — so the tag that lifts it has to be one that allows
+    // secrets. Any tag at all used to lift it, and `parseAllowTags` reads
+    // `[allow-<anything>]`, so `[allow-banana]` and a mistyped `[allow-pi]` both
+    // turned the guard off.
+    //
+    // Lifting the name guard is not permission to skip the file: `[allow-secret]`
+    // says nothing about the PII in it, and returning here skipped the content
+    // scan along with the name. So this falls through, and `applyAllowTags`
+    // below drops the findings the tag really covers.
+    if (!allowTags.has("secret") && !allowTags.has("all")) {
+      block(
+        filePath,
+        [
+          "🚫 Blocked: .env and .env.* files contain secrets and must not be read into the conversation.",
+        ],
+        buildAllowHints(`please read ${filePath}`, [], true),
+      );
+    }
   }
 
   // The name guard above runs first and on the name alone, so `cat .env.missing`
   // is still blocked. Everything past here opens the file.
   if (!isRegularFile(filePath)) return;
+  if (scanned.has(filePath)) return;
+  scanned.add(filePath);
+  if (bytesScanned >= MAX_TOTAL_SCAN_BYTES) return;
 
   let content: string;
   try {
@@ -333,6 +373,7 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
       fs.closeSync(fd);
     }
     // Binary files: scan only the text prefix before the first NUL byte
+    bytesScanned += raw.length;
     const nulIndex = raw.indexOf(0);
     content = (nulIndex === -1 ? raw : raw.subarray(0, nulIndex)).toString(
       "utf8",
@@ -373,6 +414,10 @@ process.stdin.on("end", () => {
   }
 
   const tool = data.tool_name ?? "";
+  // Before anything resolves a path: a relative path in a command is relative to
+  // where Claude Code will run it, not to where this hook was started.
+  if (data.cwd) baseDirectory = data.cwd;
+
   const input = data.tool_input ?? {};
 
   const allowTags = data.transcript_path
@@ -386,6 +431,16 @@ process.stdin.on("end", () => {
 
   if (tool === "Bash") {
     const command = input.command ?? "";
+    // `cd build && cat secrets` runs the read somewhere else, and the payload's
+    // cwd is where the command starts rather than where it ends up. The last
+    // `cd` wins, which is what the shell does; a `cd` whose argument is not a
+    // literal path leaves the base alone rather than guessing.
+    for (const segment of tokenizeCommand(command)) {
+      const [head, target] = segment;
+      if (head?.value !== "cd" || head.redirect) continue;
+      if (target === undefined || target.redirect) continue;
+      baseDirectory = path.resolve(baseDirectory, target.value);
+    }
     const refs = extractCommandRefs(command);
 
     // A bare `env` or `printenv` prints everything, so every variable is in play.


### PR DESCRIPTION
Four reviewers over the release candidate, each told the author was unreliable, had already shipped several holes, and that no comment or test name should be trusted as evidence of behaviour. That framing was earned.

## The one a user hits first

```
{"tool_name":"Bash","tool_input":{"command":"cd /work && cat secrets.txt"}}   before: exit 0
{"cwd":"/work","tool_name":"Bash","tool_input":{"command":"cat secrets.txt"}} before: exit 0
```

The PreToolUse payload carries the directory Claude Code runs the tool in. **Nothing read it.** A relative path was resolved against wherever the hook process happened to start, so it named a file that is not there and was dropped. Both forms now block; the last literal `cd` in the command moves the base too.

## The three file shapes this tool exists to guard

```
POSTGRES_PASSWORD: Sup3rS3cretDbPassw0rd          before: exit 0
"client_secret": "Xk9mP2qR7vL4nW1sYj3c"          before: exit 0
aws_secret_access_key = wJalrXUtnFEMIK7MDEN…     before: exit 0
```

`env-assignment` wanted `[A-Z_]` and `=`. A `docker-compose.yml`, an `appsettings.json` and an `~/.aws/credentials` were therefore invisible. The rule now reads `:` as a separator and either case, and still leaves `password: hunter2` and `see the token: docs` alone. Measured linear at 547 KB (1 ms), and it is in the quadratic guard.

## A comment that was hiding a hole

```
cat <(echo hi) secrets      before: []        after: ["secrets"]
cat $(echo hi) secrets      before: ["$"]     after: ["secrets"]
diff <(sort a) secrets      before: ["a"]     after: ["a","secrets"]
```

A substitution among the operands ended the segment, so the file after it landed in a segment of its own and was read as a command name. The comment on that line said the only cost was reaching the inner command twice.

## A fourth hole of my own

After the buffer sized from `stat`, and the two the glob expansion opened, this is the fourth: **the expansion had no budget.** 300 large files took half a minute — long enough for the PreToolUse timeout to kill the hook, and a killed hook does not block — and five overlapping globs read the same files five times.

```
five overlapping globs over 60 x 1 MiB   before: 9s      after: 0s
```

One tool call now reads at most 8 MiB in total and never the same file twice.

## The `.env` guard came off for any bracketed word

`parseAllowTags` reads `[allow-<anything>]` and the guard asked only whether *any* tag was present, so `[allow-banana]` and a mistyped `[allow-pi]` both turned off the block the README leads with. It now requires a tag that allows secrets — and it no longer returns, so lifting the name block no longer skips the content scan with it. A tag for one category was silently covering the other.

`README`, `docs/rules.md` and `docs/troubleshooting.md` all said "any of the three allow tags", which was both wrong and describing something the code did not do either. All three corrected.

## The suite: 15 of 34 injected faults survived

Seven closed here. The worst:

| fault | was | now |
| --- | --- | --- |
| delete the `mapbox-token` rule entirely | green | 2 failures |
| cap the scanned prompt at 2,000 characters | green (all 24 prompt cases are one line) | 4 failures |
| make the tag brackets optional, so prose saying `allow-all` is a tag | green | 7 failures |
| drop `else`/`elif` from the shell keywords | green | 1 failure |
| narrow assignment names to upper case | green | 4 failures |
| narrow the path shape rule to absolute paths | green | 3 failures |
| move the reserved-IPv4 boundary from 224 to 200 | green | 1 failure |

**The sixty-four shipped rules had neither an equality nor a case per rule** — the largest table in the product, and the only thing walking it was the timing matrix, where a rule that matches nothing passes all eight of its shapes. `mapbox-token` and `sentry-org-token` appeared in no test file at all.

1,467 → 1,544 tests.

## Documentation, corrected against what runs

Found by running each claim:

- **README's headline table promised a protection that does not exist**: "Tool result contains user@email.com → PII detected and blocked". There is no `PostToolUse` hook; a tool's output is never scanned. Row replaced with one that is true, and `SECURITY.md` now says so outright.
- **`docs/install.md` shipped `"matcher": "Read|Bash"`** in both snippets, where `hooks/hooks.json` has `Read|Bash|Grep|mcp__.*`. A user following the install guide lost Grep and every MCP tool — this release's main feature.
- **`SECURITY.md` still said only `Read` and `Bash` are intercepted**, and described a failing Node process as exiting 0. It exits 9; the call is unblocked either way, but the stated mechanism was wrong.
- **`docs/rules.md` used `API_KEY=placeholder` as an example of what the entropy gate filters out.** `entropy("placeholder")` is 3.096 against a 3.0 threshold, so it is reported. Example replaced with one that is filtered, and the gate described as the weak filter it is.
- **README and `docs/index.md` claimed phone numbers, postal codes and public IPs all require a nearby label.** `pii-phone-us`, `pii-phone-jp`, `pii-postal-jp` and `pii-ipv4` have no `requireContext`.
- `docs/rules.md` listed seven read commands; there are around forty plus a second class.

## Known and not fixed

`git clone git@github.com:acme/widgets.git` is blocked — `git@github.com` matches `pii-email`. So are `ssh deploy@host` and `ping 10.0.0.1`. None of these leaks anything, and changing PII matching at release time risks more than it fixes, so they are not touched here. Worth a decision of their own.