### PR TITLE
fix: a report about the tags is not a request for them

### DIFF
--- a/src/__tests__/pre-tool-use-hook.test.ts
+++ b/src/__tests__/pre-tool-use-hook.test.ts
@@ -998,6 +998,66 @@ describe("pre-tool-use-hook — what is not the user asking", () => {
     expect(exitCode).toBe(2);
   });
 
+  // A background task reporting back arrives under the user's role and carries
+  // an agent's prose. Prose about these tags is enough, so a report that quotes
+  // the documentation arms the guard it is describing — and a review of this
+  // very feature is the kind of report that does it.
+  it("a task notification does not carry a tag", () => {
+    const transcript = writeRawTranscript([
+      {
+        type: "user",
+        origin: { kind: "human" },
+        message: { role: "user", content: "review the tag priority table" },
+      },
+      {
+        type: "user",
+        origin: { kind: "task-notification" },
+        message: {
+          role: "user",
+          content: `<task-notification>\n<result>The table says ${tag} is the wider grant.</result>\n</task-notification>`,
+        },
+      },
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  // The same line without the field, which is how a runtime that does not write
+  // one records it. The element name is what catches this one.
+  it("a task notification with no origin field does not carry a tag either", () => {
+    const transcript = writeRawTranscript([
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: `<task-notification>\n<result>The table says ${tag} is the wider grant.</result>\n</task-notification>`,
+        },
+      },
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  // The direction that matters more: rejecting the runtime's lines must not
+  // reject the user's. A line marked `human` is someone asking.
+  it("a line marked as human carries its tag", () => {
+    const transcript = writeRawTranscript([
+      {
+        type: "user",
+        origin: { kind: "human" },
+        message: { role: "user", content: `${tag} read the env file` },
+      },
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   it("a tag under a fence that never closes is quoted, not asked", () => {
     const transcript = writeTranscript([
       `paste of a truncated file:\n\`\`\`\nconfig:\n  note: ${tag}\n`,
@@ -1006,6 +1066,48 @@ describe("pre-tool-use-hook — what is not the user asking", () => {
       transcriptPath: transcript,
     });
     expect(exitCode).toBe(2);
+  });
+
+  // Pairing markers off — one with two, three with four — leaves the span
+  // between the second and third readable as typed. A pasted markdown document
+  // with a code block inside it puts a quoted tag in exactly that span, and it
+  // is the ordinary shape of a paste, not a contrived one.
+  it.each([
+    ["a document quoting a code block", 4],
+    ["a document quoting two", 6],
+    ["an odd number of markers", 5],
+  ])("a tag inside %s is quoted, not asked", (_label, markers) => {
+    const fence = "```";
+    const parts = ["here is a doc I was sent:"];
+    for (let i = 0; i < markers; i++) {
+      parts.push(fence);
+      if (i === 1) parts.push(`note: ${tag}`);
+    }
+    const transcript = writeTranscript([parts.join("\n")]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(2);
+  });
+
+  it("a tag before the first fence is still asked", () => {
+    const transcript = writeTranscript([
+      `${tag} read the env file, here is the log:\n\`\`\`\nnothing\n\`\`\`\n`,
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("a tag after the last fence is still asked", () => {
+    const transcript = writeTranscript([
+      `here is the log:\n\`\`\`\nnothing\n\`\`\`\n${tag} now read the env file`,
+    ]);
+    const { exitCode } = runHook("Read", envFile(), {
+      transcriptPath: transcript,
+    });
+    expect(exitCode).toBe(0);
   });
 
   it("an ordinary message still carries one", () => {

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -50,10 +50,16 @@ function parseTagsOfType(prefix: string, messages: Message[]): Set<string> {
 //
 // Claude Code writes things the user did not type into the transcript as user
 // messages with plain string content: the output of a `!` command, the name and
-// arguments of a slash command, and system reminders. A tag in any of those
-// switched the protection off — `grep -r allow-all` was enough.
+// arguments of a slash command, system reminders, and a background task
+// reporting back. A tag in any of those switches the protection off —
+// `grep -r allow-all` is enough, and so is a subagent whose report quotes the
+// documentation for these tags.
+//
+// A list of names is a list, and the runtime is free to add to it. The
+// transcript reader asks `origin.kind` instead, which answers the question
+// directly; this is what covers the same lines when the field is not there.
 export const SYNTHETIC_ELEMENT_NAMES =
-  "local-command-stdout|local-command-stderr|command-name|command-message|command-args|bash-input|bash-output|bash-stdout|bash-stderr|system-reminder";
+  "local-command-stdout|local-command-stderr|command-name|command-message|command-args|bash-input|bash-output|bash-stdout|bash-stderr|system-reminder|task-notification";
 
 const SYNTHETIC_USER_ELEMENTS = new RegExp(
   `<(${SYNTHETIC_ELEMENT_NAMES})>[\\s\\S]*?<\\/\\1>`,
@@ -75,7 +81,15 @@ const UNCLOSED_SYNTHETIC_ELEMENT = new RegExp(
 // writes the tags that way — `[allow-secret]` — so stripping them refused the
 // form the project itself teaches, and refused it silently: the block that
 // followed advised adding the tag it had just ignored.
-const FENCED_CODE = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+//
+// From the first marker to the last, rather than marker one to marker two and
+// marker three to marker four. Pairing them off leaves the span between the
+// second and third readable as typed, and a pasted markdown document with a
+// code block inside it puts a quoted tag in exactly that span. Which markers
+// open and which close cannot be told apart here — a document quoting a fence
+// is the same characters as two documents — so the whole run counts as quoted.
+// A tag before the first fence or after the last still reads as typed.
+const FENCED_CODE = /(?:```|~~~)[\s\S]*(?:```|~~~)/g;
 
 // A fence that never closes takes the rest of the message with it, the way an
 // unclosed synthetic element does. Pairs alone let a truncated paste through:

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -77,7 +77,20 @@ interface TranscriptLine {
   // typed them: a compaction summary, and a meta line such as a skill body.
   isCompactSummary?: unknown;
   isMeta?: unknown;
+  // Where the line came from. `human` is someone at a keyboard; the other
+  // values name the runtime writing under the user's role.
+  origin?: { kind?: unknown } | null;
   message?: Message;
+}
+
+// Whether a transcript line records something a person typed.
+//
+// The field is only present on lines that have one, so a line without it is
+// left to the other tests rather than rejected: most user lines carry tool
+// results and have no origin, and an older runtime writes none at all.
+function wasTypedByAHuman(line: TranscriptLine): boolean {
+  const kind = line.origin?.kind;
+  return kind === undefined || kind === null || kind === "human";
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -232,16 +245,27 @@ function loadAllowTagsFromTranscript(transcriptPath: string): Set<string> {
       // contradictory is fine: the field is rejected only when it names some
       // other kind of line.
       //
-      // `isCompactSummary` and `isMeta` are the two the runtime writes as the
-      // user without the user having typed them. A compaction summary is a
+      // `isCompactSummary` and `isMeta` are two the runtime writes as the user
+      // without the user having typed them. A compaction summary is a
       // re-injection of earlier turns, so a tag anyone discussed at any point in
       // the conversation comes back armed; a meta line carries skill bodies and
       // other file content, so writing a `SKILL.md` would be enough to lift
       // every check. Neither is someone asking for anything.
+      //
+      // `origin.kind` says outright which lines those are, and it is asked
+      // before any of the rest: a background task reporting back arrives as
+      // `task-notification`, carrying an agent's free-form prose under the
+      // user's role. Prose about these very tags is enough, so a report that
+      // quotes the documentation arms the guard it is describing.
+      //
+      // Only lines that carry the field are judged by it. Most do not — a tool
+      // result has no origin — and treating absent as non-human would ignore
+      // every transcript written by a runtime that predates it.
       if (
         (parsed.type === undefined || parsed.type === "user") &&
         parsed.isCompactSummary !== true &&
         parsed.isMeta !== true &&
+        wasTypedByAHuman(parsed) &&
         msg?.role === "user" &&
         msg.content !== undefined
       ) {


### PR DESCRIPTION
fix: a report about the tags is not a request for them

Two ways a tag counted without anyone having asked for it.

## A background task reporting back

A task notification arrives under the user's role, carrying a subagent's
free-form prose, and `SYNTHETIC_ELEMENT_NAMES` is a fixed list that does
not know the element. Prose *about* these tags is enough, so an agent
whose report quotes the documentation arms the guard it is describing.

    transcript ends with a report quoting [allow-secret]   exit 0
    the same report with the tag words removed             exit 2

This is not hypothetical. In the transcript of the review that found it,
35 user-role lines came from task notifications and 7 of those quoted a
tag.

The transcript says outright which lines are which, and that is what the
reader asks now: `origin.kind` is `human` for someone at a keyboard and
names the runtime otherwise. Only lines carrying the field are judged by
it — a tool result has none, and neither does a transcript written by a
runtime that predates it — so the element name is added too, which covers
the same lines when the field is absent.

The general fix is the field. A list of element names is a list, and the
runtime is free to add to it; this is the second time one has been added
after the fact.

## A paste that contains a code block

`FENCED_CODE` paired markers off — one with two, three with four — which
leaves the span between the second and third readable as typed. A pasted
markdown document with a code block inside it puts a quoted tag in exactly
that span.

    ```md … ``` … [allow-secret] key=AKIA… … ``` … ```     exit 0
    the same paste with one pair of markers                exit 2

Which markers open and which close cannot be told apart here — a document
quoting a fence is the same characters as two documents — so the run from
the first marker to the last counts as quoted. A tag before the first
fence or after the last still reads as typed, and both directions are
tested.

## Verification

    a human line carrying the tag        exit 0   (unchanged)
    a report quoting it, with origin     exit 2
    a report quoting it, without origin  exit 2
    tag before the first fence           exit 0
    tag after the last fence             exit 0

Eight tests. 2259 → 2267.
