### PR TITLE
docs: say what the code does, and hold the documents to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## v0.8.0 (2026-08-16)
 
+### Breaking changes
+
+- **Two allow tags no longer add up.** Tags were resolved per category with the
+  first occurrence winning; the last tag now replaces the earlier ones whole.
+  `[allow-secret] [allow-pii]` resolves to the second tag alone, where in 0.7.0
+  it granted both — **`[allow-all]` is how both are asked for**. The change is
+  the other direction being wrong: `[allow-all]` narrowed to `[allow-secret]`
+  went on allowing PII, which is the opposite of what narrowing means and the
+  unsafe one of the two possible mistakes
+- **A tag written by anything other than a person no longer counts.** A line the
+  runtime writes under the user's role — a background task reporting back, most
+  often — is skipped, so an agent's report that quotes `[allow-all]` no longer
+  lifts the guard for the next tool call. A workflow that relied on a tag
+  arriving from a subagent's output has to write the tag in a prompt instead
+- **A tag between two fenced blocks is read as quoted.** Text from the first
+  fence marker in a message to the last is quoting, where before the markers
+  were paired off and the span between the second and third read as typed. A tag
+  before the first fence or after the last still counts
+
 ### Features
 
 - Parse Bash commands as shell syntax rather than by splitting on whitespace.
@@ -109,6 +128,51 @@
 
 ### Fixes
 
+- Read a file both ways when its encoding is a guess. Eight NUL pairs — sixteen
+  bytes — in front of a UTF-8 file were enough for `detectUtf16` to call it
+  UTF-16, and the rest of it then decoded into characters no rule matches. The
+  counts cannot separate the two cases: a UTF-8 file with a few NULs on one side
+  of its pairs looks exactly like a page of Japanese UTF-16, where `一` (U+4E00)
+  puts a NUL on the minority side. A verdict that did not come from a
+  byte-order mark is marked as a guess and both readings are scanned. The same
+  cap was excluding real documents: thirty lines of Japanese with one `一`
+  apiece were not read as UTF-16 at all
+- Keep an `.env` in a swept directory whatever its bytes look like. The sweep
+  skips binaries so that a folder of images is not ground through every rule,
+  and that skip ran before the name guard, so eight bytes of NUL at the head of
+  a `.env` took the strongest guard in the tool out of the sweep
+- Do not honour a tag written by anything other than a person. A background task
+  reporting back arrives under the user's role carrying an agent's prose, and
+  prose about these tags was enough — a report quoting the documentation armed
+  the guard it was describing. The transcript says which lines are which, and
+  that is what the reader asks now
+- Read the run from the first fence marker to the last as quoted. Pairing the
+  markers off left the span between the second and third readable as typed, and
+  a pasted markdown document with a code block inside it puts a quoted tag in
+  exactly that span
+- Scan somewhere when a search names no path. `rg pattern`, `grep -r pattern`
+  and `Grep {pattern}` with no `path` all print from the working directory, and
+  with no field to collect there was nothing to scan. Judged on names alone: a
+  directory nobody named is every repository anyone searches, and reading their
+  contents stopped a plain `rg TODO` in four of twelve checkouts
+- Correct the boundaries of six rules. Discover's `65` range stopped at 6589;
+  the card alternatives all assumed groups of four, where Amex prints 4-6-5 and
+  Diners 4-6-4; Square's exact length meant one character over the guess stopped
+  the token matching at all rather than matching partly; `twilio-sid` had no
+  word boundary, so a certificate fingerprint was an Account SID;
+  `telegram-bot-token` capped its secret part at 40 and went invisible at 41;
+  and `pii-email` excluded `zip` at the TLD position as though a list of file
+  extensions were a list of domains
+- Stop treating every dotted value as a reference to code. `isNotSecretShaped`
+  waved through anything shaped `a.b.c`, and dotted credentials exist. What
+  separates them is that a name is words: measured over 147,643 dotted
+  identifiers from source on this machine, 0.06% fall below a mean word length
+  of 2.5, and the ones that do are JWTs
+- Redact by code point. Slicing by code unit cut a surrogate pair in half and
+  wrote a lone surrogate to the terminal
+- Match the placeholder rule's connection-string pattern once rather than three
+  times, and bound its scheme: an unbounded `\w+` in front of a literal that is
+  usually absent is quadratic in the length of a value someone else writes
 - Make the email rule near-linear on its worst input. The local part
   (`[A-Za-z0-9._%+-]+`) spans the word boundary at every dot, so on a long run
   of digits and separators with no `@` — a log full of IP addresses or version

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | Without sensitive-canary | With sensitive-canary |
 |--------------------------|----------------------|
 | `cat .env` → full contents sent to Claude ❌ | Blocked by name before Claude reads it ✅ |
-| Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
+| Paste a live AWS key in a prompt ❌ | Blocked before the API call is made ✅ |
 | `Read customers.csv` full of email addresses ❌ | PII detected before Claude sees the file ✅ |
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 | `cat docker-compose.yml` with `POSTGRES_PASSWORD:` ❌ | Assignment detected in YAML and JSON too ✅ |
@@ -175,11 +175,14 @@ Then add to `~/.claude/settings.json`:
 Prompts containing secrets or PII are blocked before being sent.
 
 ```
-> My AWS key is AKIAIOSFODNN7EXAMPLE. Can you review this code?
+> Here is my deploy key:
+> -----BEGIN RSA PRIVATE KEY-----
+> MIIEowIBAAKCAQEAwK3vJ9m5Q8xY2nB4dF6hL0pR7sT1uV3wX5yZ8aC2eG4iK6mO
+> Can you review the config that uses it?
 
-🐤  sensitive-canary: sensitive data detected — blocked
+🐦 sensitive-canary: sensitive data detected — blocked
 
-  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
+  [Secret] PEM Private Key (private-key): ---****KEY
 
 To allow, add a tag to your prompt:
   [allow-secret]  — allow secrets
@@ -189,7 +192,7 @@ To allow, add a tag to your prompt:
 To allow it through, add the suggested tag:
 
 ```
-> [allow-secret] My AWS key is AKIAIOSFODNN7EXAMPLE. Can you review this code?
+> [allow-secret] Here is my deploy key: -----BEGIN RSA PRIVATE KEY-----
 ```
 
 ### .env file blocked
@@ -529,10 +532,11 @@ The terminal also receives a direct message (via `/dev/tty`).
 - **git history references** — `git show HEAD:.env` and similar references to objects in git history (not on disk) are not scanned, since the object does not exist as a file path.
 - **Unlisted commands** — the set of commands known to print file contents is a list, not an analysis of the command. A printing command that is not on the list is not caught.
 - **A template holding a real credential is blocked** — `.env.example` and its siblings are exempt from the name guard, not from the scan. Placeholders (`your-token-here`, `REPLACE_ME`, `changeme`, `<token>`, `postgres://user:password@localhost/db`) are recognised and left alone, but a template committed with a live key is blocked like any other file, through printing commands (`grep KEY .env.example`) as much as through `Read`. Use `[allow-secret]` if that is deliberate.
-- **Anything past the first NUL byte of a file** — a file's text prefix is scanned and the rest is dropped, so that a binary is not ground through every rule. A file that uses NUL as a separator rather than as binary content is therefore barely scanned: `/proc/self/environ` on Linux holds the whole environment, and only the first variable of it is seen.
-- **Anything that is not a regular file** — a directory, a FIFO, a process substitution (`/dev/fd/63`) and `/dev/stdin` are not read, so `cat` of one is not scanned. The directory case is what leaves the Grep tool's `path` and a recursive `grep -r pattern src/` alone, both of which would otherwise mean reading every file underneath. Reading them can never reach the end of the file: `cat /dev/zero` held the hook open until Claude Code's PreToolUse timeout killed it, and a killed hook does not block the call. Not scanning them is the lesser of the two, since a hang lets the call through as well.
+- **A binary swept up by a directory being named** — the files under a directory are scanned because the directory was named, and one whose first four kilobytes read as neither text nor UTF-16 is skipped rather than ground through every rule. A file named outright is scanned whatever its bytes look like, and so is an `.env` in a swept directory: the name decides that one when the contents cannot.
+- **Anything that is not a regular file** — a FIFO, a process substitution (`/dev/fd/63`) and `/dev/stdin` are not read, so `cat` of one is not scanned. Reading them can never reach the end of the file: `cat /dev/zero` held the hook open until Claude Code's PreToolUse timeout killed it, and a killed hook does not block the call. Not scanning them is the lesser of the two, since a hang lets the call through as well. A directory is not read either, but it is not left alone: the files directly under it are scanned, one level and no further.
+- **A search that names no path is judged on names alone** — `rg pattern`, `grep -r pattern` and `Grep {pattern}` with no `path` all print from the working directory, so that directory is checked for an `.env` and its siblings. Its other files are not read. A directory the user named is one they asked about and its contents are scanned; a directory only implied by a search is every repository anyone works in, and reading those stopped a plain `rg TODO` in a third of the checkouts it was measured against.
 - **`~user/…` is not expanded** — `~` and `~/…` are resolved to the home directory, but the form naming another user needs the password database, and guessing would name the wrong file.
-- **A file whose text is not bytes the scanner reads as text** — scanning stops at the first NUL byte, which is what keeps a binary from being ground through every pattern. UTF-16 is the exception and is decoded first, by its byte-order mark or by which side of each byte pair the zeros fall on. A file that carries no zeros at all in its first sixteen kilobytes — text in a script with no Latin characters and no line breaks — is not recognised as UTF-16 and is read to its first zero byte.
+- **A file in an encoding neither reading recovers** — every run of text between NUL bytes is scanned, and UTF-16 is decoded first: by its byte-order mark, or by NULs falling on one side of each pair through the first sixteen kilobytes. Without a mark that verdict is a guess, so both readings are scanned and a wrong guess hides nothing. What is left out is an encoding that is neither: a file in Shift_JIS or GBK is read as the bytes it is, and a credential written in one of those character sets is not found. An ASCII credential inside such a file still is.
 - **A shell construct that names the file only at run time** — `for f in secrets; do cat "$f"; done` and `find . -name secrets -exec cat {} +` both name the file in the command line, but the hook classifies the command it can see, and in these the reading command is `cat` reached through a loop or through `find`'s own argument list.
 - **At most 64 MiB is read across one tool call** — the per-file cut bounds one file; this bounds the call. A glob naming three hundred large files took half a minute, which is long enough for the PreToolUse timeout to kill the hook, and a killed hook does not block. Files past the budget are not scanned, so naming enough large files before the one that matters is a way past the scan.
 - **A relative path is resolved against the directory Claude Code reports** — and against a literal `cd` at the start of the same command. A `cd` later in the line, one inside a subshell, and one whose argument is a variable, a glob or `-` are all left alone, because where they land cannot be worked out here. A directory changed some other way is the same case.
@@ -560,14 +564,14 @@ Allow tags filter the scan results — the scan still runs, including for a `.en
 If you include a mask tag, sensitive-canary will explain this and list what was detected:
 
 ```
-> [mask-secret] My key is AKIAIOSFODNN7EXAMPLE, can you review this?
+> [mask-secret] My deploy key is -----BEGIN RSA PRIVATE KEY----- , can you review this?
 
 🐦 sensitive-canary: prompt masking is not supported
 
   [mask-secret] cannot mask prompt content.
   The following sensitive data was detected:
 
-  [Secret] AWS Access Key ID (aws-access-key): AKIA****MPLE
+  [Secret] PEM Private Key (private-key): ---****KEY
 
   Please choose one of the following:
 
@@ -579,13 +583,19 @@ If you include a mask tag, sensitive-canary will explain this and list what was 
 
 ### Allow + Mask tag priority
 
-When both `[allow-*]` and `[mask-*]` tags appear in the same prompt, **the tag that appears first wins** for each category (`secret`, `pii`). `[allow-all]` and `[mask-all]` resolve both categories at once.
+When more than one tag appears, **the last one wins**. It replaces the earlier ones entirely rather than combining with them, so changing your mind mid-message works the way it reads.
 
-| Example | Result |
-|---------|--------|
-| `[allow-secret] [mask-secret] …` | secret allowed |
-| `[mask-secret] [allow-secret] …` | masking not supported error |
-| `[allow-secret] [mask-pii] …` | secret allowed, PII mask error |
+| Example | secret | pii |
+|---------|--------|-----|
+| `[allow-all] … [allow-secret]` | allow | blocked |
+| `[allow-secret] … [allow-all]` | allow | allow |
+| `[allow-secret] … [mask-secret]` | mask (unsupported) | blocked |
+| `[mask-secret] … [allow-secret]` | allow | blocked |
+| `[allow-secret] … [allow-pii]` | blocked | allow |
+
+The last line is the one to watch: two tags do not add up. Narrowing from `[allow-all]` to `[allow-secret]` really does put PII back under guard, which is the point — but so does writing `[allow-secret] [allow-pii]` and expecting both. **`[allow-all]` is how you ask for both.**
+
+A tag counts wherever it appears in the message, mid-sentence included. What does not count is a tag inside a fenced code block, inside one of the elements Claude Code writes around command output, or in a line the runtime wrote rather than you — a compaction summary, a skill body, or a background task reporting back. Those are quoting, not asking.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,7 @@ sensitive-canary is a best-effort guard, not a guaranteed security boundary:
 
 All scanned content is processed in memory and immediately discarded. Detected findings are:
 
-- Displayed in the terminal (redacted: first 4 + last 4 chars, middle masked as `****`)
+- Displayed in the terminal, redacted to at most a quarter of the value: an eighth from each end, never more than four characters a side, and nothing at all below eight characters. A twenty-character key shows two characters at each end (`AK****RS`), which is enough to tell two findings apart and not enough to be one
 - Returned to Claude as a structured block reason (redacted)
 - Never written to disk or sent anywhere
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Claude Code is a powerful development tool, but file reads and command execution
 | Without Sensitive Canary | With Sensitive Canary |
 |--------------------------|----------------------|
 | `cat .env` → full contents sent to Claude ❌ | Blocked by name by default before Claude reads it ✅ |
-| Paste `AKIAIOSFODNN7EXAMPLE` in prompt ❌ | Blocked before the API call is made ✅ |
+| Paste a live AWS key in a prompt ❌ | Blocked before the API call is made ✅ |
 | `Read customers.csv` full of email addresses ❌ | PII detected before Claude sees the file ✅ |
 | `echo $API_KEY` with live key ❌ | Env var value scanned and blocked ✅ |
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,12 +29,17 @@ exit 2 stops a tool call, so a hook that fails to start is silent. This step is
 not optional.
 
 ```bash
-printf 'key=AKIA''IOSFODNN7EXAMPLE\n' > /tmp/canary-check.txt
+printf -- '-----BEGIN RSA PRIVATE KEY-----\n' > /tmp/canary-check.txt
 ```
 
 Ask Claude to read `/tmp/canary-check.txt`. It should refuse and say why. If it
-reads the file and shows you the key, the hooks are not running — see
+reads the file and shows you what is in it, the hooks are not running — see
 [Troubleshooting](/troubleshooting).
+
+A private-key header is the fixture here because it carries no key material and
+is recognised on its own. AWS's documented `AKIAIOSFODNN7EXAMPLE` will not do:
+it appears in AWS's own setup guides and in READMEs that copy them, so this tool
+reads it as documentation and allows it.
 
 ### Updating
 
@@ -117,13 +122,18 @@ An installation that checks nothing looks exactly like one that works, so this
 step is not optional. Run the hook by hand and read the exit code:
 
 ```bash
-printf 'key=AKIA''IOSFODNN7EXAMPLE\n' > /tmp/canary-check.txt
+printf -- '-----BEGIN RSA PRIVATE KEY-----\n' > /tmp/canary-check.txt
 printf '{"tool_name":"Read","tool_input":{"file_path":"/tmp/canary-check.txt"}}' \
   | node <dist>/pre-tool-use-hook.js; echo "exit=$?"
 ```
 
 `exit=2` means it is working. Anything else — 0, 1, or a module-not-found error
 — means the path is wrong and nothing is being checked.
+
+The fixture is a private-key header rather than a key: it carries no key
+material and is recognised on its own. AWS's documented `AKIAIOSFODNN7EXAMPLE`
+would report `exit=0` here, because this tool reads it as the documentation it
+is — see [Rules](/rules).
 
 
 ## Manual Setup (git clone)
@@ -217,7 +227,7 @@ Runs before Claude uses `Read`, `Bash`, `Grep` or any MCP tool. It blocks:
 - `.env` and `.env.*` files by filename (a secret guard; only while the `secret` category is enabled)
 - Any file whose contents contain secrets or PII
 - `cat`, `head`, `tail`, and other file-reading commands targeting sensitive files
-- Bash commands containing secrets inline (e.g. `echo AKIAIOSFODNN7EXAMPLE`)
+- Bash commands containing secrets inline (e.g. `echo ghp_…`)
 - Environment variables referenced in Bash commands whose values contain secrets
 
 ## Allow Tags

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -277,7 +277,7 @@ Files that end in `.env` but don't start with a dot (e.g. `production.env`) are 
 When Claude uses the `Bash` tool, sensitive-canary checks three things:
 
 1. **Environment variables** — any `$VAR` or `${VAR}` references in the command are looked up in the current environment; if their values contain secrets or PII, the command is blocked.
-2. **Command string** — the raw command is scanned (catches inline secrets like `echo AKIAIOSFODNN7EXAMPLE`).
+2. **Command string** — the raw command is scanned, which catches a secret written inline (`echo ghp_…`, `curl -H "Authorization: Bearer …"`).
 3. **File-reading commands** — the target files are read and scanned before the command runs. The set is the one in `src/lib/bash-commands.ts`: around forty commands that print their operands (`cat`, `head`, `xxd`, `zcat`, `iconv`, `comm`, …), a second class whose first argument is a pattern and whose rest are files (`grep`, `sed`, `awk`, `jq`, `zgrep`, …), the git subcommands that print contents, `dd if=`, and inline program text. Compound commands using `|`, `;`, `&&`, `||` are split and each segment is checked independently. README's "How it works" has the full picture.
 
 ### Ways a rule goes quiet without saying so

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -5,6 +5,7 @@ import {
   compileRule,
   enabledCategoriesFromEnv,
   parseCategories,
+  scan,
 } from "../rules.ts";
 import { VALIDATOR_NAMES } from "../validators.ts";
 import { DEFAULT_RULES } from "./rule-fixtures.ts";
@@ -89,6 +90,43 @@ describe("the documents and the registry agree", () => {
         !rulesDocText.includes(`\`${name}\``),
     );
     expect(undocumented).toEqual([]);
+  });
+
+  // The counts the README puts in its section headings. A rule added to the
+  // config and not to the table below it leaves the heading wrong, which is how
+  // a reader finds out whether the list they are reading is the list that ships.
+  it.each([
+    ["Secrets", "secret" as const],
+    ["PII", "pii" as const],
+  ])("the %s heading states the number that ships", (heading, category) => {
+    const shipped = DEFAULT_RULES.filter((r) => r.category === category).length;
+    expect(readmeText).toContain(`### ${heading} (${shipped} rules)`);
+  });
+
+  // The step the install guide calls not optional. Its fixture has to be one
+  // this tool actually blocks — AWS's documented key was the fixture until the
+  // `aws-key` validator started reading it as the documentation it is, at which
+  // point the guide told every new user their installation was broken.
+  it("the install guide verifies with something that is blocked", () => {
+    const installText = docText("../../../docs/install.md");
+    const fixtures = [...installText.matchAll(/printf -- '([^']+)'/g)].map(
+      (m) => (m[1] ?? "").replace(/\\n/g, "\n"),
+    );
+    expect(fixtures.length).toBeGreaterThan(0);
+    for (const fixture of fixtures) {
+      expect(scan(fixture), `printf -- '${fixture.trim()}'`).not.toEqual([]);
+    }
+  });
+
+  // Both documents describe the same tag resolution, and one of them was left
+  // behind when it changed. Each has to say which way it goes, and neither may
+  // still say the other.
+  it.each([
+    ["README.md", () => readmeText],
+    ["docs/rules.md", () => rulesDocText],
+  ])("%s states the tag priority that ships", (_name, text) => {
+    expect(text()).toContain("the last one wins");
+    expect(text()).not.toContain("appears first wins");
   });
 
   // A configuration can switch a rule off without warning, in ways somebody


### PR DESCRIPTION
docs: say what the code does, and hold the documents to it

## The install check reported a broken install on a working one

`docs/install.md` calls its verification step not optional, and its
fixture was AWS's documented `AKIAIOSFODNN7EXAMPLE`. The `aws-key`
validator reads that key as the documentation it is, so the step every
new user is told to run returned the exit code it says means the hooks
are not running.

    printf 'key=AKIA''IOSFODNN7EXAMPLE\n' > /tmp/canary-check.txt
    … | node dist/pre-tool-use-hook.js; echo "exit=$?"
    exit=0        # "means the path is wrong and nothing is being checked"

The fixture is a private-key header now: no key material, recognised on
its own, safe to write literally. Both install paths, and the guide says
why that key will not do.

The same key was the front-page demonstration in `README.md` and
`docs/index.md`, the prompt in three worked examples, and the inline
example in two places. All replaced, and the worked examples are the real
output of the real hook rather than prose.

## What the documents said that the code does not

- The tag priority table in `README.md` still described first-wins. All
  three of its rows produced the opposite result. `docs/rules.md` was
  correct and is now what the README says too
- `SECURITY.md` described the redaction as first four plus last four. It
  is at most a quarter of the value — a twenty-character key shows two a
  side
- Two Known Limitations were fixed releases ago and still listed: text
  past the first NUL byte is scanned, and a directory named by a search
  is not left alone. Rewritten to what is actually left out — an encoding
  that is neither UTF-8 nor UTF-16, and the contents of a directory only
  implied by a pathless search

## The changelog

A **Breaking changes** section, which the file had none of. Three entries
belonged in one: two tags no longer add up, a tag written by anything
other than a person no longer counts, and a tag between two fenced blocks
reads as quoted. Every user-visible change from this round's six fixes is
written up under Fixes.

## Held to it from now on

Doc drift caused two of the findings this round, so the claims that can be
checked are checked, beside the validator-coverage test that was already
there:

    the Secrets and PII headings state the counts that ship
    the install guide verifies with something that is blocked
    both documents state the tag priority that ships

The last one asserts the absence of the old wording as well as the
presence of the new, since a document can gain a correct sentence and keep
the wrong one.

`pnpm run ci` → 2383 passed | 2 skipped. `pnpm run docs:build` → clean.
