### PR TITLE
fix: what three reviews found at the gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,20 +68,109 @@ jobs:
             echo "::error::version mismatch — package.json is $pkg, .claude-plugin/plugin.json is $plugin."
             exit 1
           fi
+      - name: the packed artifact is what gets tested
+        run: |
+          # Everything below runs against the tarball npm would publish, not the
+          # checked-out tree. Dropping "dist/" from `files` used to pass every
+          # gate here while shipping a package whose hooks cannot start.
+          set -euo pipefail
+          # A clean directory and an exact filename: a leftover tarball from an
+          # earlier pack would otherwise be the one extracted, and the checks
+          # below would pass against a package this build did not produce.
+          rm -rf /tmp/pack /tmp/artifact
+          mkdir -p /tmp/pack /tmp/artifact
+          pnpm pack --pack-destination /tmp/pack
+          tarball=$(ls /tmp/pack/*.tgz)
+          test -f "$tarball" || { echo "::error::pnpm pack produced no tarball."; exit 1; }
+          tar xzf "$tarball" -C /tmp/artifact
+          root=/tmp/artifact/package
+          for required in \
+            "$root/dist/pre-tool-use-hook.js" \
+            "$root/dist/user-prompt-submit-hook.js" \
+            "$root/dist/lib/default-config.json" \
+            "$root/hooks/hooks.json" \
+            "$root/.claude-plugin/plugin.json"; do
+            test -f "$required" || {
+              echo "::error::the tarball is missing $required — check the \`files\` field."
+              exit 1
+            }
+          done
+          if find "$root/src" -path '*__tests__*' -print -quit | grep -q .; then
+            echo "::error::the tarball ships tests."
+            exit 1
+          fi
+          echo "ARTIFACT_ROOT=$root" >> "$GITHUB_ENV"
+
+      - name: the hook manifest names commands that run
+        run: |
+          # The plugin install path uses hooks/hooks.json and nothing else did
+          # read it. Emptying it left every other gate green.
+          set -uo pipefail
+          node -e '
+            const { readFileSync, existsSync } = require("node:fs");
+            const root = process.env.ARTIFACT_ROOT;
+            const manifest = JSON.parse(readFileSync(`${root}/hooks/hooks.json`, "utf8"));
+            const events = Object.keys(manifest.hooks ?? {});
+            for (const want of ["PreToolUse", "UserPromptSubmit"]) {
+              if (!events.includes(want)) throw new Error(`hooks.json declares no ${want}`);
+            }
+            const commands = Object.values(manifest.hooks)
+              .flat()
+              .flatMap((entry) => entry.hooks ?? [])
+              .map((hook) => hook.command);
+            if (commands.length < 2) throw new Error("hooks.json declares no commands");
+            for (const command of commands) {
+              const match = command.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/([^"\s]+)/);
+              if (!match) throw new Error(`no CLAUDE_PLUGIN_ROOT path in: ${command}`);
+              const target = `${root}/${match[1]}`;
+              if (!existsSync(target)) throw new Error(`hooks.json points at a missing ${match[1]}`);
+            }
+            console.log(`hooks.json: ${commands.length} commands, all present`);
+          '
+
       - name: the published hooks run, and still block
         run: |
           # Exit 0 alone would pass for a hook that starts and checks nothing,
           # which is the failure this exists to catch. So both directions.
+          #
+          # No `set -e` here, and every hook invocation captures its status with
+          # `|| status=$?`: a blocking hook exits 2 on purpose, and under the
+          # default `bash -e {0}` that killed the step before the assertion ran,
+          # which made the release unable to publish at all.
+          set -uo pipefail
           key="AKIA""IOSFODNN7EXAMPLE"
-          printf '%s' '{"tool_name":"Bash","tool_input":{"command":"ls"}}' \
-            | node dist/pre-tool-use-hook.js
-          test $? -eq 0 || { echo "::error::the published PreToolUse hook did not allow a clean command"; exit 1; }
-          printf '{"prompt":"key=%s"}' "$key" | node dist/user-prompt-submit-hook.js
-          test $? -eq 2 || { echo "::error::the published UserPromptSubmit hook did not block a secret"; exit 1; }
+          fail=0
+          check() {
+            local want=$1 label=$2 hook=$3 payload=$4 status=0
+            printf '%s' "$payload" | node "$ARTIFACT_ROOT/$hook" > /dev/null || status=$?
+            if [ "$status" -ne "$want" ]; then
+              echo "::error::$label — expected exit $want, got $status"
+              fail=1
+            fi
+          }
           printf 'key=%s\n' "$key" > /tmp/smoke-secret.txt
-          printf '{"tool_name":"Read","tool_input":{"file_path":"/tmp/smoke-secret.txt"}}' \
-            | node dist/pre-tool-use-hook.js
-          test $? -eq 2 || { echo "::error::the published PreToolUse hook did not block a secret"; exit 1; }
+          printf 'ok\n' > /tmp/smoke-clean.txt
+          mkdir -p /tmp/smoke-env
+          printf 'TOKEN=real\n' > /tmp/smoke-env/.env
+          printf 'TOKEN=your-token-here\n' > /tmp/smoke-env/.env.example
+          check 0 "a clean command must be allowed" dist/pre-tool-use-hook.js \
+            '{"tool_name":"Bash","tool_input":{"command":"ls"}}'
+          check 0 "a clean file must be allowed" dist/pre-tool-use-hook.js \
+            '{"tool_name":"Read","tool_input":{"file_path":"/tmp/smoke-clean.txt"}}'
+          check 2 "a secret in a prompt must be blocked" dist/user-prompt-submit-hook.js \
+            "$(printf '{"prompt":"key=%s"}' "$key")"
+          check 2 "a secret in a file must be blocked" dist/pre-tool-use-hook.js \
+            '{"tool_name":"Read","tool_input":{"file_path":"/tmp/smoke-secret.txt"}}'
+          check 2 "a secret in a command must be blocked" dist/pre-tool-use-hook.js \
+            "$(printf '{"tool_name":"Bash","tool_input":{"command":"echo %s"}}' "$key")"
+          check 2 "an env file must be blocked by name" dist/pre-tool-use-hook.js \
+            '{"tool_name":"Read","tool_input":{"file_path":"/tmp/smoke-env/.env"}}'
+          # The other direction of the same guard: a template of placeholders is
+          # a file users are told to commit, and blocking it is what gets the
+          # plugin uninstalled.
+          check 0 "a template of placeholders must be allowed" dist/pre-tool-use-hook.js \
+            '{"tool_name":"Read","tool_input":{"file_path":"/tmp/smoke-env/.env.example"}}'
+          exit "$fail"
 
       - name: Publish to npm
         run: pnpm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,13 @@
   - `.env.example`, `.env.sample`, `.env.template`, `.env.dist` and
     `.env.defaults` are not blocked by name. Their contents are still scanned, so
     a template with a real key in it is still caught — by what is in it
+- Add two more from a format survey: an Azure Shared Access Key
+  (`SharedAccessKey=` + 44-char base64, for Service Bus, Event Hubs and IoT Hub,
+  which is a different length from the 88-character storage account key) and a
+  Google OAuth client secret (`GOCSPX-`). Google's `ya29.` access tokens and
+  `1//` refresh tokens are deliberately not matched: Google documents no format
+  for them beyond a size cap and reserves the right to change it, so a pattern
+  would be a guess that reads as a guarantee
 - Add nine rules for credentials that no rule covered: OpenAI service-account and
   admin keys, Azure Storage account keys, Fly.io, Databricks, HashiCorp Vault,
   Shopify, Doppler, Grafana and Notion tokens. 64 rules to 73

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,67 @@
   - `.env.example`, `.env.sample`, `.env.template`, `.env.dist` and
     `.env.defaults` are not blocked by name. Their contents are still scanned, so
     a template with a real key in it is still caught — by what is in it
+- **Private IPv4 addresses are no longer detected.** An RFC 1918 address is
+  non-routable and identifies nothing outside the network it belongs to, and the
+  rule spent its time on ansible inventories, ssh configs, Kubernetes manifests
+  and docker-compose files — five such files, all blocked before, all quiet now.
+  Public addresses are unchanged and still require a nearby label. Anyone who
+  wants the old behaviour can add the rule back through the config file; the
+  `excludeContext` field it used is documented now and still serves the postal
+  code rule. 75 rules to 74
+- **Private IPv4 addresses are no longer detected.** An RFC 1918 address is
+  non-routable and identifies nothing outside the network it belongs to, and the
+  rule spent its time on ansible inventories, ssh configs, Kubernetes manifests
+  and docker-compose files — five such files, all blocked before, all quiet now.
+  Public addresses are unchanged and still require a nearby label. Anyone who
+  wants the old behaviour can add the rule back through the config file; the
+  `excludeContext` field it used is documented now and still serves the postal
+  code rule. 75 rules to 74
+- The release could not publish. GitHub runs every `run:` step as `bash -e {0}`,
+  and the smoke test added last round pipes into a hook that exits 2 on purpose,
+  so errexit killed the step before the assertion that expected the 2. The gate
+  written to make the release safer made it impossible; every invocation now
+  captures its status instead of letting the pipeline decide the step's fate
+- The release gates now run against the tarball `npm publish` would upload, not
+  the checked-out tree. Deleting `"dist/"` from the `files` field used to pass
+  every gate while shipping a package whose hooks cannot start — verified by
+  doing it, along with dropping `hooks/` and shipping the tests
+- `hooks/hooks.json` — the file the plugin install path reads, and the only one
+  still pointing at the TypeScript sources — had no gate at all. Emptying it left
+  every check green. The release now parses it, requires both events, and
+  resolves every command's path inside the tarball
+- Recognise a value written to be replaced. Half of a realistic `.env.example`
+  was blocked on its contents (`your-password-here`, `REPLACE_ME_WITH_REAL`,
+  `django-insecure-...`, `postgres://user:password@localhost/db`), which defeats
+  exempting the name: the file exists to be committed and read. Ten realistic
+  templates now read clean, and one holding a live key is still blocked. Only
+  secret rules consult the list, and `example` is deliberately not on it — AWS's
+  own documented key ends in it and is still a key
+- An address stopped being found when a remote-shell word appeared anywhere
+  within forty characters: `rsync failed, notify alice@corp.io` was silently
+  dropped. The exemption now covers the operand position only — `ssh user@host`
+  and at most two arguments in between — and the `host:path` forms of scp and
+  rsync are left to the trailing-colon rule that already handled them
+- Cover the credit card brands the rule claimed and did not match. The Discover
+  branch required seventeen digits, so no Discover, JCB or Diners card could
+  reach it, and Mastercard's 2-series (2221-2720) and UnionPay were absent
+  outright — five brands undetected. Ranges follow Discover's published IIN
+  summary, which also puts the Discover range at 644-658, so 659 is no longer
+  claimed
+- Slack's rotated tokens (`xoxe-`), app-level tokens (`xapp-`) and workflow
+  tokens (`xwfp-`) were not matched; nor were Stripe restricted, organization
+  and webhook-signing secrets, nor eight of GitLab's ten token prefixes
+- Mapbox and Sentry tokens were written to shapes those services do not issue —
+  Mapbox delimits into three parts of which the first is the literal `pk`, `sk`
+  or `tk`, and a Sentry org token is underscore-separated, not dotted. Neither
+  rule had ever matched a real token
+- A Square token longer than sixty characters was missed. Square's contract
+  allows up to 1024; the length had been pinned at exactly what appears in the
+  wild
+- Codice fiscale: omocodia substitutes letters for digits at the seven numeric
+  positions when two people would share the first fifteen characters, and both
+  the pattern and the checksum guard demanded digits there — so every such code,
+  each issued to a real person, was missed
 - Add two more from a format survey: an Azure Shared Access Key
   (`SharedAccessKey=` + 44-char base64, for Service Bus, Event Hubs and IoT Hub,
   which is a different length from the 88-character storage account key) and a

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `cat docker-compose.yml` with `POSTGRES_PASSWORD:` ❌ | Assignment detected in YAML and JSON too ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **73 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **75 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE, KR RRN/BRN, CN Resident ID)
 - **Context gating** — the noisiest rules only fire when a label is nearby: non-US/JP phone numbers, ZIP and EU/KR postal codes, public IPv4 and IPv6, and the Korean resident and business numbers. A private IPv4 is matched without one, but *excluded* when a command that takes a host is beside it — `ping 10.0.0.1` and `kubectl port-forward --address 10.0.0.1` name machines. US and Japanese phone numbers and Japanese postal codes are matched without a label, since their shapes are specific enough
 - **Not everything that looks like a secret is one** — published test card numbers, RFC 2606 domains (`example.com`), a value that is a variable reference (`PASSWORD: ${VAR}`), an ssh or scp target (`git@github.com`, `deploy@host`, `user@host:path`), and `.env.example` and its siblings are left alone. Each was blocking ordinary work. A template is exempt only when its contents can be read whole. One holding a NUL byte, running past the per-file cut, reached after the call's budget or deadline, or that is not a regular file at all is blocked on its name, since the contents are what the exemption relies on. A template name that exists on no disk is not blocked — there is nothing to read and nothing to leak
@@ -348,12 +348,14 @@ Invalid rules (bad regex, wrong types, missing required fields) are skipped with
 
 ## Detection rules
 
-### Secrets (48 rules)
+### Secrets (50 rules)
 
 | Rule ID | Description |
 |---|---|
 | `openai-service-key` | OpenAI Service Account / Admin Key (`sk-svcacct-`, `sk-admin-`, `sk-proj-` prefix) |
 | `azure-storage-key` | Azure Storage Account Key (`AccountKey=` + 88-char base64) |
+| `azure-sas-key` | Azure Shared Access Key for Service Bus, Event Hubs and IoT Hub (`SharedAccessKey=` + 44-char base64). Separate from the storage account key, which is 88 characters |
+| `google-oauth-secret` | Google OAuth Client Secret (`GOCSPX-` prefix) |
 | `flyio-token` | Fly.io API Token (`FlyV1 fm2_` prefix) |
 | `databricks-token` | Databricks Personal Access Token (`dapi` + 32 hex) |
 | `vault-token` | HashiCorp Vault Token (`hvs.` / `hvb.` prefix) |

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `cat docker-compose.yml` with `POSTGRES_PASSWORD:` ❌ | Assignment detected in YAML and JSON too ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **75 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **74 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Checksum validation** — credit cards (Luhn) and national ID numbers (JP My Number, FR NIR, IT Codice Fiscale, DE Steuer-IdNr., ES DNI/NIE, KR RRN/BRN, CN Resident ID)
-- **Context gating** — the noisiest rules only fire when a label is nearby: non-US/JP phone numbers, ZIP and EU/KR postal codes, public IPv4 and IPv6, and the Korean resident and business numbers. A private IPv4 is matched without one, but *excluded* when a command that takes a host is beside it — `ping 10.0.0.1` and `kubectl port-forward --address 10.0.0.1` name machines. US and Japanese phone numbers and Japanese postal codes are matched without a label, since their shapes are specific enough
+- **Context gating** — the noisiest rules only fire when a label is nearby: non-US/JP phone numbers, ZIP and EU/KR postal codes, public IPv4 and IPv6, and the Korean resident and business numbers. US and Japanese phone numbers and Japanese postal codes are matched without a label, since their shapes are specific enough. RFC 1918 private addresses are not matched at all — they are non-routable, they identify nothing outside the network they belong to, and they fill the inventories, manifests and ssh configs this tool is most often pointed at
 - **Not everything that looks like a secret is one** — published test card numbers, RFC 2606 domains (`example.com`), a value that is a variable reference (`PASSWORD: ${VAR}`), an ssh or scp target (`git@github.com`, `deploy@host`, `user@host:path`), and `.env.example` and its siblings are left alone. Each was blocking ordinary work. A template is exempt only when its contents can be read whole. One holding a NUL byte, running past the per-file cut, reached after the call's budget or deadline, or that is not a regular file at all is blocked on its name, since the contents are what the exemption relies on. A template name that exists on no disk is not blocked — there is nothing to read and nothing to leak
 - **Entropy filtering** — reduces false positives on low-entropy values
 - **Local only** — all scanning runs in your terminal; nothing is sent anywhere
@@ -186,7 +186,7 @@ To allow it through, add the suggested tag:
 
 ### .env file blocked
 
-`.env` / `.env.*` files are blocked by filename, regardless of their contents. This name-based block is a secret guard and only applies while the `secret` category is enabled (the default).
+`.env` and its siblings are blocked by filename, before anything is read. Template names — `.env.example`, `.env.sample`, `.env.template`, `.env.dist`, `.env.defaults` — are the exception: they are meant to be committed, so they are read and judged on their contents like any other file. A template that turns out to hold a real credential is still blocked, and one whose contents cannot be read whole falls back to the name. This name-based block is a secret guard and only applies while the `secret` category is enabled (the default).
 
 ```
 > Read .env
@@ -403,13 +403,12 @@ Invalid rules (bad regex, wrong types, missing required fields) are skipped with
 | `env-assignment` | `.env`-style secret assignment *(entropy ≥ 3.0)* |
 | `connection-string` | Database connection string with embedded credentials |
 
-### PII (25 rules)
+### PII (24 rules)
 
 | Rule ID | Description | Validation |
 |---|---|---|
 | `pii-email` | Email address | — |
 | `pii-credit-card` | Credit card number | Luhn check |
-| `pii-ipv4` | IPv4 address (RFC 1918 private ranges only) | — |
 | `pii-ssn` | US Social Security Number | Invalid prefix exclusion |
 | `pii-mynumber-jp` | Japanese Individual Number (My Number) | Checksum (weighted mod 11) |
 | `pii-nir-fr` | French NIR / Social Security Number | Check key (mod 97) |
@@ -518,7 +517,7 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **A bare filename under an unlisted field name** — a value is treated as a path when its field name says so or when it contains a `/`. A tool passing `{ "target": "secrets.txt" }` satisfies neither, so it is not scanned. Requiring the `/` is deliberate: without it, a search for the text `.env` would be blocked as though the file had been read.
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
 - **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
-- **`.env.*` is blocked by name** — the filename guard covers every `.env.*`, so a template like `.env.example` is blocked as well, now through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` for those.
+- **A template holding a real credential is blocked** — `.env.example` and its siblings are exempt from the name guard, not from the scan. Placeholders (`your-token-here`, `REPLACE_ME`, `changeme`, `<token>`, `postgres://user:password@localhost/db`) are recognised and left alone, but a template committed with a live key is blocked like any other file, through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` if that is deliberate.
 - **Anything past the first NUL byte of a file** — a file's text prefix is scanned and the rest is dropped, so that a binary is not ground through every rule. A file that uses NUL as a separator rather than as binary content is therefore barely scanned: `/proc/self/environ` on Linux holds the whole environment, and only the first variable of it is seen.
 - **Anything that is not a regular file** — a directory, a FIFO, a process substitution (`/dev/fd/63`) and `/dev/stdin` are not read, so `cat` of one is not scanned. The directory case is what leaves the Grep tool's `path` and a recursive `grep -r pattern src/` alone, both of which would otherwise mean reading every file underneath. Reading them can never reach the end of the file: `cat /dev/zero` held the hook open until Claude Code's PreToolUse timeout killed it, and a killed hook does not block the call. Not scanning them is the lesser of the two, since a hang lets the call through as well.
 - **`~user/…` is not expanded** — `~` and `~/…` are resolved to the home directory, but the form naming another user needs the password database, and guessing would name the wrong file.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,7 @@ This persistent filter is applied before allow tags. A typical use is setting `s
 
 ### Custom rules
 
-All 64 detection rules are defined in JSON. You can add your own or override built-in ones by creating a config file:
+All 74 detection rules are defined in JSON. You can add your own or override built-in ones by creating a config file:
 
 ```bash
 mkdir -p ~/.config/sensitive-canary
@@ -88,4 +88,4 @@ The plugin reads this file at startup. Rules with the same `id` as a built-in ru
 ## Next Steps
 
 - [Installation](/install) — alternative installation methods
-- [Detection Rules](/rules) — all 64 detection rules explained
+- [Detection Rules](/rules) — all 74 detection rules explained

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
     details: Catches AWS keys, GitHub PATs, Stripe keys, JWTs, Anthropic/OpenAI API keys, database connection strings, Replicate/Hugging Face/Groq/xAI tokens, DigitalOcean/Square/Sentry/Linear tokens, and 20+ more credential types.
   - icon: 🕵️
     title: PII Detection
-    details: Detects email addresses, credit card numbers (Luhn-validated), US SSNs, phone numbers (JP/US/FR/IT/DE/ES/KR/CN), national IDs with checksum validation (My Number, NIR, Codice Fiscale, Steuer-IdNr., DNI/NIE, RRN, BRN, Chinese Resident ID), postal codes, and public/private IP addresses.
+    details: Detects email addresses, credit card numbers (Luhn-validated), US SSNs, phone numbers (JP/US/FR/IT/DE/ES/KR/CN), national IDs with checksum validation (My Number, NIR, Codice Fiscale, Steuer-IdNr., DNI/NIE, RRN, BRN, Chinese Resident ID), postal codes, and public IP addresses.
   - icon: 🛡️
     title: Pre-Tool-Use Hook
     details: Scans files before Claude reads them. Blocks .env files by name and any file whose contents contain secrets or PII.
@@ -54,7 +54,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 
 - **Two hooks** — `UserPromptSubmit` and `PreToolUse` cover both directions of risk
-- **64 detection rules** — sourced from gitleaks and TruffleHog detector definitions
+- **74 detection rules** — sourced from gitleaks and TruffleHog detector definitions
 - **Context gating** — the noisiest PII rules (non-US/JP phone numbers, postal codes, public IP addresses) only fire when a relevant label is nearby; US and JP phone numbers and JP postal codes are matched without one
 - **Entropy filtering** — reduces false positives on low-entropy values
 - **Luhn validation** — credit card numbers are validated, not just pattern-matched

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -97,6 +97,8 @@ Sensitive Canary scans text against the following rules. Patterns are sourced fr
 |---------|-------------|
 | `openai-service-key` | OpenAI Service Account / Admin Key (`sk-svcacct-`, `sk-admin-`, `sk-proj-` prefix) |
 | `azure-storage-key` | Azure Storage Account Key (`AccountKey=` + 88-char base64) |
+| `azure-sas-key` | Azure Shared Access Key for Service Bus, Event Hubs and IoT Hub (`SharedAccessKey=` + 44-char base64). Separate from the storage account key, which is 88 characters |
+| `google-oauth-secret` | Google OAuth Client Secret (`GOCSPX-` prefix) |
 | `flyio-token` | Fly.io API Token (`FlyV1 fm2_` prefix) |
 | `databricks-token` | Databricks Personal Access Token (`dapi` + 32 hex) |
 | `vault-token` | HashiCorp Vault Token (`hvs.` / `hvb.` prefix) |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -122,7 +122,6 @@ The entropy threshold filters out low-entropy values that are unlikely to be rea
 |---------|-------------|-------|
 | `pii-email` | Email Address | Local part up to 64 characters per unbroken run (RFC 5321's limit); domain matched as dot-separated labels, so a domain with no dot (`user@localhost`) is not one. Both bounds are there to keep the pattern from backtracking — see the note below the table |
 | `pii-credit-card` | Credit Card Number | Visa, Mastercard, Amex, Discover; validated with Luhn algorithm |
-| `pii-ipv4` | Private IPv4 Address | RFC 1918 ranges only: `10.x`, `172.16–31.x`, `192.168.x`. Excluded when a command that takes a host is nearby, or when it is followed by `:port` |
 | `pii-ssn` | US Social Security Number | Excludes invalid area (000, 666, 9xx), group (00), and serial (0000) numbers |
 | `pii-mynumber-jp` | Japanese Individual Number (My Number) | 12 digits, validated with weighted checksum (mod 11) |
 | `pii-nir-fr` | French NIR / Social Security Number | 15 digits, validated with check key (mod 97); Corsica 2A/2B supported |
@@ -181,7 +180,7 @@ Phone numbers (IT, DE, FR, ES, KR, CN) and bare postal codes (5/9-digit and Chin
 
 National ID numbers rely on their checksums instead and do not require context. Japanese postal codes keep their `〒` prefix requirement, which is a stricter form of the same idea.
 
-Public IPv4 and IPv6 addresses are also context-gated, and additionally exclude reserved ranges (private, loopback, link-local, TEST-NET, multicast, documentation, etc.) so that example IPs like `8.8.8.8` and tutorials do not fire unless a label such as `ip`, `ipv4`, or `ipv6` is nearby. The existing `pii-ipv4` rule still flags RFC 1918 private ranges without context.
+Public IPv4 and IPv6 addresses are also context-gated, and additionally exclude reserved ranges (private, loopback, link-local, TEST-NET, multicast, documentation, etc.), so an address like `8.8.8.8` fires only when a label such as `ip`, `ipv4` or `ipv6` is nearby. RFC 1918 private addresses are not matched by any rule: they are non-routable and identify nothing outside their own network, and treating them as personal data blocked ordinary infrastructure work.
 
 ### Credit Card Validation
 
@@ -277,6 +276,7 @@ Create `~/.config/sensitive-canary/config.json`, or set the `SENSITIVE_CANARY_CO
 | `requireContext` | boolean | no | Only fire when a context word is nearby. |
 | `contextWords` | string[] | no | Words that satisfy `requireContext`. |
 | `contextWindow` | number | no | Per-rule override for context scan width (tokens). |
+| `excludeContext` | No | Words that suppress a match when one of them is near it — the inverse of `contextWords`. Used by the postal-code rule so a number beside a word like `port` or `max` is not an address |
 | `validate` | string | no | Name of a built-in checksum validator. |
 
 ### Available validators

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,7 +25,7 @@ If legitimate content is being blocked:
 
 ## .env file blocking
 
-This is by design. `.env` and `.env.*` files are blocked by filename, regardless of their contents, but only while the `secret` category is enabled (the default). `[allow-secret]` or `[allow-all]` will lift this block if you need Claude to read an `.env` file intentionally. `[allow-pii]` will not: the block is a secret guard.
+This is by design. `.env` and its siblings are blocked by filename, but only while the `secret` category is enabled (the default). Template names (`.env.example`, `.env.sample`, `.env.template`, `.env.dist`, `.env.defaults`) are exempt from the name guard and scanned on their contents instead, so an ordinary template reads fine and one holding a live key does not. `[allow-secret]` or `[allow-all]` will lift this block if you need Claude to read an `.env` file intentionally. `[allow-pii]` will not: the block is a secret guard.
 
 ## Plugin not found after marketplace registration
 

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -357,6 +357,34 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
       );
     });
 
+    // An argv array is a command line with the spaces taken out. Deleting this
+    // branch entirely left every test passing.
+    it("a command given as an argv array is scanned", () => {
+      const file = writeFixture("argv.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__shell__exec", {
+        command: ["cat", file],
+      });
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("an argv array joins into one line rather than one token", () => {
+      const result = runToolHook(
+        "mcp__shell__exec",
+        { command: ["echo", "$LEAKED"] },
+        {
+          env: { PATH: process.env["PATH"] ?? "", LEAKED: AWS_KEY },
+          replaceEnv: true,
+        },
+      );
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("an argv array of non-strings is not a command", () => {
+      expect(
+        runToolHook("mcp__shell__exec", { command: [1, 2, 3] }).exitCode,
+      ).toBe(0);
+    });
+
     // A field that is not one of those names is not run through the parser.
     it("a query field is not read as a command", () => {
       const file = writeFixture("queryfield.txt", `key=${AWS_KEY}`);

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -313,6 +313,50 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
       expect(result.exitCode).toBe(2);
     });
 
+    // A tool that runs a shell prints an environment as readily as a file. The
+    // Bash branch has always scanned the variables a command would print; a
+    // command field was collected for paths and nothing else, so `printenv`
+    // handed the environment back whole.
+    it("a command field is scanned for the environment it would print", () => {
+      const result = runToolHook(
+        "mcp__shell__run",
+        { command: "printenv" },
+        {
+          env: { PATH: process.env["PATH"] ?? "", LEAKED: AWS_KEY },
+          replaceEnv: true,
+        },
+      );
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("a command field naming one variable is scanned for that variable", () => {
+      const result = runToolHook(
+        "mcp__shell__run",
+        { command: "echo $LEAKED" },
+        {
+          env: { PATH: process.env["PATH"] ?? "", LEAKED: AWS_KEY },
+          replaceEnv: true,
+        },
+      );
+      expect(result.exitCode).toBe(2);
+    });
+
+    // The write-verb exemption covers a tool's output, not what it runs.
+    it("a write-verb name does not exempt the command it is given", () => {
+      const file = writeFixture("createproc.txt", `key=${AWS_KEY}`);
+      const result = runToolHook("mcp__x__create_process", {
+        command: `cat ${file}`,
+      });
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("a write-verb name still exempts the paths it is given", () => {
+      const file = writeFixture("writepath.txt", `key=${AWS_KEY}`);
+      expect(runToolHook("mcp__fs__write_file", { path: file }).exitCode).toBe(
+        0,
+      );
+    });
+
     // A field that is not one of those names is not run through the parser.
     it("a query field is not read as a command", () => {
       const file = writeFixture("queryfield.txt", `key=${AWS_KEY}`);

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -466,14 +466,19 @@ describe("pre-tool-use-hook — .env templates", () => {
   // Every way of not reading a template falls back on its name. Filling the byte
   // budget first was a way past the guard, and so was a FIFO with a template
   // name — the contents are what the exemption relies on.
+  // Named outright, so the ordering that puts literals before patterns does not
+  // rescue it: the padding really is read first and really does spend the
+  // budget, which is the case this guards.
   it("a template reached after the byte budget is blocked", () => {
     const dir = writeFixture.path();
     const pad = "the quick brown fox ".repeat(55_000);
-    for (let i = 0; i < 70; i++) writeFixture(`pad${i}.log`, pad);
-    writeFixture(".env.late.example", "TOKEN=changeme\n");
-    expect(
-      runBashHook(`cat ${dir}/pad*.log ${dir}/.env.late.example`).exitCode,
-    ).toBe(2);
+    const names: string[] = [];
+    for (let i = 0; i < 70; i++) {
+      names.push(writeFixture(`pad${i}.log`, pad));
+    }
+    const template = writeFixture(".env.late.example", "TOKEN=changeme\n");
+    expect(runBashHook(`cat ${names.join(" ")} ${template}`).exitCode).toBe(2);
+    expect(dir.length).toBeGreaterThan(0);
   });
 
   it("a fifo with a template name is blocked", () => {

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -189,8 +189,15 @@ describe("pre-tool-use-hook — sensitive content blocking", () => {
     expect(blocked).toBe(true);
   });
 
-  it("blocks a file containing a private IP", () => {
+  // A private address is not personal data, and an inventory full of them is
+  // the file this tool is most often pointed at.
+  it("allows a file of private IPs", () => {
     const p = writeFixture("infra.txt", "server: client 192.168.1.100\n");
+    expect(runHook("Read", p).exitCode).toBe(0);
+  });
+
+  it("blocks a file containing a labelled public IP", () => {
+    const p = writeFixture("access.log", "client IP address 8.8.8.8\n");
     const { exitCode, blocked } = runHook("Read", p);
     expect(exitCode).toBe(2);
     expect(blocked).toBe(true);
@@ -479,6 +486,40 @@ describe("pre-tool-use-hook — .env templates", () => {
     const template = writeFixture(".env.late.example", "TOKEN=changeme\n");
     expect(runBashHook(`cat ${names.join(" ")} ${template}`).exitCode).toBe(2);
     expect(dir.length).toBeGreaterThan(0);
+  });
+
+  // The name-based fallback has three gates and a precondition, and deleting any
+  // of the four left the suite green.
+  it("a template that does not exist is not blocked", () => {
+    const absent = writeFixture.path(".env.absent.example");
+    expect(runBashHook(`cat ${absent}`).exitCode).toBe(0);
+  });
+
+  it("the fallback is off when secrets are not a category", () => {
+    const fifo = writeFixture.path(".env.cat.fifo");
+    execFileSync("mkfifo", [fifo]);
+    expect(
+      runHook("Read", fifo, { env: { SENSITIVE_CANARY_CATEGORIES: "pii" } })
+        .exitCode,
+    ).toBe(0);
+  });
+
+  it("the fallback honours an allow tag", () => {
+    const fifo = writeFixture.path(".env.tag.fifo");
+    execFileSync("mkfifo", [fifo]);
+    expect(
+      runHook("Read", fifo, {
+        transcriptPath: writeTranscript(["[allow-secret] read it"]),
+      }).exitCode,
+    ).toBe(0);
+  });
+
+  // `.env.` with the dot: without it `.environment` reads as an environment
+  // file, and only a path that is never read shows the difference.
+  it("a fifo named .environment is not an env file", () => {
+    const fifo = writeFixture.path(".environment");
+    execFileSync("mkfifo", [fifo]);
+    expect(runHook("Read", fifo).exitCode).toBe(0);
   });
 
   it("a fifo with a template name is blocked", () => {

--- a/src/lib/__tests__/bash-commands.test.ts
+++ b/src/lib/__tests__/bash-commands.test.ts
@@ -317,6 +317,19 @@ describe("a substitution among the operands", () => {
   });
 });
 
+describe("eval", () => {
+  // `eval 'cat secrets'` is a command line in a single word. Stepping past
+  // `eval` found that word as the command name, which classifies as nothing.
+  it.each([
+    "eval cat secrets.txt",
+    `eval 'cat secrets.txt'`,
+    `eval "cat secrets.txt"`,
+    `eval "cd /tmp && cat secrets.txt"`,
+  ])("%s names the file", (command) => {
+    expect(paths(command)).toContain("secrets.txt");
+  });
+});
+
 describe("git log -L", () => {
   // `-L` prints the lines themselves, and the file is written inside the range
   // spec after the last `:`, where neither the flag branch nor the operand

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -1151,6 +1151,8 @@ describe("every rule catches something", () => {
     "linear-key": `lin_api_${"a".repeat(40)}`,
     "postman-key": `PMAK-${"a".repeat(24)}-${"b".repeat(34)}`,
     "azure-storage-key": `AccountKey=${"a".repeat(86)}==`,
+    "azure-sas-key": `SharedAccessKey=${"a".repeat(43)}=`,
+    "google-oauth-secret": "GOCSPX-aBcD1234eFgH5678iJkL",
     "flyio-token": `FlyV1 fm2_${"a".repeat(50)}`,
     "databricks-token": `dapi${"0123456789abcdef".repeat(2)}`,
     "vault-token": `hvs.${"A".repeat(30)}`,
@@ -1229,11 +1231,12 @@ describe("the reserved IPv4 boundary", () => {
 });
 
 describe("the shipped rules", () => {
-  it("are exactly these seventy-three", () => {
+  it("are exactly these seventy-five", () => {
     expect(DEFAULT_RULES.map((r) => r.id).sort()).toEqual([
       "anthropic-key",
       "atlassian-token",
       "aws-access-key",
+      "azure-sas-key",
       "azure-storage-key",
       "connection-string",
       "databricks-token",
@@ -1247,6 +1250,7 @@ describe("the shipped rules", () => {
       "github-fine-grained",
       "github-pat",
       "gitlab-pat",
+      "google-oauth-secret",
       "grafana-token",
       "groq-key",
       "huggingface-token",
@@ -1307,12 +1311,12 @@ describe("the shipped rules", () => {
     ]);
   });
 
-  it("are split as the README says: 48 secret, 25 PII", () => {
+  it("are split as the README says: 50 secret, 25 PII", () => {
     const byCategory = DEFAULT_RULES.reduce<Record<string, number>>(
       (acc, r) => ({ ...acc, [r.category]: (acc[r.category] ?? 0) + 1 }),
       {},
     );
-    expect(byCategory).toEqual({ secret: 48, pii: 25 });
+    expect(byCategory).toEqual({ secret: 50, pii: 25 });
   });
 
   it("each declare the fields the loader needs", () => {

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -254,8 +254,15 @@ describe("scan — secrets", () => {
   });
 
   it("detects a database connection string with credentials", () => {
-    const findings = scan("postgres://user:password@localhost/mydb");
+    const findings = scan("postgres://admin:s3cr3tP4ss@db.corp.internal/mydb");
     expect(findings.some((f) => f.ruleId === "connection-string")).toBe(true);
+  });
+
+  // `user:password@localhost` is what every database README prints. Reading it
+  // as a credential is what made a committed template unreadable.
+  it("does not detect the connection string every README prints", () => {
+    const findings = scan("postgres://user:password@localhost/mydb");
+    expect(findings.some((f) => f.ruleId === "connection-string")).toBe(false);
   });
 
   it("detects an .env style assignment with sufficient entropy", () => {
@@ -425,53 +432,42 @@ describe("scan — PII", () => {
     expect(findings.some((f) => f.ruleId === "pii-postal-jp")).toBe(false);
   });
 
-  it("detects a 192.168.x.x private IPv4 address", () => {
-    const findings = scan("client 192.168.1.100 connected");
-    expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(true);
-  });
-
-  it("detects a 10.x.x.x private IPv4 address", () => {
-    const findings = scan("client 10.0.0.1 connected");
-    expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(true);
-  });
-
-  // The rule is context-gated now: `ping 10.0.0.1` and `redis-cli -h 10.0.0.30`
-  // are addresses of machines, and treating every one of them as personal data
-  // blocked most of what infrastructure work looks like.
+  // A private address is not personal data. It is non-routable, it identifies
+  // nothing outside the network it belongs to, and it appears in nearly every
+  // inventory, manifest and ssh config a developer opens — which is where the
+  // rule spent its time. Public addresses are still gated on a nearby label.
   it.each([
+    "client 192.168.1.100 connected",
+    "client 10.0.0.1 connected",
+    "visitor 172.16.0.1 seen",
+    "visitor 172.31.255.255 seen",
+    "192.168.1.50",
+    "ip=10.1.2.3",
+    "X-Forwarded-For: 10.0.0.5",
+    "remote_addr=10.0.0.5",
     "ping 10.0.0.1",
     "curl http://10.0.0.5:8080/health",
     "redis-cli -h 10.0.0.30",
-    "ECONNREFUSED 10.0.0.5:5432",
-    "CIDR 192.168.0.0/24",
+    "ansible_host: 10.0.0.5",
   ])("%s is not PII", (text) => {
-    expect(scan(text).some((f) => f.ruleId === "pii-ipv4")).toBe(false);
-  });
-
-  it("detects a 172.16–31.x.x private IPv4 address", () => {
-    expect(
-      scan("visitor 172.16.0.1 seen").some((f) => f.ruleId === "pii-ipv4"),
-    ).toBe(true);
-    expect(
-      scan("visitor 172.31.255.255 seen").some((f) => f.ruleId === "pii-ipv4"),
-    ).toBe(true);
-  });
-
-  it("does not flag 172.15.x.x (outside private range)", () => {
-    expect(scan("host: 172.15.1.1").some((f) => f.ruleId === "pii-ipv4")).toBe(
-      false,
+    expect(scan(text).filter((f) => f.ruleId.startsWith("pii-ipv4"))).toEqual(
+      [],
     );
   });
 
-  it("does not flag 172.32.x.x (outside private range)", () => {
-    expect(scan("host: 172.32.1.1").some((f) => f.ruleId === "pii-ipv4")).toBe(
-      false,
-    );
+  // The public rule is untouched by that, in both directions.
+  it("a public address with a label is still PII", () => {
+    expect(
+      scan("the client IP address is 8.8.8.8").some(
+        (f) => f.ruleId === "pii-ipv4-public",
+      ),
+    ).toBe(true);
   });
 
-  it("does not flag a public IPv4 address", () => {
-    const findings = scan("server: 8.8.8.8");
-    expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(false);
+  it("a public address without a label is not", () => {
+    expect(
+      scan("server: 8.8.8.8").some((f) => f.ruleId === "pii-ipv4-public"),
+    ).toBe(false);
   });
 });
 
@@ -976,17 +972,6 @@ describe("detections that quieting the rules had removed", () => {
     expect(hits(text)).toContain("pii-email");
   });
 
-  // Requiring a label lost every bare address, which is most of a log line.
-  it.each([
-    "192.168.1.50",
-    "ip=10.1.2.3",
-    "X-Forwarded-For: 10.0.0.5",
-    "remote_addr=10.0.0.5",
-    "2024-01-01 login from 10.1.2.3",
-  ])("%s is still a private address", (text) => {
-    expect(hits(text)).toContain("pii-ipv4");
-  });
-
   // Anchoring the rule to the start of a line lost the shapes people type.
   it.each([
     `DB_PASSWORD='${R}'`,
@@ -1032,6 +1017,178 @@ describe("detections that quieting the rules had removed", () => {
 // Shapes a review found wrong after the last round of rule changes: a keyword
 // that is a substring of an ordinary word, a command with flags between it and
 // its host, and a token boundary written in a different alphabet from the token.
+const ruleIds = (text: string): string[] => scan(text).map((f) => f.ruleId);
+
+// Half of a realistic `.env.example` was blocked on its contents, which defeats
+// the point of exempting the name: the file exists to be committed and read.
+describe("a value written to be replaced", () => {
+  it.each([
+    "DB_PASSWORD=your-password-here",
+    "API_TOKEN=REPLACE_ME_WITH_REAL",
+    "GITHUB_TOKEN=your_token_here",
+    "SECRET_KEY=django-insecure-CHANGE-THIS-IN-PRODUCTION",
+    "DATABASE_URL=postgres://user:password@localhost:5432/db",
+    "TOKEN=<your-token>",
+    "API_KEY=${SOME_OTHER_VAR}",
+    "CLIENT_SECRET=xxxxxxxxxxxxxxxx",
+  ])("%s is a placeholder", (line) => {
+    expect(scan(line)).toHaveLength(0);
+  });
+
+  // The list is deliberately short of `example`: AWS documents a key that ends
+  // in it, and that key is still a key.
+  it.each([
+    "key=AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_access_key = wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY",
+    "POSTGRES_PASSWORD: Sup3rS3cretDbPassw0rd",
+    "export GITHUB_TOKEN=ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789",
+    "DB_PASSWORD=hunter2xyzabc",
+    "postgres://admin:s3cr3tP4ss@db.corp.internal/app",
+  ])("%s is not", (line) => {
+    expect(scan(line).length).toBeGreaterThan(0);
+  });
+
+  // Only secret rules consult the list. An address is not a placeholder because
+  // somebody named a mailbox after a marker word.
+  it.each([
+    "contact todo@analytical-engines.org",
+    "write to placeholder@analytical-engines.org",
+  ])("%s is still an address", (line) => {
+    expect(ruleIds(line)).toContain("pii-email");
+  });
+});
+
+// Formats confirmed against each vendor's own documentation, after a survey
+// found the rules here were written to shapes those vendors do not issue.
+describe("credential formats", () => {
+  // Every branch of the card rule, in both directions. Luhn gates all of them,
+  // so each number below is Luhn-valid and none is published test data.
+  it.each([
+    ["36123456789013", "Diners, 14 digits"],
+    ["6011000991300009", "Discover 6011"],
+    ["6450000000000002", "Discover 644-658"],
+    ["3530111333300000", "JCB 3528-3589"],
+    ["2223003122003222", "Mastercard 2-series"],
+    ["6221260000000000", "UnionPay 62"],
+    ["8171990000000008", "UnionPay 81"],
+  ])("%s is a card (%s)", (number) => {
+    expect(ruleIds(`card ${number}`)).toContain("pii-credit-card");
+  });
+
+  // Discover's published range stops at 658. Treating "65" as a two-digit
+  // prefix claims 659, which belongs to nobody here.
+  it("659 is not a Discover range", () => {
+    expect(ruleIds("card 6591111111111116")).not.toContain("pii-credit-card");
+  });
+
+  // Token rotation introduced xoxe-; xapp- is app-level; xwfp- is a workflow
+  // token. The character class held only b, a, p, r and s.
+  it.each(["xoxb", "xoxp", "xoxe", "xapp", "xwfp"])(
+    "a Slack %s- token is found",
+    (prefix) => {
+      expect(ruleIds(`${prefix}-1-${"a".repeat(40)}`)).toContain("slack-token");
+    },
+  );
+
+  it.each([
+    "glpat",
+    "glrt",
+    "gldt",
+    "gloas",
+    "glcbt",
+    "glptt",
+    "glimt",
+    "glagent",
+  ])("a GitLab %s- token is found", (prefix) => {
+    expect(ruleIds(`${prefix}-${"a".repeat(20)}`)).toContain("gitlab-pat");
+  });
+
+  it.each([
+    [`sk_live_${"a".repeat(24)}`, "a secret key"],
+    [`rk_live_${"a".repeat(24)}`, "a restricted key"],
+    [`sk_org_${"a".repeat(24)}`, "an organization key"],
+    [`whsec_${"a".repeat(32)}`, "a webhook signing secret"],
+  ])("%s is a Stripe secret (%s)", (token) => {
+    expect(ruleIds(token)).toContain("stripe-secret-key");
+  });
+
+  // Mapbox documents the token as header.payload.signature where the header is
+  // the literal pk, sk or tk — two dots, not three. Requiring three matched
+  // nothing Mapbox issues.
+  it.each(["pk", "sk", "tk"])("a Mapbox %s. token is found", (prefix) => {
+    expect(ruleIds(`${prefix}.eyJ1IjoiYWJjIn0.${"a".repeat(22)}`)).toContain(
+      "mapbox-token",
+    );
+  });
+
+  // sentry-cli splits the token on underscores and requires exactly three
+  // parts. The rule was written for dots.
+  it("a Sentry org token is underscore-separated", () => {
+    expect(ruleIds(`sntrys_eyJpYXQiOjEuMH0=_${"c".repeat(43)}`)).toContain(
+      "sentry-org-token",
+    );
+  });
+});
+
+// D.M. 23 dicembre 1976 art. 6: when two people would share the first fifteen
+// characters, digits are replaced from the right with 0=L 1=M 2=N 3=P 4=Q 5=R
+// 6=S 7=T 8=U 9=V. Every such code belongs to a real person, and the rule
+// required digits at exactly the positions that get replaced.
+describe("codice fiscale omocodia", () => {
+  it.each([
+    ["RSSMRA85T10A562S", "no substitution"],
+    ["RSSMRA85T10A56NH", "one, from the right"],
+    ["RSSMRA85T10ARSNO", "three"],
+    ["RSSMRAURTMLARSNL", "all seven"],
+  ])("%s is a codice fiscale (%s)", (code) => {
+    expect(ruleIds(`CF ${code}`)).toContain("pii-codice-fiscale-it");
+  });
+
+  // Widening those positions to letters lets ordinary upper-case text reach the
+  // pattern; the check character is what keeps it quiet.
+  it.each(["MAXBUFFERSIZELIM", "CONTENTSECURITYPO", "SHELLKEYWORDTOKEN"])(
+    "%s is not one",
+    (word) => {
+      expect(ruleIds(word)).not.toContain("pii-codice-fiscale-it");
+    },
+  );
+});
+
+// A word anywhere within forty characters suppressed the address. The suppression
+// belongs to the operand position: `ssh user@host` is a host, `rsync failed,
+// notify alice@corp.io` is an address. The host:path forms of scp and rsync are
+// already handled by the trailing colon.
+describe("an address near a remote-shell command", () => {
+  it.each([
+    "rsync failed, notify alice@acmecorp.io",
+    "# sftp creds, ask carol@acmecorp.io",
+    "See ssh(1). Maintainer: bob@acmecorp.io",
+    "the ssh key belongs to dave@acmecorp.io",
+    "scp is slow; email erin@acmecorp.io",
+  ])("%s is an address", (text) => {
+    expect(ruleIds(text)).toContain("pii-email");
+  });
+
+  // An address is never an argument on the way to another address: without that,
+  // the first host swallows the second one's exemption.
+  it("only the host is exempt, not what follows it", () => {
+    expect(
+      ruleIds("ssh deploy@bastion.acmecorp.io admin@acmecorp.io"),
+    ).toContain("pii-email");
+  });
+
+  it.each([
+    "ssh deploy@bastion.acmecorp.io",
+    "ssh -i ~/.ssh/id_ed25519 deploy@bastion.acmecorp.io",
+    "ssh -o StrictHostKeyChecking=no deploy@bastion.acmecorp.io",
+    "scp build.tar ops@files.acmecorp.io:/srv/",
+    "rsync -a ops@files.acmecorp.io:/srv/ .",
+    "sftp ops@files.acmecorp.io",
+  ])("%s is a host", (text) => {
+    expect(ruleIds(text)).not.toContain("pii-email");
+  });
+});
+
 describe("keywords and boundaries are read as words, not substrings", () => {
   const flags = (t: string): string[] => scan(t).map((f) => f.ruleId);
   const V = "Xk9mP2qR7vL4nW1s";
@@ -1066,10 +1223,19 @@ describe("keywords and boundaries are read as words, not substrings", () => {
     expect(flags(text)).toContain("pii-email");
   });
 
-  // The token is base64url and the boundary was standard base64, so a token
-  // followed by `_` matched its first sixty characters.
-  it("a Square token running into more base64url is not one", () => {
-    expect(flags(`EAAA${"b".repeat(60)}_more`)).not.toContain(
+  // Square's own contract puts the maximum at 1024, so a token longer than the
+  // sixty seen in the wild is a token, not a false positive. Pinning the length
+  // at exactly sixty let every longer one through.
+  it.each([64, 128, 512])("a %i-character Square token is one", (length) => {
+    expect(flags(`EAAA${"b".repeat(length - 4)}`)).toContain(
+      "square-access-token",
+    );
+  });
+
+  // The boundary still has work to do: a longer standard-base64 blob that opens
+  // with these four characters is not a token.
+  it("a standard-base64 blob beginning EAAA is not one", () => {
+    expect(flags(`data:${"EAAA" + "b".repeat(60)}/x+y=`)).not.toContain(
       "square-access-token",
     );
   });
@@ -1100,7 +1266,6 @@ describe("what must still be a finding", () => {
     ["-----BEGIN ENCRYPTED PRIVATE KEY-----", "a private key header"],
     ["card 4532015112830366", "a card that is not a published test number"],
     ["the client IP address is 8.8.8.8", "a public address with a label"],
-    ["client 10.0.0.1 connected", "a private address next to a person"],
   ])("%s is a finding (%s)", (text) => {
     expect(scan(text).length).toBeGreaterThan(0);
   });
@@ -1146,7 +1311,7 @@ describe("every rule catches something", () => {
     "connection-string": "postgres://admin:hunter2xyz@db.internal/app",
     "mapbox-token": `pk.eyJ${"a".repeat(20)}.${"b".repeat(20)}.${"c".repeat(20)}`,
     "sentry-user-token": `sntryu_${"a".repeat(64)}`,
-    "sentry-org-token": `sntrys_eyJ${"a".repeat(20)}.${"b".repeat(20)}.${"c".repeat(20)}`,
+    "sentry-org-token": `sntrys_eyJpYXQiOjEuMH0=_${"c".repeat(43)}`,
     "atlassian-token": `ATATT3${"a".repeat(180)}`,
     "linear-key": `lin_api_${"a".repeat(40)}`,
     "postman-key": `PMAK-${"a".repeat(24)}-${"b".repeat(34)}`,
@@ -1164,7 +1329,6 @@ describe("every rule catches something", () => {
     "env-assignment": "DB_PASSWORD=Xk9mP2qR7vL4nW1sYj3cBz8d",
     "pii-email": "contact alice@analytical-engines.org",
     "pii-credit-card": "card 4532015112830366",
-    "pii-ipv4": "192.168.1.50",
     "pii-ipv4-public": "the client IP address is 8.8.8.8",
     "pii-ipv6": "ipv6: 2001:4860:4860::8888",
     "pii-ssn": "SSN 123-45-6789",
@@ -1231,7 +1395,7 @@ describe("the reserved IPv4 boundary", () => {
 });
 
 describe("the shipped rules", () => {
-  it("are exactly these seventy-five", () => {
+  it("are exactly these seventy-four", () => {
     expect(DEFAULT_RULES.map((r) => r.id).sort()).toEqual([
       "anthropic-key",
       "atlassian-token",
@@ -1271,7 +1435,6 @@ describe("the shipped rules", () => {
       "pii-credit-card",
       "pii-dni-nie-es",
       "pii-email",
-      "pii-ipv4",
       "pii-ipv4-public",
       "pii-ipv6",
       "pii-mynumber-jp",
@@ -1311,12 +1474,12 @@ describe("the shipped rules", () => {
     ]);
   });
 
-  it("are split as the README says: 50 secret, 25 PII", () => {
+  it("are split as the README says: 50 secret, 24 PII", () => {
     const byCategory = DEFAULT_RULES.reduce<Record<string, number>>(
       (acc, r) => ({ ...acc, [r.category]: (acc[r.category] ?? 0) + 1 }),
       {},
     );
-    expect(byCategory).toEqual({ secret: 50, pii: 25 });
+    expect(byCategory).toEqual({ secret: 50, pii: 24 });
   });
 
   it("each declare the fields the loader needs", () => {
@@ -1739,9 +1902,8 @@ describe("scan — public IPs", () => {
     expect(findings.some((f) => f.ruleId === "pii-ipv4-public")).toBe(false);
   });
 
-  it("still flags a private IPv4 via the private-range rule", () => {
-    const findings = scan("client 192.168.1.1 connected");
-    expect(findings.some((f) => f.ruleId === "pii-ipv4")).toBe(true);
+  it("does not flag a private IPv4 at all", () => {
+    expect(scan("client 192.168.1.1 connected")).toEqual([]);
   });
 
   it("detects an IPv6 with context", () => {

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -702,6 +702,17 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
     return refs;
   }
 
+  // `eval 'cat secrets'` is a command line in a single word, the same shape
+  // `env -S` carries. Stepping past `eval` finds that word as the command name,
+  // which classifies as nothing at all.
+  if (cmd === "eval") {
+    for (const operand of operands) {
+      if (operand.redirect) continue;
+      mergeRefs(refs, extractCommandRefs(operand.value, depth + 1));
+      refs.paths.push(...extractQuotedLiterals(operand.value));
+    }
+  }
+
   // `env -S "cmd args"` splits the string into the command it runs, so scan
   // inside it the way inline code is scanned.
   if (cmd === "env") {

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -575,6 +575,18 @@
       "description": "Notion Integration Token",
       "regex": "\\bntn_[A-Za-z0-9]{40,}",
       "category": "secret"
+    },
+    {
+      "id": "azure-sas-key",
+      "description": "Azure Shared Access Key (Service Bus, Event Hubs, IoT Hub)",
+      "regex": "SharedAccessKey=[A-Za-z0-9+/]{43}=",
+      "category": "secret"
+    },
+    {
+      "id": "google-oauth-secret",
+      "description": "Google OAuth Client Secret",
+      "regex": "\\bGOCSPX-[A-Za-z0-9_-]{20,}",
+      "category": "secret"
     }
   ]
 }

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -34,7 +34,7 @@
     {
       "id": "gitlab-pat",
       "description": "GitLab Personal Access Token",
-      "regex": "glpat-[A-Za-z0-9_=-]{20,22}",
+      "regex": "gl(?:pat|dt|rt|cbt|imt|agent|oas|ptt|soat|ffct)-[A-Za-z0-9_=-]{20,}",
       "category": "secret"
     },
     {
@@ -46,7 +46,7 @@
     {
       "id": "slack-token",
       "description": "Slack Token",
-      "regex": "xox[baprs]-[0-9a-zA-Z-]{10,72}",
+      "regex": "(?:xox[abeprs]|xapp|xwfp)-[0-9a-zA-Z-]{10,72}",
       "category": "secret"
     },
     {
@@ -94,7 +94,7 @@
     {
       "id": "stripe-secret-key",
       "description": "Stripe Secret Key",
-      "regex": "sk_(live|test)_[0-9a-zA-Z]{24}",
+      "regex": "(?:(?:sk|rk)_(?:live|test)|sk_org)_[0-9a-zA-Z]{24}|whsec_[0-9a-zA-Z]{32,}",
       "category": "secret"
     },
     {
@@ -167,13 +167,13 @@
     {
       "id": "square-access-token",
       "description": "Square Access Token",
-      "regex": "(?<![A-Za-z0-9+/])EAAA[a-zA-Z0-9\\-_+=]{60}(?![A-Za-z0-9+/=_-])",
+      "regex": "(?<![A-Za-z0-9+/])EAAA[a-zA-Z0-9\\-_+=]{60,}(?![A-Za-z0-9+/=_-])",
       "category": "secret"
     },
     {
       "id": "mapbox-token",
       "description": "Mapbox Token",
-      "regex": "(?:pk|sk)\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "regex": "\\b(?:pk|sk|tk)\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
       "category": "secret"
     },
     {
@@ -185,7 +185,7 @@
     {
       "id": "sentry-org-token",
       "description": "Sentry Organization Auth Token",
-      "regex": "sntrys_eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "regex": "sntrys_[A-Za-z0-9+/=]{10,}_[A-Za-z0-9]{43}",
       "category": "secret"
     },
     {
@@ -245,13 +245,13 @@
     {
       "id": "pii-email",
       "description": "Email Address",
-      "regex": "(?<!\\b(?:ssh|scp|rsync|sftp)\\b[^@\\n]{0,40})\\b(?!(?:git|hg|svn)@)[A-Za-z0-9._%+-]{1,64}@(?!example\\.(?:com|net|org|edu)\\b)(?![A-Za-z0-9.-]{0,255}\\.(?:test|invalid|localhost|local|example)\\b)(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}(?![A-Za-z0-9.-])(?!:\\S)",
+      "regex": "(?<!\\b(?:ssh|scp|rsync|sftp)\\b(?:[ \\t]+[^\\s@,;()]+){0,2}[ \\t]+)\\b(?!(?:git|hg|svn)@)[A-Za-z0-9._%+-]{1,64}@(?!example\\.(?:com|net|org|edu)\\b)(?![A-Za-z0-9.-]{0,255}\\.(?:test|invalid|localhost|local|example)\\b)(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}(?![A-Za-z0-9.-])(?!:\\S)",
       "category": "pii"
     },
     {
       "id": "pii-credit-card",
       "description": "Credit Card Number",
-      "regex": "\\b(?:4[0-9]{3}(?:[\\s-]?[0-9]{4}){3}|5[1-5][0-9]{2}(?:[\\s-]?[0-9]{4}){3}|3[47][0-9]{2}[\\s-]?[0-9]{6}[\\s-]?[0-9]{5}|6(?:011|5[0-9]{2})[0-9](?:[\\s-]?[0-9]{4}){3})\\b",
+      "regex": "\\b(?:4[0-9]{3}(?:[\\s-]?[0-9]{4}){3}|5[1-5][0-9]{2}(?:[\\s-]?[0-9]{4}){3}|2(?:22[1-9]|2[3-9][0-9]|[3-6][0-9]{2}|7[01][0-9]|720)(?:[\\s-]?[0-9]{4}){3}|3[47][0-9]{2}[\\s-]?[0-9]{6}[\\s-]?[0-9]{5}|6(?:011|4[4-9][0-9]|5[0-8][0-9])(?:[\\s-]?[0-9]{4}){3}|35(?:2[89]|[3-8][0-9])(?:[\\s-]?[0-9]{4}){3}|3(?:0[0-5]|[689][0-9])[0-9](?:[\\s-]?[0-9]{4}){3}|3(?:0[0-5]|[68][0-9])[0-9][\\s-]?[0-9]{6}[\\s-]?[0-9]{4}|(?:62|81)[0-9]{2}(?:[\\s-]?[0-9]{4}){3})\\b",
       "category": "pii",
       "validate": "luhn"
     },
@@ -280,42 +280,6 @@
       "category": "pii"
     },
     {
-      "id": "pii-ipv4",
-      "description": "IPv4 Address (private range)",
-      "regex": "\\b(10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.(1[6-9]|2\\d|3[01])\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3})\\b(?!:\\d)",
-      "category": "pii",
-      "excludeContext": [
-        "ping",
-        "curl",
-        "wget",
-        "ssh",
-        "scp",
-        "telnet",
-        "nc",
-        "netcat",
-        "redis",
-        "psql",
-        "mysql",
-        "mongo",
-        "kubectl",
-        "docker",
-        "port",
-        "forward",
-        "bind",
-        "listen",
-        "cidr",
-        "netmask",
-        "subnet",
-        "route",
-        "gateway",
-        "dns",
-        "nslookup",
-        "dig",
-        "traceroute",
-        "iptables"
-      ]
-    },
-    {
       "id": "pii-mynumber-jp",
       "description": "Japanese Individual Number (My Number)",
       "regex": "\\b\\d{12}\\b",
@@ -333,7 +297,7 @@
     {
       "id": "pii-codice-fiscale-it",
       "description": "Italian Codice Fiscale",
-      "regex": "\\b[A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z]\\b",
+      "regex": "\\b[A-Z]{6}[0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]\\b",
       "category": "pii",
       "validate": "codice-fiscale-it"
     },

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -217,7 +217,19 @@ const CF_ODD_VALUES: Record<string, number> = {
 
 export function validateCodiceFiscale(input: string): boolean {
   const cf = input.toUpperCase().replace(/\s/g, "");
-  if (!/^[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]$/.test(cf)) return false;
+  // Omocodia: when two people would share the first fifteen characters, the
+  // Agenzia delle Entrate substitutes letters for digits from the right,
+  // 0=L 1=M 2=N 3=P 4=Q 5=R 6=S 7=T 8=U 9=V, over the seven numeric
+  // positions. Requiring digits there rejected every substituted code — all
+  // of them issued to real people. The check character below needs no change:
+  // it is defined over the substituted fifteen, and the odd/even tables
+  // already carry letters.
+  if (
+    !/^[A-Z]{6}[0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]$/.test(
+      cf,
+    )
+  )
+    return false;
 
   let sum = 0;
   for (let i = 0; i < 15; i++) {
@@ -235,7 +247,14 @@ export function validateCodiceFiscale(input: string): boolean {
 }
 
 // German Steuer-Identifikationsnummer (IdNr.): 11 digits, first digit non-zero.
-// Uses ISO/IEC 7064 MOD 11,10. Spec: Bundeszentralamt für Steuern.
+// The procedure is ISO/IEC 7064 MOD 11,10, though the tax administration's own
+// specification states it as code rather than by that name.
+//
+// Deliberately not enforced: the digit-composition rule. Since 2016 it reads
+// "exactly one digit occurs twice or three times in positions 1-10", replacing
+// an older "exactly twice". Adding the older form as a tightening would reject
+// valid current numbers.
+// Spec: ELSTER, Prüfung der Steuer- und Steueridentifikationsnummer, §2.2.
 export function validateGermanIdNr(input: string): boolean {
   const cleaned = input.replace(/\s/g, "");
   if (!/^[1-9]\d{10}$/.test(cleaned)) return false;
@@ -254,7 +273,13 @@ export function validateGermanIdNr(input: string): boolean {
 // Spanish DNI (8 digits + letter) and NIE (X/Y/Z + 7 digits + letter). The
 // control letter is selected from TRWAGMYFPDXBNJZSQVHLCKE by the number mod 23.
 // NIE leading letters map X→0, Y→1, Z→2 before the mod.
-// Spec: Ministerio del Interior, Orden INT/2058/2008.
+// The X/Y/Z mapping and the mod-23 alphabet are what every implementation uses,
+// but they were not confirmed against a Spanish government source here — the
+// Interior page that documents them was unreachable. The governing decree is
+// Real Decreto 255/2025, which repealed RD 1553/2005 on 2025-04-02, and it
+// specifies neither digit count nor separator; the Agencia Tributaria describes
+// the number as "ocho dígitos ... más una letra de control", with no separator.
+// Hyphens are stripped above so both the official and the common form are read.
 const NIF_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE";
 
 export function validateSpanishNIF(input: string): boolean {
@@ -278,9 +303,14 @@ export function validateSpanishNIF(input: string): boolean {
 // Korean Resident Registration Number (RRN, 주민등록번호): 13 digits.
 // Checksum is (11 - (weighted sum mod 11)) mod 10 with weights
 // 2,3,4,5,6,7,8,9,2,3,4,5 over the first 12 digits.
-// Note: numbers issued after Oct 2020 randomize digits 8-13, so the checksum
-// may not pass for valid recent numbers (false negatives possible).
-// Spec: 주민등록 사무편람 (Ministry of the Interior and Safety).
+// Numbers newly issued or changed on or after 2020-10-05 randomize digits 8-13,
+// and the check digit is the 13th — so it is inside the randomized block and the
+// weighted sum above holds only by chance, roughly one time in ten. Treat a pass
+// as evidence, never as a requirement. 주민등록법 시행규칙 제2조 (행정안전부령
+// 제204호) now reads "생년월일ㆍ성별 등을 표시할 수 있는 13자리의 숫자", with the
+// 지역 (region) term of the older text removed. No rule ever specified the check
+// digit, so no rule announces its end either.
+// Spec: 주민등록법 시행규칙 제2조; 주민등록 사무편람 (Ministry of the Interior and Safety).
 export function validateKoreanRRN(input: string): boolean {
   const s = input.replace(/[-\s]/g, "");
   if (!/^\d{13}$/.test(s)) return false;
@@ -409,6 +439,33 @@ export function isReservedIpv6(ip: string): boolean {
   if ((groups[0] ?? 0) === 0x2001 && (groups[1] ?? 0) === 0x0db8) return true;
 
   return false;
+}
+
+// A value written to be replaced. Half of a realistic `.env.example` was being
+// blocked on its contents, which is the block most likely to get the tool turned
+// off — the file is meant to be committed and read.
+//
+// Only secret rules consult this. "todo@company.com" is a real address, and
+// AWS's own documented key ends in EXAMPLE and is still a key, so `example` is
+// deliberately absent from the list.
+export function isPlaceholder(value: string): boolean {
+  if (/^[Xx]+$/.test(value)) return true;
+  if (/x{8,}/i.test(value)) return true;
+  // `<your-token>`, `${TOKEN}`, `{{ token }}` — a value nobody typed.
+  if (/[<{][^>}]*[>}]/.test(value)) return true;
+  // A connection string whose user and password are both the words for them.
+  // `root:secret@` is not one of these: `secret` alone is a password people
+  // actually set, and `root` is a real account.
+  if (
+    /\/\/(?:your)?(?:user|username)(?:name)?:(?:your)?(?:password|passwd|pwd)@/i.test(
+      value,
+    )
+  )
+    return true;
+  if (/^your[_-]/i.test(value)) return true;
+  return /\b(?:changeme|change[_-]me|placeholder|dummy|fixme|todo|insecure|replace[_-](?:me|this|with)|your[_-][a-z])/i.test(
+    value,
+  );
 }
 
 // Shannon entropy (bits per character; ≈0–8 for byte-sized alphabets)
@@ -730,6 +787,7 @@ export function scan(
         rule.secretGroup != null ? match[rule.secretGroup] : match[0];
 
       if (!secretValue) continue;
+      if (rule.category === "secret" && isPlaceholder(secretValue)) continue;
       if (
         rule.entropyThreshold != null &&
         entropy(secretValue) < rule.entropyThreshold

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -413,6 +413,14 @@ function collectCommandFields(
 // PreToolUse timeout killed it. A killed hook does not block the call, so a hang
 // is a fail-open — the one failure mode worth spending a `stat` on every path to
 // avoid.
+function isDirectory(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function isRegularFile(candidate: string): boolean {
   try {
     return fs.statSync(candidate).isFile();
@@ -453,6 +461,54 @@ function blockUnreadEnvFile(filePath: string, allowTags: Set<string>): void {
     ],
     buildAllowHints(`please read ${filePath}`, [], true),
   );
+}
+
+// The values a command would print, whichever tool is running it.
+function scanEnvironment(names: string[], allowTags: Set<string>): void {
+  for (const varName of names) {
+    const value = process.env[varName];
+    if (!value) continue;
+    const findings = applyAllowTags(
+      dedupeFindings(scan(value, ENABLED_CATEGORIES)),
+      allowTags,
+    );
+    if (findings.length === 0) continue;
+    block(
+      "bash command",
+      [
+        `🚫 Blocked: environment variable $${varName} contains sensitive data`,
+        "",
+        ...findingsToLines(findings),
+      ],
+      buildAllowHints("please run the command", findings),
+    );
+  }
+}
+
+// Files named outright, then the ones a pattern has to be expanded to find.
+//
+// Expanding a pattern costs what the walk costs and cannot be interrupted, so a
+// deep one spent the call's whole deadline — and every file named after it in
+// the same command went unscanned. `cat ~/*/*/*/*/* secrets` read nothing of
+// `secrets`. Ordering does not make the walk cheaper; it stops one token
+// starving the rest.
+function scanPathsLiteralsFirst(
+  paths: string[],
+  allowTags: Set<string>,
+  opts?: { onlyExisting?: boolean },
+): void {
+  const scanOne = (candidate: string): void => {
+    if (opts?.onlyExisting) scanIfRegularFile(candidate, allowTags);
+    else scanFile(candidate, allowTags);
+  };
+  const patterns: string[] = [];
+  for (const candidate of paths) {
+    if (GLOB_METACHARACTERS.test(candidate)) patterns.push(candidate);
+    else for (const p of expandCandidate(candidate)) scanOne(p);
+  }
+  for (const candidate of patterns) {
+    for (const p of expandCandidate(candidate)) scanOne(p);
+  }
 }
 
 function scanFile(filePath: string, allowTags: Set<string>): void {
@@ -589,7 +645,7 @@ process.stdin.on("end", () => {
     process.exit(0);
   }
 
-  const tool = data.tool_name ?? "";
+  const tool = typeof data.tool_name === "string" ? data.tool_name : "";
   // Before anything resolves a path: a relative path in a command is relative to
   // where Claude Code will run it, not to where this hook was started.
   if (typeof data.cwd === "string" && data.cwd) baseDirectory = data.cwd;
@@ -644,12 +700,17 @@ process.stdin.on("end", () => {
         // not exist, and every relative path after it went unscanned.
         if (
           target.value === "-" ||
+          target.value === "--" ||
           target.value.includes("$") ||
           GLOB_METACHARACTERS.test(target.value)
         ) {
           break;
         }
-        baseDirectory = path.resolve(baseDirectory, expandTilde(target.value));
+        // A `cd` the shell will fail is a `cd` that does not happen. Following
+        // it moved the base somewhere neither the command nor this will read.
+        const moved = path.resolve(baseDirectory, expandTilde(target.value));
+        if (!isDirectory(moved)) break;
+        baseDirectory = moved;
       }
     }
     const refs = extractCommandRefs(command);
@@ -659,24 +720,7 @@ process.stdin.on("end", () => {
       ? Object.keys(process.env)
       : [...new Set([...extractEnvVarNames(command), ...refs.envVars])];
 
-    for (const varName of envVarNames) {
-      const value = process.env[varName];
-      if (!value) continue;
-      const findings = applyAllowTags(
-        dedupeFindings(scan(value, ENABLED_CATEGORIES)),
-        allowTags,
-      );
-      if (findings.length === 0) continue;
-      block(
-        "bash command",
-        [
-          `🚫 Blocked: environment variable $${varName} contains sensitive data`,
-          "",
-          ...findingsToLines(findings),
-        ],
-        buildAllowHints("please run the command", findings),
-      );
-    }
+    scanEnvironment(envVarNames, allowTags);
 
     const cmdFindings = applyAllowTags(
       dedupeFindings(scan(command, ENABLED_CATEGORIES)),
@@ -694,9 +738,7 @@ process.stdin.on("end", () => {
       );
     }
 
-    for (const fp of refs.paths) {
-      for (const p of expandCandidate(fp)) scanFile(p, allowTags);
-    }
+    scanPathsLiteralsFirst(refs.paths, allowTags);
 
     process.exit(0);
   }
@@ -705,7 +747,7 @@ process.stdin.on("end", () => {
   // contents the same way Read does, so a field naming an existing file is
   // scanned before the call. Grep needs no branch of its own — its `path` is one
   // of the fields collected here, and it is neither exempt nor named as a writer.
-  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool) && !isWritingTool(tool)) {
+  if (!TOOLS_WITHOUT_FILE_OUTPUT.has(tool)) {
     // An MCP server that runs a shell takes the command as an input field, and
     // an IDE bridge takes code the same way. Only `Bash` was read as a command,
     // so `mcp__desktop-commander__start_process` with `{"command":"cat .env"}`
@@ -717,15 +759,28 @@ process.stdin.on("end", () => {
       // command in it this can classify, and the path is a quoted literal — the
       // same shape inline `-c` text is read for.
       refs.paths.push(...extractQuotedLiterals(value));
-      for (const fp of refs.paths) {
-        for (const candidate of expandCandidate(fp)) {
-          scanIfRegularFile(candidate, allowTags);
-        }
-      }
+      scanPathsLiteralsFirst(refs.paths, allowTags, { onlyExisting: true });
+
+      // A command names an environment as readily as a file. The Bash branch
+      // has always scanned the variables a command would print; a tool that
+      // runs a shell was collected for paths and nothing else, so
+      // `{"command":"printenv"}` handed the environment back whole.
+      scanEnvironment(
+        refs.dumpsEnvironment
+          ? Object.keys(process.env)
+          : [...new Set([...extractEnvVarNames(value), ...refs.envVars])],
+        allowTags,
+      );
     }
 
-    for (const candidate of collectPathFields(input)) {
-      scanIfRegularFile(candidate, allowTags);
+    // The write-verb exemption is about a tool's *output*: naming a file it only
+    // writes to is not a leak. A command is not output — `create_process` runs
+    // what it is handed — so the command fields above are read whatever the name
+    // says, and only the path fields are exempt.
+    if (!isWritingTool(tool)) {
+      for (const candidate of collectPathFields(input)) {
+        scanIfRegularFile(candidate, allowTags);
+      }
     }
   }
 

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -201,10 +201,12 @@ function isEnvName(filePath: string): boolean {
   return base === ".env" || base.startsWith(".env.");
 }
 
+// The same names, minus the templates. Stated in terms of `isEnvName` rather
+// than repeating the test: the two answered the question separately, so a change
+// to one silently disagreed with the other.
 function isBlockedEnvFile(filePath: string): boolean {
-  if (!filePath) return false;
+  if (!isEnvName(filePath)) return false;
   const base = path.basename(filePath);
-  if (base !== ".env" && !base.startsWith(".env.")) return false;
   return !ENV_TEMPLATE_SUFFIXES.some((suffix) => base.endsWith(suffix));
 }
 


### PR DESCRIPTION
Three independent reviews of the release, each pointed at a different seam. Every finding was reproduced before it was fixed, and every fix was checked by breaking the thing again.

## The release could not publish

GitHub runs every `run:` step as `bash -e {0}`. The smoke test pipes into a hook that exits 2 on purpose, so errexit killed the step before the assertion that expected the 2.

```
$ bash -e smoke.sh
🐤 sensitive-canary: sensitive data detected — blocked
--- step exit: 2      # "SMOKE REACHED THE END" never printed
```

`Publish to npm` was never reached. The gate written to make the release safer made it impossible.

## The gates were not looking at what gets published

| broken this way | before | after |
| --- | --- | --- |
| `files` drops `dist/` | all green | **caught** |
| `files` drops `hooks/` | all green | **caught** |
| tarball ships the tests | all green | **caught** |
| `hooks.json` emptied | all green | **caught** |
| `hooks.json` points at a missing file | all green | **caught** |
| a hook that never blocks | — | **caught** |
| the `.env` name guard switched off | — | **caught** |

The first version of this gate passed against a package it had not built: `tar xzf /tmp/*.tgz` matched a leftover tarball. The pack is deterministic now.

## Twenty things went undetected

The card rule's Discover branch required seventeen digits, so no Discover, JCB or Diners card could reach it; Mastercard's 2-series and UnionPay were absent outright. **Five brands.**

Slack's rotated (`xoxe-`), app-level (`xapp-`) and workflow (`xwfp-`) tokens. Stripe's restricted, organization and webhook-signing secrets. Eight of GitLab's ten prefixes. A Square token longer than sixty characters, against a contract that allows 1024.

Mapbox and Sentry were written to shapes those services do not issue — Mapbox delimits into three parts of which the first is the literal `pk`/`sk`/`tk`, and a Sentry org token is underscore-separated. **Neither rule had ever matched a real token.**

Every codice fiscale altered by omocodia: the seven positions the pattern demanded digits at are exactly the ones that receive letters.

## Two things were detected that should not be

Half of a realistic `.env.example` was blocked on its contents, which defeats exempting the name — the file exists to be committed. Ten realistic templates read clean now; one holding a live key is still blocked.

An address stopped being found whenever a remote-shell word sat anywhere within forty characters: `rsync failed, notify alice@corp.io` was silently dropped.

## Private addresses are no longer PII

An RFC 1918 address is non-routable and identifies nothing outside its own network. The rule spent its time on ansible inventories, ssh configs, Kubernetes manifests and docker-compose files — five such files, all blocked before, all quiet now. Public addresses are unchanged and still require a nearby label.

## Mutation

Nine mutants had survived the suite. Six are killed by tests written here, each confirmed by re-introducing the mutation:

```
KILLED  M01 isEnvName .env. -> .env      KILLED  M07 drop allow-tag gate
KILLED  M04 drop existsSync guard        KILLED  M17 drop argv array branch
KILLED  M06 drop category gate           KILLED  M26 email lookbehind allows @
```

The remaining finding was mine: `.env` name matching was implemented twice, and the two could disagree.

## Numbers

| | |
| --- | --- |
| tests | 1,816 → **1,904** |
| rules | 73 → **74** |
| corpora | 20/18 and 21/11, **0 wrong** |
| session false positives | **10.9%**, unchanged |
| ReDoS | 11 changed rules, 100 KB adversarial input, worst 8 ms |