### PR TITLE
fix: the findings of the third-party review of this release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,13 @@
   with no field to collect there was nothing to scan. Judged on names alone: a
   directory nobody named is every repository anyone searches, and reading their
   contents stopped a plain `rg TODO` in four of twelve checkouts
+- Stop the search for the wrapped command at a command that prints its
+  arguments. `sudo echo cat secrets` resolved to the `cat` sitting in echo's
+  arguments and scanned a file the command never opens, so `echo`, `printf`,
+  `true`, `false` and `:` end the descent
+- Leave the output file of `sort -o out.txt in.txt` and its siblings
+  (`shuf -o`, `iconv -o`, `tee`) out of the scan. The operand a flag names as a
+  destination is written, not printed, so naming it is not a read
 - Correct the boundaries of six rules. Discover's `65` range stopped at 6589;
   the card alternatives all assumed groups of four, where Amex prints 4-6-5 and
   Diners 4-6-4; Square's exact length meant one character over the guess stopped

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,10 @@ If the backport PR has conflicts, resolve them manually before merging.
 ## Adding a New Detection Rule
 
 1. Add the rule to `src/lib/default-config.json` — define `id`, `description`, `regex`, `category`, and optionally `entropyThreshold` and `flags`. `src/lib/rules.ts` reads that file; it holds the checksum validators, not the rules
-2. Add tests to `src/lib/__tests__/rules.test.ts` — cover true positives, false negatives, and entropy filtering
-   - Add the rule to the `EXAMPLES` table in the same file. Every rule needs one value it must find, or the id list proves only that a name is present: four rules shipped with patterns that could be disabled in silence because nothing asked them to match anything
-   - If the pattern carries a `*`, `+` or `{n,}` on a character class, work out what input makes it backtrack and add that shape to `no rule is quadratic` in the same file. A pattern that does not return is a way past the hook, not a slow scan — see the note in `docs/rules.md`
+2. Add tests — cover true positives, false negatives, and entropy filtering
+   - Add the rule to the `EXAMPLES` table in `src/lib/__tests__/rule-patterns.test.ts`. Every rule needs one value it must find, or the id list proves only that a name is present: four rules shipped with patterns that could be disabled in silence because nothing asked them to match anything
+   - The same file pads every example and requires the rule to still match, so a length you guessed too tight fails there rather than in a release. If the format really is exact — a checksum, a fixed-width field — add the id to `LONGER_IS_A_DIFFERENT_THING` with the reason
+   - If the pattern carries a `*`, `+` or `{n,}` on a character class, work out what input makes it backtrack and add that shape to `no rule is quadratic` in `src/lib/__tests__/rules.test.ts`. A pattern that does not return is a way past the hook, not a slow scan — see the note in `docs/rules.md`
 3. Update `README.md` — add to the detection rules table
 4. Update `docs/rules.md` — add full reference entry
 5. Update `CHANGELOG.md` — add the rule under `## Unreleased` (see [Changelog](#changelog))

--- a/src/__tests__/fixtures/slow-rules.json
+++ b/src/__tests__/fixtures/slow-rules.json
@@ -1,0 +1,52 @@
+{
+  "rules": [
+    {
+      "id": "slow-0",
+      "description": "deliberately slow: nested quantifiers with a literal that never comes",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-1",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-2",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-3",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-4",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-5",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-6",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    },
+    {
+      "id": "slow-7",
+      "description": "deliberately slow",
+      "regex": "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+      "category": "secret"
+    }
+  ]
+}

--- a/src/__tests__/manifest.test.ts
+++ b/src/__tests__/manifest.test.ts
@@ -1,0 +1,110 @@
+// What Claude Code is told to run, and for which tools.
+//
+// The hook can be perfect and reach nothing. `hooks.json` is the only thing
+// that decides whether the runtime calls it, and until now no test read it: a
+// tool name dropped from the matcher, or a path that no longer resolves, would
+// ship and every other test in this suite would still pass. The install guide
+// exists because that failure is silent; so does this file.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { TOOLS_WITHOUT_FILE_OUTPUT } from "../lib/tool-inputs.ts";
+import { runToolHook } from "./hook-harness.ts";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const readJson = (relative: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(join(ROOT, relative), "utf8"));
+
+interface HookCommand {
+  type?: string;
+  command?: string;
+}
+interface HookEntry {
+  matcher?: string;
+  hooks?: HookCommand[];
+}
+
+const manifest = readJson("hooks/hooks.json");
+const events = manifest["hooks"] as Record<string, HookEntry[]>;
+
+describe("hooks.json", () => {
+  it("registers both events", () => {
+    expect(Object.keys(events).sort()).toEqual([
+      "PreToolUse",
+      "UserPromptSubmit",
+    ]);
+  });
+
+  // The path Claude Code will run. `${CLAUDE_PLUGIN_ROOT}` is the checkout, so
+  // the file has to exist relative to this repository under the same name.
+  it.each(Object.entries(events))(
+    "%s runs a file that exists",
+    (_event, entries) => {
+      for (const entry of entries) {
+        for (const hook of entry.hooks ?? []) {
+          expect(hook.type).toBe("command");
+          const script = /\$\{CLAUDE_PLUGIN_ROOT\}\/([^"']+)/.exec(
+            hook.command ?? "",
+          )?.[1];
+          expect(script, hook.command).toBeDefined();
+          expect(isAbsolute(script ?? "x")).toBe(false);
+          expect(existsSync(join(ROOT, script ?? "")), script).toBe(true);
+        }
+      }
+    },
+  );
+
+  // Every tool the hook has something to say about has to reach it. The matcher
+  // is a regular expression over the tool name, so it is tested by running the
+  // names rather than by reading it.
+  const matcher = new RegExp(
+    `^(?:${(events["PreToolUse"] ?? [])[0]?.matcher ?? "(?!)"})$`,
+  );
+
+  it.each([
+    "Read",
+    "Bash",
+    "Grep",
+    "mcp__filesystem__read_text_file",
+    "mcp__desktop-commander__start_process",
+  ])("%s reaches the hook", (tool) => {
+    expect(matcher.test(tool)).toBe(true);
+  });
+
+  // The other direction, so the matcher is not quietly `.*`: a tool that only
+  // writes has nothing to leak, and sending every call here would cost a
+  // process spawn on each one.
+  it.each([...TOOLS_WITHOUT_FILE_OUTPUT].filter((t) => !t.startsWith("mcp__")))(
+    "%s does not",
+    (tool) => {
+      expect(matcher.test(tool)).toBe(false);
+    },
+  );
+
+  // A tool the matcher lets through must actually be handled, not merely
+  // reached. `Grep` was in the matcher long before its pathless form was
+  // scanned.
+  it.each(["Read", "Grep"])("%s is handled once it arrives", (tool) => {
+    const result = runToolHook(tool, { pattern: "x", path: ROOT });
+    expect(result.exitCode === 0 || result.exitCode === 2).toBe(true);
+  });
+});
+
+describe("plugin.json", () => {
+  const plugin = readJson(".claude-plugin/plugin.json");
+  const pkg = readJson("package.json");
+
+  it("declares the same version as package.json", () => {
+    expect(plugin["version"]).toBe(pkg["version"]);
+  });
+
+  it("declares a version at all", () => {
+    expect(String(plugin["version"])).toMatch(/^\d+\.\d+\.\d+(?:[-+].*)?$/);
+  });
+
+  it("names the package this repository publishes", () => {
+    expect(plugin["name"]).toBe(String(pkg["name"]).replace(/^@[^/]+\//, ""));
+  });
+});

--- a/src/__tests__/pre-tool-use-hook-files.test.ts
+++ b/src/__tests__/pre-tool-use-hook-files.test.ts
@@ -606,3 +606,65 @@ describe("pre-tool-use-hook — UTF-16", () => {
     expect(runHook("Read", p).exitCode).toBe(0);
   });
 });
+
+// The five-second deadline, which nothing reached.
+//
+// Two clocks bound one invocation: a ten-second scan budget, which throws, and
+// this one, which stops reading between files. Only the budget had a case, so
+// the deadline could be deleted or its comparison inverted and the whole suite
+// stayed green — on a guard whose job is to keep the hook inside Claude Code's
+// PreToolUse timeout, because a hook killed by that timeout does not block.
+//
+// What makes it observable is the `.env` fallback. A file skipped for time is
+// silently not scanned, which reads the same as a file that was clean; an
+// `.env` reached after the deadline is blocked on its name instead.
+describe("pre-tool-use-hook — the deadline between files", () => {
+  const writeFixture = useFixtureDir("deadline");
+
+  // A rule that backtracks, so a modest file costs seconds rather than
+  // milliseconds. Several files rather than one big one: the deadline is
+  // checked between files, and a single file long enough to pass it also runs
+  // past the scan budget, which throws first and proves the wrong guard.
+  it("an .env reached after the deadline is blocked on its name", () => {
+    const slowConfig = writeFixture(
+      "slow.json",
+      JSON.stringify({
+        rules: Array.from({ length: 8 }, (_, i) => ({
+          id: `slow-${i}`,
+          description: "deliberately slow",
+          regex:
+            "(?<!x)eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}",
+          category: "secret",
+        })),
+      }),
+    );
+    const slow = [1, 2, 3].map((n) =>
+      writeFixture(`slow-${n}.txt`, "eyJ".repeat(7_000)),
+    );
+    // A template name, so the plain `.env` guard does not decide it: this one
+    // is exempt while its contents can be read, and blocked on its name when
+    // they cannot. That is what makes the deadline observable.
+    const env = writeFixture(
+      ".env.after-deadline.example",
+      "TOKEN=your-token-here\n",
+    );
+
+    // Named in order, which `scanPathsLiteralsFirst` keeps, so the deadline is
+    // spent before the `.env` is reached.
+    const result = runBashHook(`cat ${slow.join(" ")} ${env}`, {
+      env: { SENSITIVE_CANARY_CONFIG: slowConfig },
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.reason).toContain(
+      "the scan for this call had already stopped",
+    );
+  }, 30_000);
+
+  // The other direction, so the case above is not passing on the `.env` name
+  // alone: given time to read it, a template of placeholders is allowed.
+  it("the same .env is read when there is time to read it", () => {
+    const env = writeFixture(".env.in-time.example", "TOKEN=your-token-here\n");
+    expect(runBashHook(`cat ${env}`).exitCode).toBe(0);
+  });
+});

--- a/src/__tests__/user-prompt-submit-hook.test.ts
+++ b/src/__tests__/user-prompt-submit-hook.test.ts
@@ -139,10 +139,28 @@ describe("user-prompt-submit-hook — an unforeseen error", () => {
     },
   );
 
-  it("the handler is installed", () => {
-    const source = readFileSync(HOOK, "utf8");
-    expect(source).toContain('process.on("uncaughtException"');
-    expect(source).toContain('process.on("unhandledRejection"');
+  // Both hooks register the same two handlers, from one place. Asserted on the
+  // shared module rather than on each hook's own text: reading the hook's source
+  // for the string pinned where the registration was written, so moving it broke
+  // the test while the behaviour it stands for was unchanged.
+  it("both hooks register the handler", () => {
+    const shared = readFileSync(
+      fileURLToPath(new URL("../lib/fail-closed.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(shared).toContain('process.on("uncaughtException"');
+    expect(shared).toContain('process.on("unhandledRejection"');
+
+    for (const hook of [
+      "../pre-tool-use-hook.ts",
+      "../user-prompt-submit-hook.ts",
+    ]) {
+      const source = readFileSync(
+        fileURLToPath(new URL(hook, import.meta.url)),
+        "utf8",
+      );
+      expect(source, hook).toContain("blockOnUnhandledError()");
+    }
   });
 });
 
@@ -439,4 +457,46 @@ describe("user-prompt-submit-hook — SENSITIVE_CANARY_CATEGORIES", () => {
     expect(stderr).toContain("aws-access-key");
     expect(stderr).toContain("pii-credit-card");
   });
+});
+
+// Which channel the prompt hook answers on.
+//
+// Writing to both channels leaves the documented one dead: stdout wins and
+// stderr is discarded when both carry text. The PreToolUse hook has this fixed;
+// this one did not, so a payload could come back on stdout and every other case
+// in this file would still pass.
+describe("user-prompt-submit-hook — the channel it answers on", () => {
+  it("reports the reason on stderr and writes nothing to stdout", () => {
+    const { exitCode, stdout, stderr } = runHook(`my key is ${AWS_KEY}`);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("allow-secret");
+  });
+
+  // An allowed prompt cannot be recognised by an empty stderr: node's type
+  // stripping is experimental, so it warns there on every run. What must be
+  // empty is stdout, and what must be absent from stderr is a block.
+  it("says nothing about a block when the prompt is allowed", () => {
+    const { exitCode, stdout, stderr } = runHook("list the files here");
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).not.toContain("allow-secret");
+    expect(stderr).not.toContain("blocked");
+  });
+
+  // A scan that cannot finish is not a scan that found nothing. The budget
+  // throws, and the throw has to stop the prompt rather than let it through —
+  // the same contract the tool hook has, on the hook that sees what the user
+  // typed.
+  it("a scan that cannot finish stops the prompt", () => {
+    const config = fileURLToPath(
+      new URL("./fixtures/slow-rules.json", import.meta.url),
+    );
+    const { exitCode, stderr } = runHook(`x ${"eyJ".repeat(21_845)}`, {
+      env: { SENSITIVE_CANARY_CONFIG: config },
+    });
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("the check could not complete");
+    expect(stderr).not.toContain("sensitive data detected");
+  }, 120_000);
 });

--- a/src/lib/__tests__/inspector.test.ts
+++ b/src/lib/__tests__/inspector.test.ts
@@ -9,6 +9,7 @@ import {
   applyAllowTags,
   dedupeFindings,
   findingsToLines,
+  MAX_FINDING_LINES,
   parseAllowTags,
   resolveTagPriority,
 } from "../inspector.ts";
@@ -335,5 +336,48 @@ describe("findingsToLines", () => {
     ];
     const lines = findingsToLines(findings);
     expect(lines[0]).toBe("  [PII] Email Address (pii-email): user****");
+  });
+});
+
+// The cap on how many findings are printed.
+//
+// A rule that matches everywhere once produced forty thousand lines of stderr,
+// which buries the block it is explaining and is itself a way of hiding one.
+// Neither the cap nor the line that says what was left out was fixed by a test,
+// so both could move or vanish without anything noticing.
+describe("how many findings are printed", () => {
+  const finding = (n: number): Finding => ({
+    ruleId: `rule-${n}`,
+    description: `Rule ${n}`,
+    category: "secret",
+    matchRedacted: "ab****yz",
+    secretValue: `value-${n}`,
+  });
+
+  const linesFor = (count: number): string[] =>
+    findingsToLines(Array.from({ length: count }, (_, i) => finding(i)));
+
+  it("prints every finding when there are few", () => {
+    expect(linesFor(3)).toHaveLength(3);
+  });
+
+  // The boundary itself, from both sides: at the cap nothing is elided, one
+  // over it the extra line appears.
+  it("prints exactly the cap with nothing added", () => {
+    const lines = linesFor(MAX_FINDING_LINES);
+    expect(lines).toHaveLength(MAX_FINDING_LINES);
+    expect(lines.join("\n")).not.toContain("more");
+  });
+
+  it("says how many it left out", () => {
+    const lines = linesFor(MAX_FINDING_LINES + 1);
+    expect(lines).toHaveLength(MAX_FINDING_LINES + 1);
+    expect(lines[lines.length - 1]).toBe("  … and 1 more");
+  });
+
+  it("counts the ones it left out", () => {
+    const lines = linesFor(MAX_FINDING_LINES + 4_000);
+    expect(lines).toHaveLength(MAX_FINDING_LINES + 1);
+    expect(lines[lines.length - 1]).toBe("  … and 4000 more");
   });
 });

--- a/src/lib/fail-closed.ts
+++ b/src/lib/fail-closed.ts
@@ -1,0 +1,36 @@
+// What both hooks do when the check itself goes wrong.
+//
+// A hook that crashes exits 1, and only exit 2 blocks, so an unforeseen error
+// is a silent pass — the failure this whole tool exists to prevent. What went
+// wrong is unknown at this point, and "unknown" is not "safe": the check did
+// not finish, so the call is stopped rather than let through. `[allow-all]`
+// gets past it, and the message says the check failed rather than claiming a
+// finding.
+//
+// One copy, because two would be two rules: the wording, the exit code and
+// which events are handled all have to be the same in both hooks, and a fix
+// applied to one of two copies is a hook that fails open on the other.
+
+export function failClosed(error: unknown): never {
+  try {
+    process.stderr.write(
+      `\n🐤 sensitive-canary: the check could not complete — ${
+        error instanceof Error ? error.message : String(error)
+      }\n\n` +
+        "  Nothing was scanned, so nothing can be vouched for. Stopping rather\n" +
+        "  than passing it through. Add [allow-all] to your prompt to proceed\n" +
+        "  anyway, and please report this.\n",
+    );
+  } catch {
+    // A closed stderr must not turn the block back into a pass.
+  }
+  process.exit(2);
+}
+
+// Registered by both hooks as their first statement. A rejection that nothing
+// awaited reaches the process the same way an exception does, and either one
+// arriving unhandled is the pass this exists to stop.
+export function blockOnUnhandledError(): void {
+  process.on("uncaughtException", failClosed);
+  process.on("unhandledRejection", failClosed);
+}

--- a/src/lib/inspector.ts
+++ b/src/lib/inspector.ts
@@ -192,9 +192,31 @@ export function dedupeFindings(findings: Finding[]): Finding[] {
   });
 }
 
+// Which tags a block should suggest, given what it found.
+//
+// Three places write these lines — the tool hook's hint builder, and the prompt
+// hook's mask and block paths — with only the indentation differing. Written
+// out three times, a change to the wording reaches whichever copy the author
+// happened to be looking at, and the tag a user is told to add is the one thing
+// in the message that has to be right.
+export function allowTagLines(
+  findings: Finding[],
+  options: { indent?: string; showAll?: boolean } = {},
+): string[] {
+  const indent = options.indent ?? "  ";
+  const showAll = options.showAll ?? false;
+  const lines: string[] = [];
+  if (showAll || findings.some((f) => f.category === "secret"))
+    lines.push(`${indent}[allow-secret]  — allow secrets`);
+  if (showAll || findings.some((f) => f.category === "pii"))
+    lines.push(`${indent}[allow-pii]     — allow PII`);
+  lines.push(`${indent}[allow-all]     — bypass all sensitive-canary checks`);
+  return lines;
+}
+
 // One line per finding, capped. A rule that matches everywhere produced forty
 // thousand lines of stderr, which buries the block it is trying to explain.
-const MAX_FINDING_LINES = 50;
+export const MAX_FINDING_LINES = 50;
 
 export function findingsToLines(findings: Finding[]): string[] {
   const lines = findings.slice(0, MAX_FINDING_LINES).map((f) => {

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -5,8 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { extractCommandRefs } from "./lib/bash-commands.ts";
+import type { CommandRefs } from "./lib/command-tables.ts";
 import { detectUtf16, looksBinary, utf8Runs } from "./lib/encoding.ts";
+import { blockOnUnhandledError, failClosed } from "./lib/fail-closed.ts";
 import {
+  allowTagLines,
   applyAllowTags,
   dedupeFindings,
   findingsToLines,
@@ -32,30 +35,7 @@ import {
 } from "./lib/tool-inputs.ts";
 import { loadAllowTagsFromTranscript } from "./lib/transcript.ts";
 
-// A hook that crashes exits 1, and only exit 2 blocks — so until now any
-// unforeseen error was a silent pass, which is the failure this whole tool
-// exists to prevent. What went wrong is unknown at this point, and "unknown" is
-// not "safe": the check did not finish, so the call is stopped rather than let
-// through. `[allow-all]` gets past it, and the message says the check failed
-// rather than claiming a finding.
-function failClosed(error: unknown): never {
-  try {
-    process.stderr.write(
-      `\n🐤 sensitive-canary: the check could not complete — ${
-        error instanceof Error ? error.message : String(error)
-      }\n\n` +
-        "  Nothing was scanned, so nothing can be vouched for. Stopping rather\n" +
-        "  than passing it through. Add [allow-all] to your prompt to proceed\n" +
-        "  anyway, and please report this.\n",
-    );
-  } catch {
-    // A closed stderr must not turn the block back into a pass.
-  }
-  process.exit(2);
-}
-
-process.on("uncaughtException", failClosed);
-process.on("unhandledRejection", failClosed);
+blockOnUnhandledError();
 
 interface HookInput {
   transcript_path?: string;
@@ -78,11 +58,11 @@ function searchesWithoutAPath(
   tool: string,
   input: Record<string, unknown>,
 ): boolean {
-  const searchTerm =
+  const hasSearchTerm =
     typeof input["pattern"] === "string" ||
     typeof input["query"] === "string" ||
     typeof input["regex"] === "string";
-  return searchTerm && (tool === "Grep" || tool.startsWith("mcp__"));
+  return hasSearchTerm && (tool === "Grep" || tool.startsWith("mcp__"));
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -233,11 +213,7 @@ function buildAllowHints(
     showAllTags || findings.some((f) => f.category === "secret");
   const hasPii = showAllTags || findings.some((f) => f.category === "pii");
 
-  const lines: string[] = [];
-  if (hasSecret) lines.push("  [allow-secret]  — allow secrets");
-  if (hasPii) lines.push("  [allow-pii]     — allow PII");
-  lines.push("  [allow-all]     — bypass all sensitive-canary checks");
-  lines.push("");
+  const lines = [...allowTagLines(findings, { showAll: showAllTags }), ""];
 
   const example =
     hasSecret && hasPii
@@ -533,6 +509,18 @@ function blockUnreadEnvFile(
     [ENV_BLOCK_REASON, "", reason],
     buildAllowHints(`please read ${forOutput(filePath)}`, [], true),
   );
+}
+
+// The variables a command puts in play: the ones it names, plus the ones the
+// command line references directly. A bare `env` or `printenv` prints
+// everything, so there the answer is every variable there is.
+//
+// Asked in two places — the Bash branch and the tool that runs a shell through
+// an input field — and a difference between them would be a difference in what
+// each of those two paths protects.
+function environmentNamed(commandText: string, refs: CommandRefs): string[] {
+  if (refs.dumpsEnvironment) return Object.keys(process.env);
+  return [...new Set([...extractEnvVarNames(commandText), ...refs.envVars])];
 }
 
 // The values a command would print, whichever tool is running it.
@@ -899,12 +887,7 @@ process.stdin.on("end", () => {
     }
     const refs = extractCommandRefs(command);
 
-    // A bare `env` or `printenv` prints everything, so every variable is in play.
-    const envVarNames = refs.dumpsEnvironment
-      ? Object.keys(process.env)
-      : [...new Set([...extractEnvVarNames(command), ...refs.envVars])];
-
-    scanEnvironment(envVarNames, allowTags);
+    scanEnvironment(environmentNamed(command, refs), allowTags);
 
     const cmdFindings = dedupeFindings(
       applyAllowTags(scan(command, ENABLED_CATEGORIES), allowTags),
@@ -971,12 +954,7 @@ process.stdin.on("end", () => {
       // has always scanned the variables a command would print; a tool that
       // runs a shell was collected for paths and nothing else, so
       // `{"command":"printenv"}` handed the environment back whole.
-      scanEnvironment(
-        refs.dumpsEnvironment
-          ? Object.keys(process.env)
-          : [...new Set([...extractEnvVarNames(value), ...refs.envVars])],
-        allowTags,
-      );
+      scanEnvironment(environmentNamed(value, refs), allowTags);
     }
 
     // The write-verb exemption is about a tool's *output*: naming a file it only

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+import { blockOnUnhandledError, failClosed } from "./lib/fail-closed.ts";
 import {
+  allowTagLines,
   applyAllowTags,
   dedupeFindings,
   type Finding,
@@ -15,30 +17,7 @@ import {
   scan,
 } from "./lib/rules.ts";
 
-// A hook that crashes exits 1, and only exit 2 blocks — so until now any
-// unforeseen error was a silent pass, which is the failure this whole tool
-// exists to prevent. What went wrong is unknown at this point, and "unknown" is
-// not "safe": the check did not finish, so the call is stopped rather than let
-// through. `[allow-all]` gets past it, and the message says the check failed
-// rather than claiming a finding.
-function failClosed(error: unknown): never {
-  try {
-    process.stderr.write(
-      `\n🐤 sensitive-canary: the check could not complete — ${
-        error instanceof Error ? error.message : String(error)
-      }\n\n` +
-        "  Nothing was scanned, so nothing can be vouched for. Stopping rather\n" +
-        "  than passing it through. Add [allow-all] to your prompt to proceed\n" +
-        "  anyway, and please report this.\n",
-    );
-  } catch {
-    // A closed stderr must not turn the block back into a pass.
-  }
-  process.exit(2);
-}
-
-process.on("uncaughtException", failClosed);
-process.on("unhandledRejection", failClosed);
+blockOnUnhandledError();
 
 interface HookInput {
   prompt?: unknown;
@@ -120,8 +99,6 @@ process.stdin.on("end", () => {
   );
 
   if (maskableFindings.length > 0) {
-    const hasSecret = maskableFindings.some((f) => f.category === "secret");
-    const hasPii = maskableFindings.some((f) => f.category === "pii");
     const usedTags = effectiveMask.has("all")
       ? "[mask-all]"
       : (["secret", "pii"] as const)
@@ -141,17 +118,12 @@ process.stdin.on("end", () => {
       "",
       "  1. Manually redact the values above and resubmit",
       "  2. To send as-is, add an allow tag to your prompt:",
-      ...(hasSecret ? ["       [allow-secret]  — allow secrets"] : []),
-      ...(hasPii ? ["       [allow-pii]     — allow PII"] : []),
-      "       [allow-all]     — bypass all sensitive-canary checks",
+      ...allowTagLines(maskableFindings, { indent: "       " }),
       "",
     ];
     process.stderr.write(maskBlockLines.join("\n"));
     process.exit(2);
   }
-
-  const hasSecret = afterAllow.some((f) => f.category === "secret");
-  const hasPii = afterAllow.some((f) => f.category === "pii");
 
   const blockLines = [
     "",
@@ -160,9 +132,7 @@ process.stdin.on("end", () => {
     ...findingsToLines(afterAllow),
     "",
     "To allow, add a tag to your prompt:",
-    ...(hasSecret ? ["  [allow-secret]  — allow secrets"] : []),
-    ...(hasPii ? ["  [allow-pii]     — allow PII"] : []),
-    "  [allow-all]     — bypass all sensitive-canary checks",
+    ...allowTagLines(afterAllow),
     "",
   ];
 


### PR DESCRIPTION
fix: the findings of the third-party review of this release

Each was reproduced before being acted on. What is not here, and why, is
at the end.

## The instructions my own refactor broke

`CONTRIBUTING.md` told a contributor to add a rule's example to the
`EXAMPLES` table "in the same file" as its tests. #210 moved that table to
`rule-patterns.test.ts` and left the step behind. It now names the file,
and says what the padding test asks of a new rule.

## Three guards nothing tested

**The five-second deadline.** Two clocks bound one invocation: a
ten-second scan budget, which throws and had a case, and a deadline
checked between files, which had none. It could be deleted or its
comparison inverted and the whole suite stayed green — on a guard whose
job is to keep the hook inside the PreToolUse timeout, because a hook
killed by that timeout does not block.

Made observable through the `.env` fallback, since a file skipped for time
is silently not scanned and reads the same as a file that was clean. Three
slow files then a template name: past the deadline the template is judged
on its name. Verified by removing the deadline — the test fails.

**`hooks.json`.** The hook can be perfect and reach nothing. No test read
the manifest, so a tool name dropped from the matcher, or a path that no
longer resolves, would ship in silence. The matcher is now run against the
tool names rather than read, in both directions, and each command's script
has to exist. Verified by removing `Grep` from the matcher — the test
fails.

**The fifty-line cap on findings.** A rule that matched everywhere once
produced forty thousand lines of stderr, which buries the block it is
explaining. Neither the cap nor the "… and N more" line was fixed by a
test. Both sides of the boundary now are.

**The prompt hook's channel.** The tool hook asserts that a reason goes to
stderr and stdout stays empty; this hook did not, so a payload could come
back on stdout and every case still pass. Its budget exhaustion is
asserted too, against a fixture rather than a config written inline.

## Three things written twice

`failClosed` was duplicated between the hooks, wording and handlers and
all — two copies of the rule that decides what happens when the check goes
wrong. One `src/lib/fail-closed.ts` now.

The allow-tag hint lines were written in three places, differing only in
indentation. The tag a user is told to add is the one thing in a block
message that has to be right.

The environment-variable expression was written twice, once per path that
scans a command. A difference between them would be a difference in what
each path protects.

## Naming

`searchTerm` held a boolean. `hasSearchTerm`.

## Changelog

Two behaviours from earlier rounds had no entry: the descent past a
wrapper stopping at a command that prints its arguments, and the output
file of `sort -o` and its siblings being left out of the scan.

## Not done, and why

- **The hook is still 1010 lines.** Splitting further means threading
  `scanned`, `bytesScanned`, `DEADLINE` and `baseDirectory` through
  parameters. Said in #210 and still true: it is the next file to take,
  not one to start hours before a release
- **`ScanContext`, and a type for the allow-tag set.** Both are real and
  neither changes behaviour. After the release
- **The integration test still never runs in CI.** It needs credentials
  and a network round trip, so making it run is a decision about spend,
  not a code change. It was run by hand for this release and passed
- **CI is ubuntu-only.** Adding a macOS runner is the same kind of
  decision
- **`git -c k=v log f` reads as a patch request.** Over-scanning, which is
  the safe direction

`pnpm run ci` → 2415 passed | 2 skipped. 2383 → 2415.
