### PR TITLE
fix: a search that names no path still searches somewhere

### DIFF
--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -79,6 +79,45 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
       expect(result.blocked).toBe(true);
     });
 
+    // `Grep {pattern}` with no `path` is the form Claude reaches for first, and
+    // it searches wherever the tool runs. With no field to collect there was
+    // nothing to scan, so the directory the search prints from was the one
+    // directory never looked at.
+    it("blocks a pathless search when a .env sits where it runs", () => {
+      const dir = writeFixture.path("grep-nopath-env");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, ".env"), `TOKEN=${TOKEN_VALUE}\n`, "utf8");
+      const result = runToolHook("Grep", { pattern: "TODO" }, { cwd: dir });
+      expect(result.exitCode).toBe(2);
+      expect(result.blocked).toBe(true);
+    });
+
+    // Names only, and this is the case that says so. A directory nobody named is
+    // every repository anyone searches; content-scanning those stopped a plain
+    // `rg TODO` in a third of the checkouts it was measured against, because a
+    // changelog quoting a connection string is enough.
+    it("allows a pathless search over ordinary files that mention secrets", () => {
+      const dir = writeFixture.path("grep-nopath-prose");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "CHANGELOG.md"),
+        `- redact a key such as ${AWS_KEY} in the terminal\n`,
+        "utf8",
+      );
+      const result = runToolHook("Grep", { pattern: "TODO" }, { cwd: dir });
+      expect(result.exitCode).toBe(0);
+    });
+
+    // A path that was named keeps the content scan: the user pointed at the
+    // directory, and reading it is answering what they asked.
+    it("still content-scans a directory the search names", () => {
+      const dir = writeFixture.path("grep-named-prose");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "notes.md"), `key=${AWS_KEY}\n`, "utf8");
+      const result = runGrepHook(dir);
+      expect(result.exitCode).toBe(2);
+    });
+
     // The other direction, so the case above is not passing on the sweep having
     // stopped skipping binaries altogether.
     it("still allows a directory of binaries with no env name", () => {

--- a/src/lib/__tests__/bash-commands.test.ts
+++ b/src/lib/__tests__/bash-commands.test.ts
@@ -105,6 +105,46 @@ describe("commands whose first operand is a pattern or a script", () => {
   );
 });
 
+// A searcher given no file searches where it runs. `rg PATTERN` is the ordinary
+// way to search a repository and names nothing, so there is no operand to
+// collect and the tree it prints from went unaccounted for.
+describe("a search that names no file", () => {
+  const searchesCwd = (command: string): boolean =>
+    extractCommandRefs(command).searchesWorkingDirectory;
+
+  it.each(["rg", "ag", "ack", "ugrep"])("%s alone searches here", (cmd) => {
+    expect(searchesCwd(`${cmd} pattern`)).toBe(true);
+  });
+
+  it.each(["rg", "ag", "ack", "ugrep"])(
+    "%s with a path named does not",
+    (cmd) => {
+      expect(searchesCwd(`${cmd} pattern src/`)).toBe(false);
+    },
+  );
+
+  // `grep` reads stdin unless it is asked to recurse, so the flag is what puts
+  // it in this class, one command at a time.
+  it.each(["grep -r", "grep -R", "grep --recursive", "grep -rn", "grep -in"])(
+    "`%s pattern` is judged on whether it recurses",
+    (prefix) => {
+      expect(searchesCwd(`${prefix} pattern`)).toBe(prefix !== "grep -in");
+    },
+  );
+
+  it("a plain grep reads stdin rather than the tree", () => {
+    expect(searchesCwd("grep pattern")).toBe(false);
+  });
+
+  it("a recursive grep with a path named does not search here", () => {
+    expect(searchesCwd("grep -r pattern src/")).toBe(false);
+  });
+
+  it("a flag after -- is an operand, not a request to recurse", () => {
+    expect(searchesCwd("grep pattern -- -r")).toBe(false);
+  });
+});
+
 describe("wrappers", () => {
   it.each([...WRAPPER_COMMANDS])(
     "%s is stepped past to reach the command it runs",

--- a/src/lib/bash-commands.ts
+++ b/src/lib/bash-commands.ts
@@ -374,6 +374,40 @@ export interface CommandRefs {
   envVars: string[];
   // Whether the command dumps the whole environment (bare `env` / `printenv`).
   dumpsEnvironment: boolean;
+  // Whether the command searches the working directory because it was given no
+  // file to search. `rg PATTERN` is the ordinary way to search a repository and
+  // names nothing, so there is no operand to collect and the whole tree it
+  // prints from went unscanned.
+  searchesWorkingDirectory: boolean;
+}
+
+// Searchers that walk the working directory when handed no path. The `grep`
+// family is not here: it reads stdin unless `-r` is given, and that flag is
+// what puts it in this class for the length of one command.
+const RECURSIVE_BY_DEFAULT = new Set(["rg", "ag", "ack", "ugrep"]);
+
+const GREP_FAMILY = new Set([
+  "grep",
+  "egrep",
+  "fgrep",
+  "zgrep",
+  "zegrep",
+  "zfgrep",
+]);
+
+// `-r`, `-R`, `--recursive`, and the letter inside a bundle such as `-rn`. A
+// bundle is read letter by letter because `grep -rn PATTERN` is how it is
+// usually typed.
+function asksForRecursion(operands: ShellToken[]): boolean {
+  for (const tok of operands) {
+    if (tok.redirect) continue;
+    const v = tok.value;
+    if (v === "--recursive" || v === "--dereference-recursive") return true;
+    if (v === "--") break;
+    if (!v.startsWith("-") || v.startsWith("--") || v.length < 2) continue;
+    if (/[rR]/.test(v.slice(1))) return true;
+  }
+  return false;
 }
 
 // Fold one set of refs into another. A command line yields refs from several
@@ -384,6 +418,8 @@ function mergeRefs(into: CommandRefs, refs: CommandRefs): void {
   into.paths.push(...refs.paths);
   into.envVars.push(...refs.envVars);
   into.dumpsEnvironment = into.dumpsEnvironment || refs.dumpsEnvironment;
+  into.searchesWorkingDirectory =
+    into.searchesWorkingDirectory || refs.searchesWorkingDirectory;
 }
 
 // What this hook knows about how a command treats its operands.
@@ -643,7 +679,12 @@ function isInlineCodeFlag(cmd: string, token: string): boolean {
 // Everything a Bash command reveals that the hook can inspect before it runs:
 // the files whose contents it may print, and the environment it may expose.
 export function extractCommandRefs(command: string, depth = 0): CommandRefs {
-  const refs: CommandRefs = { paths: [], envVars: [], dumpsEnvironment: false };
+  const refs: CommandRefs = {
+    paths: [],
+    envVars: [],
+    dumpsEnvironment: false,
+    searchesWorkingDirectory: false,
+  };
 
   if (depth > MAX_NESTING_DEPTH) return refs;
 
@@ -667,13 +708,19 @@ export function extractCommandRefs(command: string, depth = 0): CommandRefs {
     paths: [...new Set(refs.paths)],
     envVars: [...new Set(refs.envVars)],
     dumpsEnvironment: refs.dumpsEnvironment,
+    searchesWorkingDirectory: refs.searchesWorkingDirectory,
   };
 }
 
 // File paths one segment of a command line may print, plus anything found inside
 // inline program text it carries.
 function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
-  const refs: CommandRefs = { paths: [], envVars: [], dumpsEnvironment: false };
+  const refs: CommandRefs = {
+    paths: [],
+    envVars: [],
+    dumpsEnvironment: false,
+    searchesWorkingDirectory: false,
+  };
 
   const start = findCommandIndex(tokens);
   const cmdToken = tokens[start];
@@ -878,6 +925,18 @@ function collectSegmentRefs(tokens: ShellToken[], depth: number): CommandRefs {
     ) {
       refs.paths.push(tok.value);
     }
+  }
+
+  // A searcher handed no file searches where it is run. `rg PATTERN` and
+  // `grep -r PATTERN` are the ordinary forms and name nothing, so the loop above
+  // collects the pattern and stops with no path — and the tree they print from
+  // is the working directory. The caller is what knows which directory that is.
+  if (
+    refs.paths.length === 0 &&
+    (RECURSIVE_BY_DEFAULT.has(cmd) ||
+      (GREP_FAMILY.has(cmd) && asksForRecursion(operands)))
+  ) {
+    refs.searchesWorkingDirectory = true;
   }
 
   return refs;

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -83,6 +83,21 @@ interface TranscriptLine {
   message?: Message;
 }
 
+// Whether a tool is searching, and named nothing to search. `Grep` is the one
+// Claude Code ships; an MCP server offering the same thing is recognised by the
+// shape of its input rather than by name, since the names are the server's to
+// choose. A pattern with no path is a search of the working directory.
+function searchesWithoutAPath(
+  tool: string,
+  input: Record<string, unknown>,
+): boolean {
+  const searchTerm =
+    typeof input["pattern"] === "string" ||
+    typeof input["query"] === "string" ||
+    typeof input["regex"] === "string";
+  return searchTerm && (tool === "Grep" || tool.startsWith("mcp__"));
+}
+
 // Whether a transcript line records something a person typed.
 //
 // The field is only present on lines that have one, so a line without it is
@@ -635,16 +650,36 @@ function isRegularFile(candidate: string): boolean {
 function scanIfRegularFile(
   candidate: string | undefined,
   allowTags: Set<string>,
+  options: { namesOnly?: boolean } = {},
 ): void {
   if (!candidate) return;
   for (const p of expandCandidate(candidate)) {
-    if (isRegularFile(p)) scanFile(p, allowTags);
-    else for (const child of filesDirectlyUnder(p)) scanFile(child, allowTags);
+    if (isRegularFile(p)) {
+      if (options.namesOnly)
+        blockUnreadEnvFile(p, allowTags, SEARCH_ROOT_ENV_REASON);
+      else scanFile(p, allowTags);
+      continue;
+    }
+    for (const child of filesDirectlyUnder(p)) {
+      if (options.namesOnly)
+        blockUnreadEnvFile(child, allowTags, SEARCH_ROOT_ENV_REASON);
+      else scanFile(child, allowTags);
+    }
   }
 }
 
+const UNREAD_ENV_REASON =
+  "Its contents were not read — it is not a regular file, or the scan for this call had already stopped — so the name is what decides.";
+
+const SEARCH_ROOT_ENV_REASON =
+  "The search names no path, so it runs here and prints from whatever it matches. This file was not read; it is the name that decides.";
+
 // A `.env` file that will not be read is judged on its name, template or not.
-function blockUnreadEnvFile(filePath: string, allowTags: Set<string>): void {
+function blockUnreadEnvFile(
+  filePath: string,
+  allowTags: Set<string>,
+  reason: string = UNREAD_ENV_REASON,
+): void {
   if (!isEnvName(filePath) || !ENABLED_CATEGORIES.has("secret")) return;
   // A path that names nothing has nothing to leak. `cat .env.example` in a
   // checkout without one is an ordinary command, and the plain `.env` guard
@@ -653,11 +688,7 @@ function blockUnreadEnvFile(filePath: string, allowTags: Set<string>): void {
   if (allowTags.has("secret") || allowTags.has("all")) return;
   block(
     filePath,
-    [
-      ENV_BLOCK_REASON,
-      "",
-      "Its contents were not read — it is not a regular file, or the scan for this call had already stopped — so the name is what decides.",
-    ],
+    [ENV_BLOCK_REASON, "", reason],
     buildAllowHints(`please read ${forOutput(filePath)}`, [], true),
   );
 }
@@ -1147,6 +1178,12 @@ process.stdin.on("end", () => {
     }
 
     scanPathsLiteralsFirst(refs.paths, allowTags);
+    // `rg PATTERN` and `grep -r PATTERN` name nothing and print from the working
+    // directory. Judged on names alone, for the reason set out where the same
+    // thing is done for the search tools.
+    if (refs.searchesWorkingDirectory) {
+      scanIfRegularFile(baseDirectory, allowTags, { namesOnly: true });
+    }
 
     process.exit(0);
   }
@@ -1203,8 +1240,24 @@ process.stdin.on("end", () => {
     // what it is handed — so the command fields above are read whatever the name
     // says, and only the path fields are exempt.
     if (!isWritingTool(tool)) {
-      for (const candidate of collectPathFields(input)) {
+      const candidates = collectPathFields(input);
+      for (const candidate of candidates) {
         scanIfRegularFile(candidate, allowTags);
+      }
+      // A search tool given no path searches where it is run, and that is its
+      // ordinary form: `Grep {pattern}` with no `path` is what Claude reaches
+      // for first. With no field to collect there is nothing to scan, so the
+      // directory the search prints from is the one directory never looked at.
+      //
+      // Names only. A directory the user pointed at is one they asked about, and
+      // reading its files is answering the question they asked; a directory
+      // nobody named is every repository anyone searches, and content-scanning
+      // those stopped an ordinary `rg TODO` in a third of the checkouts on this
+      // machine — a README quoting a connection string is enough. The name guard
+      // keeps the case worth keeping, since a `.env` sitting in the search root
+      // is both the likeliest leak and the one no pattern has to match for.
+      if (candidates.length === 0 && searchesWithoutAPath(tool, input)) {
+        scanIfRegularFile(baseDirectory, allowTags, { namesOnly: true });
       }
     }
   }


### PR DESCRIPTION
fix: a search that names no path still searches somewhere

The default form of every search was unscanned.

    Grep {pattern: "AWS", path: "."}      exit 2
    Grep {pattern: "AWS"}                 exit 0
    grep -r AWS .                         exit 2
    grep -r AWS                           exit 0
    rg AWS                                exit 0

Measured with a live AWS key in the working directory's `.env`. `rg` is
what Claude reaches for first, and it walks the tree from where it runs.
`collectPathFields` returns only fields that are present, and there is no
field here to be present; on the Bash side the pattern is consumed as the
first operand and nothing is left to collect.

A searcher handed no file now resolves to the working directory. `rg`,
`ag`, `ack` and `ugrep` recurse by default; the `grep` family reads stdin
unless `-r` or `-R` is given, so the flag is what puts it in that class
for one command, bundles (`-rn`) included and `--` respected.

## Names only, and why

Scanning the contents of a directory nobody named is too much. Measured
across the git checkouts on this machine, content-scanning the working
directory stopped a plain `rg TODO` in **four of twelve** — a changelog
quoting a connection string is enough, and a tool that stops an ordinary
search is a tool that gets uninstalled.

So the two cases are separated. A directory the user pointed at is one
they asked about, and reading its files answers the question they asked;
a directory only implied by a pathless search is judged on names alone.
That keeps the case worth keeping — a `.env` in the search root is both
the likeliest leak and the one no pattern has to match for — and drops the
rate to **one of twelve**, which is a checkout with a real `.env` in it.

    directories: 12   blocked: 4   (contents)
    directories: 12   blocked: 1   (names)

The message for that block says why the file was not read, rather than
reusing the wording about a scan that had already stopped.

## Verification

    rg with a secret in cwd            exit 2
    rg in a clean directory            exit 0
    rg in this repository              exit 0
    grep with no -r                    exit 0   (reads stdin)
    Grep naming a directory            exit 2   (contents, unchanged)

Twenty-seven tests, both directions of each. 2259 → 2286.
