### PR TITLE
fix: the last tag is the one that applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,14 @@
   matched `process.env.API_TOKEN`, `user.password_digest` and `self.api_key`;
   two in five of the distinct values it matched across thirty thousand real
   files were one of these
+- The last tag in a message is the one that applies, replacing the earlier ones
+  rather than merging with them. Resolving each category separately kept the
+  wider grant of the two, so `[allow-all]` narrowed to `[allow-secret]` went on
+  allowing PII — the opposite of what narrowing means. Two tags no longer add
+  up: `[allow-all]` is how both categories are asked for
+- Resolve tags the same way in both hooks. `PreToolUse` collected every allow
+  tag and never looked at mask tags, so `[mask-secret] [allow-secret]` stopped
+  the prompt and then allowed the tool call it was stopping
 - Read AWS's documented keys as documentation. AWS writes `EXAMPLE` where the
   random part would end — `AKIAIOSFODNN7EXAMPLE` and its siblings — and those
   appear in every setup guide and in every README that copies one, where a block

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -227,19 +227,30 @@ If you include a mask tag in your prompt, sensitive-canary shows an explanation 
 | `[mask-pii]` | `[allow-pii]` |
 | `[mask-all]` | `[allow-all]` |
 
-### Allow + Mask Tag Priority
+### Tag Priority
 
-When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category dimension (`secret`, `pii`).
+When more than one tag appears, **the last one wins**. It replaces the earlier
+ones entirely rather than combining with them, so changing your mind mid-message
+works the way it reads.
 
 | Example | secret | pii |
 |---------|--------|-----|
-| `[allow-secret] [mask-secret] …` | allow | — |
-| `[mask-secret] [allow-secret] …` | mask (unsupported) | — |
-| `[allow-all] [mask-secret] …` | allow | allow |
-| `[mask-all] [allow-secret] …` | mask (unsupported) | mask (unsupported) |
-| `[allow-secret] [mask-pii] …` | allow | mask (unsupported) |
+| `[allow-all] … [allow-secret]` | allow | blocked |
+| `[allow-secret] … [allow-all]` | allow | allow |
+| `[allow-secret] … [mask-secret]` | mask (unsupported) | blocked |
+| `[mask-secret] … [allow-secret]` | allow | blocked |
+| `[allow-secret] … [allow-pii]` | blocked | allow |
 
-`[allow-all]` and `[mask-all]` resolve both dimensions at once.
+The last line is the one to watch: two tags do not add up. Narrowing from
+`[allow-all]` to `[allow-secret]` really does put PII back under guard, which is
+the point — but so does writing `[allow-secret] [allow-pii]` and expecting both.
+**`[allow-all]` is how you ask for both.**
+
+A tag counts wherever it appears in the message, including mid-sentence. What
+does not count is a tag inside a fenced code block, inside one of the elements
+Claude Code writes around command output, or in a message the runtime wrote
+rather than you — a compaction summary or a skill body. Those are quoting, not
+asking.
 
 ## Category Filtering
 

--- a/src/__tests__/user-prompt-submit-hook.test.ts
+++ b/src/__tests__/user-prompt-submit-hook.test.ts
@@ -329,63 +329,62 @@ describe("user-prompt-submit-hook — [mask-xxx] tags", () => {
   });
 });
 
-describe("user-prompt-submit-hook — first-occurrence tag priority", () => {
-  it("[allow-secret] before [mask-secret] → passes through (exit 0)", () => {
-    const { exitCode } = runHook(
+describe("user-prompt-submit-hook — the last tag is the one that applies", () => {
+  it("[allow-secret] then [mask-secret] → mask, so the prompt stops", () => {
+    const { exitCode, stderr } = runHook(
       `[allow-secret] [mask-secret] my key is ${AWS_KEY}`,
     );
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("prompt masking is not supported");
   });
 
-  it("[mask-secret] before [allow-secret] → shows masking not supported (exit 2)", () => {
-    const { exitCode, stderr } = runHook(
+  it("[mask-secret] then [allow-secret] → allow, so it passes", () => {
+    const { exitCode } = runHook(
       `[mask-secret] [allow-secret] my key is ${AWS_KEY}`,
     );
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("prompt masking is not supported");
+    expect(exitCode).toBe(0);
   });
 
-  it("[allow-all] before [mask-secret] → passes through (exit 0)", () => {
+  it("[mask-all] then [allow-secret] → allow", () => {
     const { exitCode } = runHook(
-      `[allow-all] [mask-secret] my key is ${AWS_KEY}`,
+      `[mask-all] [allow-secret] my key is ${AWS_KEY}`,
     );
     expect(exitCode).toBe(0);
   });
 
-  it("[mask-all] before [allow-secret] → shows masking not supported (exit 2)", () => {
+  // Narrowing really narrows: the PII that `[allow-all]` covered is guarded
+  // again, so the email stops the prompt while the key does not.
+  it("[allow-all] then [allow-secret] puts PII back under guard", () => {
     const { exitCode, stderr } = runHook(
-      `[mask-all] [allow-secret] my key is ${AWS_KEY}`,
+      `[allow-all] [allow-secret] key ${AWS_KEY} email ada@analytical-engines.org`,
     );
     expect(exitCode).toBe(2);
-    expect(stderr).toContain("prompt masking is not supported");
+    expect(stderr).toContain("pii-email");
+    expect(stderr).not.toContain("aws-access-key");
   });
 
-  it("[allow-secret] [mask-pii] → secret allowed, pii masked → masking not supported (exit 2)", () => {
-    const { exitCode, stderr } = runHook(
-      `[allow-secret] [mask-pii] key ${AWS_KEY} email ada@analytical-engines.org`,
+  it("[allow-secret] then [allow-all] passes both", () => {
+    const { exitCode } = runHook(
+      `[allow-secret] [allow-all] key ${AWS_KEY} email ada@analytical-engines.org`,
     );
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("prompt masking is not supported");
-    expect(stderr).toContain("[mask-pii]");
-    expect(stderr).not.toContain("[mask-secret]");
+    expect(exitCode).toBe(0);
   });
 
-  it("[mask-pii] [allow-secret] → secret: allow, pii: mask → masking not supported for email (exit 2)", () => {
+  // Two tags do not add up. `[allow-all]` is how both are asked for.
+  it("[allow-secret] then [allow-pii] leaves the secret blocked", () => {
     const { exitCode, stderr } = runHook(
-      `[mask-pii] [allow-secret] key ${AWS_KEY} email ada@analytical-engines.org`,
+      `[allow-secret] [allow-pii] key ${AWS_KEY} email ada@analytical-engines.org`,
     );
     expect(exitCode).toBe(2);
-    expect(stderr).toContain("prompt masking is not supported");
-    expect(stderr).toContain("[mask-pii]");
+    expect(stderr).toContain("aws-access-key");
+    expect(stderr).not.toContain("pii-email");
   });
 
-  it("[allow-pii] before [mask-pii] → pii allowed, secret still blocked (exit 2)", () => {
-    const { exitCode, stderr } = runHook(
-      `[allow-pii] [mask-pii] key ${AWS_KEY} email ada@analytical-engines.org`,
+  it("a tag in the middle of a sentence still counts", () => {
+    const { exitCode } = runHook(
+      `my key is ${AWS_KEY} [allow-secret] please have a look`,
     );
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("sensitive data detected");
-    expect(stderr).not.toContain("prompt masking is not supported");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/inspector.test.ts
+++ b/src/lib/__tests__/inspector.test.ts
@@ -115,49 +115,67 @@ describe("resolveTagPriority", () => {
     expect(effectiveAllow.has("secret")).toBe(false);
   });
 
-  it("[allow-secret] before [mask-secret] → allow wins for secret", () => {
+  // The last tag replaces the earlier ones whole. Merging per category kept the
+  // wider grant of the two, so narrowing from `[allow-all]` to `[allow-secret]`
+  // went on allowing PII.
+  it("[allow-secret] then [mask-secret] → mask", () => {
     const { effectiveAllow, effectiveMask } = resolveTagPriority(
       "[allow-secret] [mask-secret] key=abc",
-    );
-    expect(effectiveAllow.has("secret")).toBe(true);
-    expect(effectiveMask.has("secret")).toBe(false);
-  });
-
-  it("[mask-secret] before [allow-secret] → mask wins for secret", () => {
-    const { effectiveAllow, effectiveMask } = resolveTagPriority(
-      "[mask-secret] [allow-secret] key=abc",
     );
     expect(effectiveMask.has("secret")).toBe(true);
     expect(effectiveAllow.has("secret")).toBe(false);
   });
 
-  it("[allow-all] before [mask-secret] → allow wins for both dimensions", () => {
+  it("[mask-secret] then [allow-secret] → allow", () => {
     const { effectiveAllow, effectiveMask } = resolveTagPriority(
-      "[allow-all] [mask-secret] key=abc",
+      "[mask-secret] [allow-secret] key=abc",
     );
     expect(effectiveAllow.has("secret")).toBe(true);
-    expect(effectiveAllow.has("pii")).toBe(true);
+    expect(effectiveMask.has("secret")).toBe(false);
+  });
+
+  it("[allow-all] then [allow-secret] narrows, and PII is guarded again", () => {
+    const { effectiveAllow, effectiveMask } = resolveTagPriority(
+      "[allow-all] [allow-secret] key=abc",
+    );
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveAllow.has("pii")).toBe(false);
+    expect(effectiveAllow.has("all")).toBe(false);
     expect(effectiveMask.size).toBe(0);
   });
 
-  it("[mask-all] before [allow-secret] → mask wins for both dimensions", () => {
+  it("[allow-secret] then [allow-all] widens", () => {
+    const { effectiveAllow } = resolveTagPriority(
+      "[allow-secret] [allow-all] key=abc",
+    );
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveAllow.has("pii")).toBe(true);
+    expect(effectiveAllow.has("all")).toBe(true);
+  });
+
+  it("[mask-all] then [allow-secret] → allow, for secret only", () => {
     const { effectiveAllow, effectiveMask } = resolveTagPriority(
       "[mask-all] [allow-secret] key=abc",
     );
-    expect(effectiveMask.has("secret")).toBe(true);
-    expect(effectiveMask.has("pii")).toBe(true);
-    expect(effectiveMask.has("all")).toBe(true);
-    expect(effectiveAllow.size).toBe(0);
+    expect(effectiveAllow.has("secret")).toBe(true);
+    expect(effectiveAllow.has("pii")).toBe(false);
+    expect(effectiveMask.size).toBe(0);
   });
 
-  it("[allow-secret] [mask-pii] → allow for secret, mask for pii", () => {
-    const { effectiveAllow, effectiveMask } = resolveTagPriority(
-      "[allow-secret] [mask-pii] ...",
+  // Two tags do not add up: `[allow-all]` is how both categories are asked for.
+  it("[allow-secret] then [allow-pii] is not both", () => {
+    const { effectiveAllow } = resolveTagPriority(
+      "[allow-secret] [allow-pii] ...",
+    );
+    expect(effectiveAllow.has("pii")).toBe(true);
+    expect(effectiveAllow.has("secret")).toBe(false);
+  });
+
+  it("a tag mid-sentence still counts", () => {
+    const { effectiveAllow } = resolveTagPriority(
+      "please read the env file [allow-secret] and summarise it",
     );
     expect(effectiveAllow.has("secret")).toBe(true);
-    expect(effectiveMask.has("pii")).toBe(true);
-    expect(effectiveAllow.has("pii")).toBe(false);
-    expect(effectiveMask.has("secret")).toBe(false);
   });
 
   it("[allow-all] → effectiveAllow has 'all'", () => {

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -120,13 +120,18 @@ export function parseAllowTags(messages: Message[]): Set<string> {
   return parseTagsOfType("allow", messages);
 }
 
-// Resolve effective allow/mask tags based on first-occurrence priority.
-// For each category dimension ("secret", "pii"), the first matching tag wins.
-// [allow-all] / [mask-all] resolve both dimensions at once.
+// The last tag in the text is the one that applies. Earlier ones are discarded
+// whole, not merged with it.
 //
-//   "[allow-secret] [mask-secret] ..." → secret: allow
-//   "[mask-secret] [allow-secret] ..." → secret: mask
-//   "[allow-secret] [mask-pii]   ..." → secret: allow, pii: mask
+//   "[allow-all] … [allow-secret]"  → secret only; PII is blocked again
+//   "[allow-secret] … [allow-all]"  → both
+//   "[mask-secret] … [allow-secret]" → allow
+//
+// Merging per category would keep the wider grant of the two, so a writer who
+// started with `[allow-all]` and narrowed to `[allow-secret]` would still be
+// allowing PII — the opposite of what narrowing means. Writing two tags to
+// combine categories does not work either; `[allow-all]` is how both are asked
+// for.
 export function resolveTagPriority(prompt: string): {
   effectiveAllow: Set<string>;
   effectiveMask: Set<string>;
@@ -134,27 +139,22 @@ export function resolveTagPriority(prompt: string): {
   const pattern = /\[(allow|mask)-(all|secret|pii)\]/gi;
   const effectiveAllow = new Set<string>();
   const effectiveMask = new Set<string>();
-  const resolved = new Set<string>();
 
-  for (const [, kind, tag] of prompt.matchAll(pattern)) {
-    if (!kind || !tag) continue;
-    const k = kind.toLowerCase() as "allow" | "mask";
-    const t = tag.toLowerCase();
-    const dims = t === "all" ? ["secret", "pii"] : [t];
+  const tags = [...prompt.matchAll(pattern)];
+  const last = tags[tags.length - 1];
+  if (!last) return { effectiveAllow, effectiveMask };
 
-    for (const dim of dims) {
-      if (!resolved.has(dim)) {
-        resolved.add(dim);
-        (k === "allow" ? effectiveAllow : effectiveMask).add(dim);
-      }
-    }
-  }
+  const kind = last[1]?.toLowerCase();
+  const category = last[2]?.toLowerCase();
+  if (!kind || !category) return { effectiveAllow, effectiveMask };
 
-  if (effectiveAllow.has("secret") && effectiveAllow.has("pii")) {
-    effectiveAllow.add("all");
-  }
-  if (effectiveMask.has("secret") && effectiveMask.has("pii")) {
-    effectiveMask.add("all");
+  const target = kind === "allow" ? effectiveAllow : effectiveMask;
+  if (category === "all") {
+    target.add("secret");
+    target.add("pii");
+    target.add("all");
+  } else {
+    target.add(category);
   }
 
   return { effectiveAllow, effectiveMask };

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -11,8 +11,8 @@ import {
   findingsToLines,
   forOutput,
   type Message,
-  parseAllowTags,
   randomBird,
+  resolveTagPriority,
   userTypedText,
 } from "./lib/inspector.ts";
 import {
@@ -258,11 +258,11 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
   }
 
   if (!lastUserMessage || toolResultAfterLastText) return new Set();
-  // Parsed from the typed text, not the raw content, so the two agree about
-  // what counts as the user speaking.
-  return parseAllowTags([
-    { role: "user", content: userTypedText(lastUserMessage) },
-  ]);
+  // Through the same resolution the prompt hook uses, over the typed text
+  // rather than the raw content. Collecting every tag instead meant this hook
+  // did not see mask tags at all, so `[mask-secret] [allow-secret]` stopped the
+  // prompt and then allowed the tool call it was stopping.
+  return resolveTagPriority(userTypedText(lastUserMessage)).effectiveAllow;
 }
 
 // ── .env pattern ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two decisions, both taken deliberately: **the last tag wins**, and **a tag still counts mid-sentence**.

## The last tag wins

Tags were resolved per category with the first occurrence winning, which kept the wider grant of any two. Measured before:

```
[allow-all] then [allow-secret]   allow={all,pii,secret}   everything passes
```

The writer narrowed from "everything" to "secrets only" and PII went on being allowed. That is the unsafe direction of the two mistakes available here.

After:

```
[allow-secret] then [allow-all]   allow={all,pii,secret}   everything passes
[allow-all] then [allow-secret]   allow={secret}           PII blocked
[allow-secret] [mask-secret]      mask                     (last one written)
[mask-secret] [allow-secret]      allow                    (last one written)
```

### What this costs

Two tags no longer add up. `[allow-secret] [allow-pii]` resolves to the second one, not to both — **`[allow-all]` is how both are asked for.**

That is the trade for a rule that can be stated once. Per-category merging cannot both combine `[allow-secret] [allow-pii]` into two grants and let `[allow-secret]` narrow `[allow-all]` down to one: the two behaviours contradict each other on the same input. The documentation now says which one this is, and calls out the case that surprises.

## The two hooks disagreed

`PreToolUse` collected every allow tag through `parseAllowTags` and never looked at mask tags at all. So `[mask-secret] [allow-secret]` stopped the prompt and then allowed the very tool call it was stopping. Both hooks now go through `resolveTagPriority`.

## A tag mid-sentence still counts

The alternative — requiring the tag to be the first or last token — would close the case where text a user *pasted* contains the literal `[allow-all]` and lifts the checks for the next call. That case remains open, deliberately: closing it would stop `read the env file [allow-secret] then delete it` from working, and the tag is meant to read as part of a sentence.

Still ignored, unchanged: a tag inside a fenced code block, inside the elements Claude Code writes around command output, and in a line the runtime wrote with the user's role — a compaction summary or a skill body.

## Tests

The eleven tests asserting first-occurrence priority are rewritten rather than deleted, and paired with the cases that now differ:

```
[allow-all] then [allow-secret] puts PII back under guard
  → exit 2, stderr names pii-email and does not name aws-access-key
[allow-secret] then [allow-pii] leaves the secret blocked
  → exit 2, stderr names aws-access-key and does not name pii-email
a tag in the middle of a sentence still counts
  → exit 0
```

## Verification

```
pnpm run ci     tsc --noEmit  →  clean
                biome check --error-on-warnings  →  clean
                vitest  →  2250 passed | 2 skipped
```

`docs/rules.md`'s priority table is rewritten to match. Tests 2248 → **2250**.
