### PR TITLE
test: hold every rule to the defect one of them had

### DIFF
--- a/src/lib/__tests__/rule-patterns.test.ts
+++ b/src/lib/__tests__/rule-patterns.test.ts
@@ -307,6 +307,87 @@ describe("every rule catches something", () => {
     if (example === undefined) throw new Error(`no example for ${id}`);
     expect(scan(example).map((f) => f.ruleId)).toContain(id);
   });
+
+  // A credential longer than the pattern guessed must not become invisible.
+  //
+  // This is the defect the Square rule had, generalised: an exact length with a
+  // negative lookahead behind it has no shorter match to fall back to, so one
+  // character over the guess stopped the token matching at all. Every vendor
+  // length in this file is a guess about someone else's format, so the check is
+  // run over every rule rather than the ones anyone suspected — the example is
+  // padded with more of the characters it already ends in.
+  // The rules a longer value legitimately does not belong to. Each is exact
+  // because the format is, not because a length was guessed: a checksum fixes
+  // the digits, or the credential is a fixed-width field. Anything not listed
+  // has to survive the padding, so a new rule with a guessed upper bound fails
+  // here rather than going quiet in a release.
+  const LONGER_IS_A_DIFFERENT_THING: Record<string, string> = {
+    "aws-access-key": "twenty characters exactly; a longer run is not a key",
+    "databricks-token": "dapi and thirty-two hex; longer is a digest",
+    "shopify-token": "a prefix and thirty-two hex; longer is a digest",
+    "twilio-sid": "thirty-four characters; longer is a certificate digest",
+    "pii-email": "padding the end writes a different domain",
+    "pii-credit-card": "the checksum fixes the digits",
+    "pii-ssn": "nine digits; a longer run is not one",
+    "pii-mynumber-jp": "twelve digits with a check digit",
+    "pii-nir-fr": "fifteen digits with a two-digit key",
+    "pii-codice-fiscale-it": "sixteen characters, checksummed",
+    "pii-steuer-id-de": "eleven digits with a check digit",
+    "pii-dni-nie-es": "eight digits and a checksum letter",
+    "pii-rrn-kr": "thirteen digits with a check digit",
+    "pii-brn-kr": "ten digits with a check digit",
+    "pii-resident-id-cn": "eighteen characters with a check digit",
+    "pii-phone-us": "a dialling plan fixes the length",
+    "pii-phone-jp": "ten or eleven digits",
+    "pii-phone-fr": "ten digits",
+    "pii-phone-it": "a dialling plan fixes the length",
+    "pii-phone-de": "a dialling plan fixes the length",
+    "pii-phone-es": "nine digits",
+    "pii-postal-code": "five digits",
+    "pii-postal-cn": "six digits",
+    "pii-ipv4-public": "four octets",
+  };
+
+  // The list above is a list, so it is held to the rules that exist: an id left
+  // in it after its rule is renamed or dropped would silently stop anything
+  // being checked.
+  it("exempts only rules that are shipped", () => {
+    const ids = new Set(DEFAULT_RULES.map((r) => r.id));
+    const stale = Object.keys(LONGER_IS_A_DIFFERENT_THING).filter(
+      (id) => !ids.has(id),
+    );
+    expect(stale).toEqual([]);
+  });
+
+  const alphabetFor = (example: string): string => {
+    const tail = example.slice(-12);
+    if (/^[0-9]+$/.test(tail)) return "0123456789";
+    if (/^[a-f0-9]+$/i.test(tail)) return "abcdef0123456789";
+    if (/^[a-z0-9]+$/.test(tail)) return "abcdefghijklmnopqrstuvwxyz0123456789";
+    return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  };
+
+  const padded = (example: string, extra: number): string => {
+    const alphabet = alphabetFor(example);
+    let out = example;
+    for (let i = 0; i < extra; i++) out += alphabet[i % alphabet.length];
+    return out;
+  };
+
+  it.each(
+    DEFAULT_RULES.map((r) => r.id).filter(
+      (id) => !(id in LONGER_IS_A_DIFFERENT_THING),
+    ),
+  )("%s still finds a value that runs longer", (id) => {
+    const example = EXAMPLES[id];
+    if (example === undefined) throw new Error(`no example for ${id}`);
+    for (const extra of [1, 8, 64]) {
+      expect(
+        scan(padded(example, extra)).map((f) => f.ruleId),
+        `${id} with ${extra} more characters`,
+      ).toContain(id);
+    }
+  });
 });
 
 // Every rule has an example, and the test above enforces that. What no example

--- a/src/lib/__tests__/shapes.test.ts
+++ b/src/lib/__tests__/shapes.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { scan } from "../rules.ts";
-import { entropy, isNotSecretShaped } from "../shapes.ts";
+import {
+  entropy,
+  isNotSecretShaped,
+  MIN_MEAN_WORD_LENGTH,
+  readsAsWords,
+  SHORTEST_MEASURABLE_SEGMENT,
+} from "../shapes.ts";
 import { isRealAwsKey } from "../validators.ts";
 import { AWS_KEY, ruleIds } from "./rule-fixtures.ts";
 
@@ -311,5 +317,62 @@ describe("env-assignment does not read code as a secret", () => {
         file,
       ).toEqual([]);
     }
+  });
+});
+
+// A threshold tested at one point says nothing about where it sits. Each of
+// these was chosen from a measurement, and the pair of cases is what stops it
+// drifting: the UTF-16 defect in this release was exactly a number with a case
+// on one side of it and none on the other.
+describe("each threshold, from both sides", () => {
+  // A segment shorter than this is a word by default, because the statistic has
+  // nothing to average over. At the length itself it is measured.
+  describe("the shortest segment worth measuring", () => {
+    // Alternating case, which fails the word test wherever it is applied. Below
+    // the length it is not applied, which is the whole of the difference.
+    const alternating = (length: number): string =>
+      Array.from({ length }, (_, i) => (i % 2 === 0 ? "a" : "B")).join("");
+
+    it("a segment one under the length is taken on trust", () => {
+      expect(readsAsWords(alternating(SHORTEST_MEASURABLE_SEGMENT - 1))).toBe(
+        true,
+      );
+    });
+
+    it("a segment at the length is measured", () => {
+      expect(readsAsWords(alternating(SHORTEST_MEASURABLE_SEGMENT))).toBe(
+        false,
+      );
+    });
+  });
+
+  // Mean word length: how many characters run between one camelCase boundary
+  // and the next.
+  describe("the mean word length that separates a name from a token", () => {
+    // Words of a chosen size, so the mean lands either side of the threshold by
+    // construction rather than by luck.
+    const wordsOf = (size: number, count: number): string =>
+      Array.from(
+        { length: count },
+        (_, i) => (i === 0 ? "a" : "A") + "b".repeat(size - 1),
+      ).join("");
+
+    it("words shorter than the threshold read as a token", () => {
+      const value = wordsOf(2, 6);
+      expect(value.length / 6).toBeLessThan(MIN_MEAN_WORD_LENGTH);
+      expect(readsAsWords(value)).toBe(false);
+    });
+
+    it("words longer than the threshold read as a name", () => {
+      const value = wordsOf(3, 4);
+      expect(value.length / 4).toBeGreaterThan(MIN_MEAN_WORD_LENGTH);
+      expect(readsAsWords(value)).toBe(true);
+    });
+
+    // And the consequence, which is what the threshold is for.
+    it("a dotted name is a reference and a dotted token is not", () => {
+      expect(isNotSecretShaped(`config.${wordsOf(3, 4)}`)).toBe(true);
+      expect(isNotSecretShaped(`config.${wordsOf(2, 6)}`)).toBe(false);
+    });
   });
 });

--- a/src/lib/default-config.json
+++ b/src/lib/default-config.json
@@ -65,7 +65,7 @@
     {
       "id": "telegram-bot-token",
       "description": "Telegram Bot Token",
-      "regex": "\\b[0-9]{6,12}:AA[0-9A-Za-z_-]{30,40}\\b",
+      "regex": "\\b[0-9]{6,12}:AA[0-9A-Za-z_-]{30,128}\\b",
       "category": "secret"
     },
     {


### PR DESCRIPTION
test: hold every rule to the defect one of them had

Four holes shipped in this release cycle and three were the same shape: a
number with a case on one side of it and none on the other, or a form of
an input nobody wrote a case for. Cases are added one at a time; these
are asked of everything.

## A longer credential is still a credential

The Square rule guessed a length and put a negative lookahead behind it,
so one character over the guess stopped the token matching at all rather
than matching partly. Every vendor length in the config is a guess about
someone else's format, so the check runs over every rule: take the rule's
own example, pad it with more of the characters it already ends in, and
require the rule to still report.

Twenty-four rules are exempt, each with the reason written beside it, and
each exact because the format is — a checksum fixes the digits, or the
field is fixed width. Anything not on that list has to survive the
padding, so a new rule with a guessed upper bound fails here instead of
going quiet in a release. A second test holds the exemption list to the
rules that exist, so an id left behind after a rename cannot silently
stop anything being checked.

It found one: `telegram-bot-token` capped its secret part at 40 and went
invisible at 41. Widened to 128, which is still bounded — the unbounded
version of this is what made a megabyte of Square prefixes take twelve
seconds.

## Both sides of each threshold

`MINIMUM_NULS`, `SHORTEST_MEASURABLE_SEGMENT` and `MIN_MEAN_WORD_LENGTH`
are each a number chosen from a measurement, and a case above a threshold
says nothing about where it sits. Each now has a case on each side,
written from the constant rather than from a value that happens to fall
there, so moving the constant moves the tests with it.

    a segment one under the length   taken on trust
    a segment at the length          measured
    words of two characters          a token
    words of three                   a name

2320 → 2378.
