### PR TITLE
fix: the release could not publish, and four ways past the allow-tag guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,13 @@ jobs:
             });
           '
 
+  # Not gated on `should_release`. Gating the whole job on it meant a failure
+  # after the publish could not be recovered: npm then has the version, the gate
+  # says there is nothing to release, and the tag, the GitHub Release and the
+  # catalog sync are never made. Only the publish itself is conditional; every
+  # other step is idempotent and re-runs harmlessly.
   release:
     needs: check
-    if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -200,10 +204,13 @@ jobs:
           # Exit 0 alone would pass for a hook that starts and checks nothing,
           # which is the failure this exists to catch. So both directions.
           #
-          # No `set -e` here, and every hook invocation captures its status with
-          # `|| status=$?`: a blocking hook exits 2 on purpose, and under the
-          # default `bash -e {0}` that killed the step before the assertion ran,
-          # which made the release unable to publish at all.
+          # `set +e` is load-bearing, and `set -uo pipefail` does not imply it:
+          # `-e` arrives from the step's own `bash -e {0}` invocation. A blocking
+          # hook exits 2 on purpose, and the `eval` below runs it as the last
+          # element of a pipeline, where errexit fires inside the subshell and
+          # the status reaching `|| status=$?` is 1 rather than 2 — so every
+          # blocking assertion fails and the release cannot publish.
+          set +e
           set -uo pipefail
           key="AKIA""IOSFODNN7EXAMPLE"
           fail=0
@@ -284,6 +291,7 @@ jobs:
           fi
 
       - name: Publish to npm
+        if: needs.check.outputs.should_release == 'true'
         run: pnpm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -327,8 +335,11 @@ jobs:
       # Scoped to the one repository this needs to reach, and minted per run.
       # It replaces a personal access token that was issued in March and never
       # rotated. calc-mcp already dispatches this way.
+      # Dispatched on every run, not only the one that cut the release. The sync
+      # workflow exits early when the catalog already names this version, so a
+      # repeat costs nothing — and gating it on "we just created the release"
+      # left the catalog stuck whenever that step was the one that failed.
       - name: Mint app token for marketplace sync
-        if: steps.gh_release.outputs.created == 'true'
         id: marketplace-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -338,7 +349,6 @@ jobs:
           repositories: claude-code-marketplace
 
       - name: Sync marketplace
-        if: steps.gh_release.outputs.created == 'true'
         env:
           GH_TOKEN: ${{ steps.marketplace-token.outputs.token }}
           VERSION: ${{ needs.check.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,37 @@
   documents 16–64 byte keys; `anthropic-key` asked for 95 characters after the
   prefix where the format has 101, truncating the match; and `twilio-sid` had no
   rule for the API Key SID at all
+- Start the scan clock when the payload arrives, not when the process does.
+  Both the five-second file deadline and the scan budget began at module load
+  and counted the wait for stdin against themselves, so a slow handover spent
+  the whole allowance before a file was read: six seconds of delay and nothing
+  was scanned, on an exit code of 0
+- Stop a compaction summary and a skill body from carrying an allow tag. Both
+  are written by the runtime with the user's role, and neither is anyone asking
+  for anything: a summary re-injects earlier turns, so a tag discussed at any
+  point in a conversation came back armed, and a meta line carries file content,
+  so writing a `SKILL.md` was enough to lift every check
+- Treat a fence that never closes as quoting, the way an unclosed synthetic
+  element already was. A paste cut short is still a paste
+- Return a quarter of a value in the block reason rather than eight characters
+  of it. The reason is written to stderr, which is where Claude reads it, so it
+  reaches the API the block exists to keep the value from — of a nine-character
+  password, eight characters were being handed back
+- Skip binaries when a directory is swept, while still scanning one in full when
+  it is named outright. Nobody asked for the files a directory sweep picks up,
+  and a folder of images cost three seconds and reported the compressed bytes as
+  email addresses. Measured: 8 MiB of images, 3,103ms to 131ms
+- Require a NUL imbalance to be near-total before reading a file as UTF-16. An
+  eight-to-one ratio read four real binaries out of seventeen thousand as text,
+  and a key sitting in a JPEG's bytes went unfound because the file decoded to
+  nonsense
+- Stop reading a reference to a value in code as the value. `env-assignment`
+  matched `process.env.API_TOKEN`, `user.password_digest` and `self.api_key`;
+  two in five of the distinct values it matched across thirty thousand real
+  files were one of these
+- Stop reading a Retina asset filename as an email address. `logo@2x.png`
+  satisfied the pattern because `png` is two or more letters. Thirty asset
+  extensions are excluded, none of which is a country code
 - Match card numbers at every length their brand issues. ISO/IEC 7812 allows
   10–19 digits and the pattern encoded one length per brand, so 19-digit
   UnionPay, JCB and Discover cards, 13-digit Visa, and every Maestro card went
@@ -604,6 +635,17 @@
 - Run CI on pushes to `main` and `develop`, not only on pull requests. The
   commit a merge makes belongs to no PR, so nothing built it: two branches that
   are green apart can still be red together
+- The release could not publish, again, and for a new reason. The smoke test now
+  starts each hook through `eval`, and under the `bash -e {0}` GitHub runs every
+  step with, errexit fires inside the pipeline's subshell: a hook exiting 2 on
+  purpose reached the assertion as 1, so all eight blocking assertions failed.
+  `set -uo pipefail` does not clear `-e`, which arrives from the invocation.
+  Measured: without `set +e`, eight errors and the step exits 1
+- Make every step after the publish recoverable. The job was gated on
+  `should_release`, which npm alone decides, so a failure after the publish left
+  the version on npm with no GitHub Release and no catalog sync, and a re-run
+  skipped the job entirely. Only the publish is conditional now; the tag, the
+  release and the sync are idempotent and run every time
 - Run the release smoke test against the commands `hooks/hooks.json` declares,
   as well as against `dist/`. The manifest starts `src/*.ts` under type
   stripping, which is what a plugin install runs and what the gate only checked

--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -958,6 +958,77 @@ describe("pre-tool-use-hook — Bash tool (file-reading commands)", () => {
 
 // ── allow tag bypass (transcript) ────────────────────────────────────────────
 
+// A tag is the user asking for something. These are the ways a tag reached the
+// parser without anyone having asked: two kinds of line the runtime writes with
+// the user's role, and a fence that never closed.
+describe("pre-tool-use-hook — what is not the user asking", () => {
+  const writeRawTranscript = (rows: unknown[]): string => {
+    const p = join(tmpDir, `raw-transcript-${++transcriptSeq}.jsonl`);
+    writeFileSync(p, rows.map((r) => JSON.stringify(r)).join("\n"), "utf8");
+    return p;
+  };
+  const tag = `[allow${"-"}all]`;
+  const envFile = (): string =>
+    writeFixture(
+      `.env.notuser-${++transcriptSeq}`,
+      "KEY=AKIAIOSFODNN7EXAMPLE\n",
+    );
+
+  it("a compaction summary does not carry a tag", () => {
+    const transcript = writeRawTranscript([
+      {
+        type: "user",
+        isCompactSummary: true,
+        message: {
+          role: "user",
+          content: `Summary so far: the user asked how ${tag} works.`,
+        },
+      },
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  it("a meta line does not carry a tag", () => {
+    const transcript = writeRawTranscript([
+      {
+        type: "user",
+        isMeta: true,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: `# Skill\n\nUse ${tag} to proceed.` },
+          ],
+        },
+      },
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  it("a tag under a fence that never closes is quoted, not asked", () => {
+    const transcript = writeTranscript([
+      `paste of a truncated file:\n\`\`\`\nconfig:\n  note: ${tag}\n`,
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  it("an ordinary message still carries one", () => {
+    const transcript = writeTranscript([`${tag} please read the env file`]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("pre-tool-use-hook — allow tag bypass via transcript", () => {
   // ── Read tool ──────────────────────────────────────────────────────────────
 

--- a/src/lib/__tests__/rules.test.ts
+++ b/src/lib/__tests__/rules.test.ts
@@ -92,18 +92,43 @@ describe("entropy", () => {
 // ── redact ────────────────────────────────────────────────────────────────────
 
 describe("redact", () => {
-  it("masks strings of 8 chars or fewer completely", () => {
+  it("masks a short value completely", () => {
     expect(redact("abc")).toBe("****");
-    expect(redact("12345678")).toBe("****");
-  });
-
-  it("shows first 4 and last 4 chars for strings longer than 8 chars", () => {
-    expect(redact("123456789")).toBe("1234****6789");
-    expect(redact("AKIAIOSFODNN7EXAMPLE")).toBe("AKIA****MPLE");
+    expect(redact("1234567")).toBe("****");
   });
 
   it("handles empty string", () => {
     expect(redact("")).toBe("****");
+  });
+
+  // Whatever this returns is written to stderr, which is where Claude reads it,
+  // so it reaches the API the block exists to keep the value from. A quarter of
+  // the value, capped at four characters per end.
+  it.each([
+    [9, 2],
+    [16, 4],
+    [24, 6],
+    [32, 8],
+    [64, 8],
+  ])("a %i-character value returns at most %i of it", (length, atMost) => {
+    const value = "abcdefghijklmnopqrstuvwxyz0123456789"
+      .repeat(2)
+      .slice(0, length);
+    const shown = redact(value);
+    expect(shown.replace(/\*/g, "")).toHaveLength(atMost);
+  });
+
+  it("never returns more than a quarter of the value", () => {
+    for (let length = 1; length <= 200; length++) {
+      const value = "a".repeat(length);
+      const kept = redact(value).replace(/\*/g, "").length;
+      expect(kept / length, `${length} characters`).toBeLessThanOrEqual(0.25);
+    }
+  });
+
+  it("shows the ends, so two findings can be told apart", () => {
+    expect(redact("AKIAIOSFODNN7EXAMPLE")).toBe("AK****LE");
+    expect(redact("AKIAQQQQQQQQQQQQQZZZ")).toBe("AK****ZZ");
   });
 });
 

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -245,7 +245,7 @@
     {
       "id": "pii-email",
       "description": "Email Address",
-      "regex": "(?<!\\b(?:ssh|scp|rsync|sftp)\\b(?:[ \\t]+[^\\s@,;()]+){0,2}[ \\t]+)\\b(?!(?:git|hg|svn)@)[A-Za-z0-9._%+-]{1,64}@(?![0-9]+\\.)(?!example\\.(?:com|net|org|edu)\\b)(?![A-Za-z0-9.-]{0,255}\\.(?:test|invalid|localhost|local|example)\\b)(?:[A-Za-z0-9-]+\\.)+[A-Za-z]{2,}(?![A-Za-z0-9.-])(?!:\\S)",
+      "regex": "(?<!\\b(?:ssh|scp|rsync|sftp)\\b(?:[ \\t]+[^\\s@,;()]+){0,2}[ \\t]+)\\b(?!(?:git|hg|svn)@)[A-Za-z0-9._%+-]{1,64}@(?![0-9]+\\.)(?!example\\.(?:com|net|org|edu)\\b)(?![A-Za-z0-9.-]{0,255}\\.(?:test|invalid|localhost|local|example)\\b)(?:[A-Za-z0-9-]+\\.)+(?!(?:png|jpg|jpeg|gif|webp|svg|ico|bmp|tiff|tif|css|json|html|htm|xml|yaml|yml|lock|woff|ttf|otf|eot|webm|wav|flac|pdf|zip|tgz|bz|xz)(?![A-Za-z]))[A-Za-z]{2,}(?![A-Za-z0-9.-])(?!:\\S)",
       "category": "pii"
     },
     {

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -77,6 +77,11 @@ const UNCLOSED_SYNTHETIC_ELEMENT = new RegExp(
 // followed advised adding the tag it had just ignored.
 const FENCED_CODE = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
 
+// A fence that never closes takes the rest of the message with it, the way an
+// unclosed synthetic element does. Pairs alone let a truncated paste through:
+// the quoting is what the fence marks, and a paste cut short is still a paste.
+const UNCLOSED_FENCE = /(?:```|~~~)[\s\S]*$/g;
+
 // What the user actually typed, with the above taken out.
 export function userTypedText(msg: Message): string {
   const blocks =
@@ -87,7 +92,8 @@ export function userTypedText(msg: Message): string {
     .join("\n")
     .replace(SYNTHETIC_USER_ELEMENTS, " ")
     .replace(UNCLOSED_SYNTHETIC_ELEMENT, " ")
-    .replace(FENCED_CODE, " ");
+    .replace(FENCED_CODE, " ")
+    .replace(UNCLOSED_FENCE, " ");
 }
 
 // The same rules over a bare string, for the prompt, which is not a message.

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -485,6 +485,12 @@ export function isNotSecretShaped(value: string): boolean {
   if (/^\d+$/.test(v)) return true;
   // A dotted lower-case identifier, as a storage key or a setting name.
   if (/^[a-z][a-z0-9]*(?:\.[a-z0-9]+)+$/.test(v)) return true;
+  // A reference to a value in code rather than the value: `process.env.API_KEY`,
+  // `user.password_digest`, `self.api_key`, `response.data.accessToken`. Of the
+  // distinct values `env-assignment` matched across thirty thousand real files,
+  // two in five were one of these. No credential format has a dot in it — a JWT
+  // does, and it is matched by its own rule, which this test does not run over.
+  if (/^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/.test(v)) return true;
   return false;
 }
 
@@ -907,10 +913,16 @@ function buildRules(): Rule[] {
 
 export const RULES: Rule[] = buildRules();
 
-// Show first 4 + **** + last 4 chars; fully mask strings of 8 chars or fewer
+// Enough of a value to say which one was found, and no more.
+//
+// The block reason is written to stderr, which is where Claude reads it, so
+// whatever is shown here reaches the API that the block exists to keep it from.
+// Four characters at each end returned eight of a nine-character password.
+// A quarter of the value, capped at four per end.
 export function redact(str: string): string {
-  if (str.length <= 8) return "****";
-  return `${str.slice(0, 4)}****${str.slice(-4)}`;
+  const shown = Math.min(4, Math.floor(str.length / 8));
+  if (shown === 0) return "****";
+  return `${str.slice(0, shown)}****${str.slice(-shown)}`;
 }
 
 // Longer than any honest scan and far shorter than the hook timeout. One rule

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -73,6 +73,10 @@ interface HookInput {
 
 interface TranscriptLine {
   type?: unknown;
+  // Runtime-written lines that carry the user's role without the user having
+  // typed them: a compaction summary, and a meta line such as a skill body.
+  isCompactSummary?: unknown;
+  isMeta?: unknown;
   message?: Message;
 }
 
@@ -133,12 +137,19 @@ let bytesScanned = 0;
 // which cannot be interrupted: a pattern several directories deep still costs
 // what the walk costs. Files after the deadline are not scanned, and a `.env`
 // name reached after it falls back on the name.
-const DEADLINE = Date.now() + 5_000;
+// Both clocks start when the payload arrives, not when the process does. The
+// wait for stdin is the runtime's, and counting it against the scan meant a
+// slow handover spent the whole allowance before a single file was read — five
+// seconds of it and nothing was scanned, on an exit code of 0.
+let DEADLINE = Number.POSITIVE_INFINITY;
 
-// One budget for the whole invocation, started here rather than counted per
-// `scan()` call. A call is scanned per environment variable and per end of each
-// file, so the number of calls is set by the payload.
-beginScanBudget();
+function startTheClock(): void {
+  DEADLINE = Date.now() + 5_000;
+  // One budget for the whole invocation rather than one per `scan()` call: a
+  // call is made per environment variable and per end of each file, so the
+  // payload sets how many there are.
+  beginScanBudget();
+}
 
 // The directory a relative path is relative to. Set from the payload before any
 // scanning; `process.cwd()` is where the hook was started, which is not
@@ -220,8 +231,17 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
       // whatever the message inside it says its role is. Absent rather than
       // contradictory is fine: the field is rejected only when it names some
       // other kind of line.
+      //
+      // `isCompactSummary` and `isMeta` are the two the runtime writes as the
+      // user without the user having typed them. A compaction summary is a
+      // re-injection of earlier turns, so a tag anyone discussed at any point in
+      // the conversation comes back armed; a meta line carries skill bodies and
+      // other file content, so writing a `SKILL.md` would be enough to lift
+      // every check. Neither is someone asking for anything.
       if (
         (parsed.type === undefined || parsed.type === "user") &&
+        parsed.isCompactSummary !== true &&
+        parsed.isMeta !== true &&
         msg?.role === "user" &&
         msg.content !== undefined
       ) {
@@ -477,16 +497,44 @@ function expandPath(candidate: string): string {
 // One level, and capped at the same limit a glob is, because the walk is the
 // part that cannot be interrupted. `readdirSync` rather than a glob: `*` does
 // not match a leading dot, and `.env` is the file this most needs to find.
+//
+// Binaries are skipped here, though a file the user names outright is still
+// scanned whole. Nobody asked for these: they are swept up because the
+// directory was named, and a folder of images cost three seconds and reported
+// the compressed bytes as email addresses.
 function filesDirectlyUnder(candidate: string): string[] {
   try {
     return fs
       .readdirSync(candidate, { withFileTypes: true })
       .filter((entry) => entry.isFile())
       .slice(0, MAX_GLOB_MATCHES)
-      .map((entry) => path.join(candidate, entry.name));
+      .map((entry) => path.join(candidate, entry.name))
+      .filter((file) => !looksBinary(file));
   } catch {
     // Not a directory, or not readable.
     return [];
+  }
+}
+
+// Whether the first few kilobytes hold a NUL byte that UTF-16 does not explain.
+// UTF-16 text is half NUL by construction, and a `.env` written by PowerShell is
+// the file a sweep least wants to skip.
+const BINARY_SNIFF_BYTES = 4096;
+
+function looksBinary(filePath: string): boolean {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const head = Buffer.alloc(BINARY_SNIFF_BYTES);
+    const read = fs.readSync(fd, head, 0, head.length, 0);
+    const bytes = head.subarray(0, read);
+    if (!bytes.includes(0)) return false;
+    return detectUtf16(bytes) === null;
+  } catch {
+    // Unreadable. Nothing to sweep, and the named-file path still guards it.
+    return true;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
 }
 
@@ -670,8 +718,14 @@ function detectUtf16(raw: Buffer): Buffer | null {
   // other side, and a single one of those in a Japanese document is not
   // evidence the file is anything but UTF-16. `readsAsText` still has to agree,
   // which is what keeps a binary whose NULs happen to lean one way out.
+  // Both a ratio and an absolute cap. A ratio alone read four real binaries out
+  // of seventeen thousand as UTF-16 — a JPEG among them, which then decoded to
+  // nonsense and hid a key sitting in its bytes. The characters this exists for
+  // are rare in a document: a handful of U+xx00 in a page of Japanese, not the
+  // hundreds a binary contributes.
+  const MAX_MINORITY_NULS = 4;
   const dominates = (side: number, other: number): boolean =>
-    side >= MINIMUM_NULS && side >= other * 8;
+    side >= MINIMUM_NULS && other <= MAX_MINORITY_NULS && side >= other * 64;
   if (dominates(oddNuls, evenNuls) && readsAsText(raw)) return raw;
   if (dominates(evenNuls, oddNuls)) {
     const be = swapped();
@@ -896,6 +950,7 @@ let raw = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk: string) => (raw += chunk));
 process.stdin.on("end", () => {
+  startTheClock();
   let data: HookInput;
   try {
     // Empty stdin is nothing to check. Bytes that do not parse are a check that

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -62,14 +62,14 @@ function collectStrings(value: unknown, depth = 0): string[] {
 
 const ENABLED_CATEGORIES = enabledCategoriesFromEnv();
 
-// One budget for the whole invocation. A prompt carries several strings and
-// each is a separate `scan()` call.
-beginScanBudget();
-
 let raw = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk: string) => (raw += chunk));
 process.stdin.on("end", () => {
+  // Started here rather than at module load: the wait for stdin belongs to the
+  // runtime, and counting it against the scan let a slow handover spend the
+  // whole allowance before anything was read.
+  beginScanBudget();
   let data: HookInput;
   try {
     // Empty stdin is nothing to check. Bytes that do not parse are a check that


### PR DESCRIPTION
Round 11, from a second four-agent review that attacked the previous round's changes rather than the code they touched. **Two of these were introduced yesterday.** Every finding was reproduced independently before being fixed.

## The release would have failed

The smoke test added yesterday starts each hook through `eval`. Under the `bash -e {0}` GitHub runs every step with, errexit fires inside the pipeline's subshell and a hook exiting 2 on purpose arrives at the assertion as 1:

```
$ bash -ec 's=0; printf x | eval "node -e \"process.exit(2)\"" >/dev/null 2>&1 || s=$?; echo $s'
1
$ bash -ec 'set +e; s=0; printf x | eval "…" >/dev/null 2>&1 || s=$?; echo $s'
2
```

All eight blocking assertions failed. The step's own comment said "No `set -e` here" — wrong: `-e` arrives from the invocation, and `set -uo pipefail` does not clear it.

Extracted from the YAML and run as GitHub would, against a real tarball:

```
without set +e  8 assertion errors, STEP_EXIT=1
with set +e     0 assertion errors, STEP_EXIT=0
```

Both flavours do run, and they are different commands:

```
plugin PreToolUse: node --experimental-strip-types ".../src/pre-tool-use-hook.ts"
npm    PreToolUse: node ".../dist/pre-tool-use-hook.js"
```

**Post-publish steps were also unrecoverable.** The job was gated on `should_release`, which npm alone decides, so a failure after the publish left the version on npm with no GitHub Release and no catalog sync — and a re-run skipped the whole job. Only the publish is conditional now.

## The clock started before the payload arrived

Both the file deadline and the scan budget began at module load and counted the wait for stdin against themselves.

```
0s before stdin arrives   exit=2
6s before stdin arrives   exit=0     ← nothing was scanned
```

Both now start in the `end` handler. Both cases are `exit=2`.

## Four ways a tag reached the parser without anyone asking

```
an ordinary user message (control)   exit=2   →  exit=2
an auto-compaction summary           exit=0   →  exit=2
a skill body (isMeta)                exit=0   →  exit=2
a tag under an unclosed fence        exit=0   →  exit=2
a tag inside pasted prose            exit=0   →  exit=0   (left open, see below)
```

A **compaction summary** is a re-injection of earlier turns, written with the user's role. A tag anyone discussed at any point in the conversation came back armed — including one the model itself wrote into the summary. `README.md:238` says "Tags are read from the current user message only… there is no risk of an accidental persistent bypass". That was not true.

A **meta line** carries skill bodies. Writing a `SKILL.md` was enough to lift every check, with no user input at all.

### What is deliberately left open

A tag in prose the user pasted still lifts checks. Closing it means requiring the tag to be the first or last token of the message, which **changes documented behaviour** — `README.md:211` teaches `"[allow-secret] please read /path/to/.env"`, and a tag in the middle of a sentence would stop working. That is a decision to take, not a bug to fix silently. Raised separately.

## The block reason returned the secret

`redact` showed four characters at each end, so a nine-character password came back as `hunt****r2XY` — **eight of nine characters**, written to stderr, which is where Claude reads it. A quarter of the value now, capped at four per end:

```
 9 chars -> h****Y     2 returned
14 chars -> s****d     2 returned
20 chars -> AK****LE   4 returned
```

## Yesterday's two changes, attacked

**Reading past NUL bytes** made a directory sweep scan every image in a folder — 46.9 MiB, 3,103 ms, and the compressed bytes reported as email addresses. A sweep now skips binaries; a file named outright is still read whole. **8 MiB of images: 3,103 ms → 131 ms.**

**The 8:1 UTF-16 ratio** read four real binaries out of 17,375 as text, and a key sitting in a JPEG went unfound because the file decoded to nonsense. The imbalance now has to be near-total. Verified both ways: the binary blocks, and UTF-16LE led by an ideographic space still blocks.

## Noise, measured over 29,927 files

Two rules produced most of it.

```
const apiToken = process.env.API_TOKEN     BLOCK  →  quiet
password = user.password_digest            BLOCK  →  quiet
token: response.access_token               BLOCK  →  quiet
api_key=self.api_key                       BLOCK  →  quiet
<img src="logo@2x.png">                    BLOCK  →  quiet
API_KEY=Zq7SxLmT4vNpB2wR9kYc3H             BLOCK  →  BLOCK
alice@realcorp.co.jp                       BLOCK  →  BLOCK
```

Two in five of `env-assignment`'s distinct matches were a reference to a value rather than a value. `pii-email` matched Retina asset filenames because `png` is two or more letters — thirty asset extensions are now excluded, none of which is a country code.

## Known limitations found and not closed

Reported so they are known, not fixed here:

- A directory sweep reads **one level**; `sub/.env` under a swept directory is missed, as are symlinked files and anything past the 256-entry cap. `grep -r` recurses; this does not.
- A bare `env` token in a `code` field scans every environment variable, so `print(len(env))` blocks on a machine with a token in its environment.
- A directory-valued path field blocks any repository containing a `.env`. `README.md:511` says a field naming a directory is left alone; that is no longer true.
- Rules can match across a NUL boundary, producing a finding present in no single run of the file.
- `AKIAIOSFODNN7EXAMPLE` is AWS's published documentation example and is treated as live, which makes 13 of this repository's own 52 files unreadable. Excluding it means rebuilding every test fixture and the release smoke test; not done hours before a release.

## Verification

```
pnpm run ci     tsc --noEmit  →  clean
                biome check --error-on-warnings  →  clean
                vitest  →  2245 passed | 2 skipped
```

Tests 2235 → **2245**.
