### PR TITLE
docs: comments explain the code, not what it used to be

### DIFF
--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -391,12 +391,12 @@ export function redact(str: string): string {
   return `${head}****${tail}`;
 }
 
-// Longer than any honest scan and far shorter than the hook timeout. One rule
-// that backtracks badly used to take minutes on a megabyte, and a hook killed by
-// the timeout does not block — so the damage was silent. Bounding the patterns
-// fixed the two that did it; this is here so the next one of that shape is
-// caught rather than repeating the same failure. The check sits between rules
-// because a single `matchAll` cannot be interrupted.
+// Longer than any honest scan and far shorter than the hook timeout. A rule
+// that backtracks badly takes minutes on a megabyte, and a hook killed by the
+// timeout does not block, so the damage is silent. The patterns that did that
+// are bounded; this catches the next one of that shape rather than letting it
+// repeat. The check sits between rules because a single `matchAll` cannot be
+// interrupted.
 export const SCAN_BUDGET_MS = 10_000;
 
 export class ScanBudgetExceeded extends Error {

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -160,10 +160,9 @@ export function tokenizeCommand(command: string): ShellToken[][] {
 
     // A substitution standing among the operands is one word to the command, so
     // it is consumed whole and no token is emitted for it. Ending the segment
-    // here instead cut the operand list in two: `cat <(echo hi) secrets` left
-    // `secrets` in a segment of its own, where it was read as a command name and
-    // its own reading went unseen. The comment that used to sit here said the
-    // only cost was reaching the inner command twice, which was wrong.
+    // here instead would cut the operand list in two: `cat <(echo hi) secrets`
+    // leaves `secrets` in a segment of its own, where it reads as a command name
+    // and its own reading goes unseen.
     //
     // The inner command is still reached: extractSubstitutions walks the raw
     // string for these forms, and the paths are deduplicated.
@@ -260,10 +259,10 @@ interface HeredocDelimiter {
 // the shell does it: `<<EOF`, `<<'EOF'`, `<<"EOF"` and `<<E"O"F` all end their
 // body at the line `EOF`. The word ends at whitespace or a shell metacharacter.
 //
-// A narrower character class (`[A-Za-z0-9_.]`) used to cut the word short, and the
-// truncated delimiter then never matched the real closing line: stripHeredocBodies
-// swallowed the rest of the command, so `cat > f <<EOF-1 … EOF-1` followed by
-// `cat .env` hid the read entirely.
+// A narrower character class (`[A-Za-z0-9_.]`) cuts the word short, and a
+// truncated delimiter never matches the real closing line: stripHeredocBodies
+// then swallows the rest of the command, so `cat > f <<EOF-1 … EOF-1` followed
+// by `cat .env` hides the read entirely.
 function readHeredocDelimiter(
   line: string,
   from: number,
@@ -341,9 +340,9 @@ function findHeredocDelimiters(line: string): HeredocDelimiter[] {
 
 // Remove heredoc bodies from a command line. A body is text, not commands —
 // `cat > deploy.sh <<EOF` followed by a script that mentions `.env` reads
-// nothing, and scanning the body as shell blocked exactly that everyday case.
+// nothing, and scanning the body as shell blocks exactly that everyday case.
 // The trade-off: a heredoc that *feeds* commands to a remote shell
-// (`ssh host <<EOF\ncat /secret\nEOF`) is no longer caught. Written up as a
+// (`ssh host <<EOF\ncat /secret\nEOF`) is not caught. Written up as a
 // known limitation under "② PreToolUse hook" in the README.
 export function stripHeredocBodies(command: string): string {
   const lines = command.split("\n");
@@ -453,10 +452,10 @@ export function extractSubstitutions(command: string): string[] {
 }
 
 // Shell keywords and the brace-group delimiters. They stand where a command
-// name would, so a segment led by one used to be classified as a command called
-// `{` or `then` and its operands never looked at: `{ cat secrets; }`,
-// `if …; then cat secrets; fi` and `while cat secrets; do :; done` all read a
-// file nothing noticed. The keywords that open a condition (`if`, `while`,
+// name would, so without this list a segment led by one is classified as a
+// command called `{` or `then` and its operands are never looked at:
+// `{ cat secrets; }`, `if …; then cat secrets; fi` and
+// `while cat secrets; do :; done` each read a file nothing notices. The keywords that open a condition (`if`, `while`,
 // `until`) matter as much as the ones that open a body: the command being tested
 // runs too.
 export const SHELL_KEYWORD_TOKENS = new Set([

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -25,12 +25,12 @@ export const TOOLS_WITHOUT_FILE_OUTPUT = new Set([
 // tools (`mcp__<server>__<tool>`) only the tool component is matched — a server
 // named "editor" or "readwrite" must not exempt every read tool it offers.
 // The verb has to be the first word of the name, not a substring of it anywhere.
-// As a substring test this exempted reads: "update" sits inside `get_updates`,
-// and "write" inside `read_and_write_file` — a tool that returns contents was
-// treated as one that only writes. Word boundaries are the `_`/`-` in snake and
+// As a substring test this would exempt reads: "update" sits inside
+// `get_updates`, and "write" inside `read_and_write_file` — a tool that returns
+// contents read as one that only writes. Word boundaries are the `_`/`-` in snake and
 // kebab names and, in camelCase, a capital that follows a lowercase letter — so
 // `write_file`, `createPage` and `WRITE_FILE` all match while `overwrite_file`
-// and `readwrite` no longer do.
+// and `readwrite` do not.
 //
 // Erring this way costs a false block on a noun-first write tool (`file_write`),
 // which is the direction to fail in. The built-in write tools are named

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -67,23 +67,24 @@ function searchesWithoutAPath(
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-// Maximum bytes scanned from the head of a file. readFileSync has no size
-// limit, so a file of any size was read whole and every rule run over all of
-// it — on a multi-GB log that is the hang this hook cannot afford, because a
-// killed hook does not block the call (see isRegularFile). A secret past the
-// cut is missed; the transcript read above makes the same trade for its tail.
+// Maximum bytes scanned from the head of a file. `readFileSync` has no size
+// limit, so without a cap a multi-GB log is read whole and every rule run over
+// all of it, which is the hang this hook cannot afford: a hook killed by the
+// PreToolUse timeout does not block the call (see isRegularFile). A secret past
+// the cut is missed, the same trade the transcript read makes for its tail.
 const MAX_FILE_SCAN_BYTES = 1_048_576; // 1 MiB
 
 // Total bytes one hook invocation will read across every file it scans. The
-// per-file cap bounds one file; nothing bounded the number of files, and a glob
-// naming three hundred of them took half a minute — long enough for the
-// PreToolUse timeout to kill the hook, which does not block the call.
+// per-file cap bounds one file and nothing else bounds the number of them: a
+// glob naming three hundred large files costs half a minute, which is long
+// enough for the PreToolUse timeout to kill the hook, and a killed hook does
+// not block the call.
 //
 // Files past the budget are not scanned, so the budget is also a way through:
-// eight files of a megabyte each, named before the one that matters, used to
-// spend it. Sixty-four megabytes is about two seconds of scanning here, which
-// keeps the hook well inside the timeout while making that trick need sixty-four
-// files rather than eight. It does not remove it — written up as a limitation.
+// enough large files named before the one that matters and it is spent.
+// Sixty-four megabytes is about two seconds of scanning here, which keeps the
+// hook well inside the timeout while making that trick need sixty-four files
+// rather than eight. It does not remove it — written up as a limitation.
 const MAX_TOTAL_SCAN_BYTES = 64 * 1_048_576; // 64 MiB
 
 // Input field names that carry something to run rather than something to read.
@@ -105,24 +106,25 @@ const MAX_COMMAND_FIELD_DEPTH = 4;
 const ENABLED_CATEGORIES = enabledCategoriesFromEnv();
 
 // Mutable for one run of the process: what has been read, and what has already
-// been looked at. Overlapping globs named the same file five times over.
+// been looked at. Overlapping globs name the same file several times over, and
+// each of those is a file read and a scan.
 const scanned = new Set<string>();
 let bytesScanned = 0;
 
 // When this invocation has to stop reading files, whatever it has read.
 //
-// A byte budget bounds the reading and not the walking, and a pattern reaching
-// one level under a home directory took ten seconds — close enough to the
-// PreToolUse timeout to matter, and a hook killed by that timeout does not
-// block. This is checked between files, so it bounds the reading of many files
-// where a byte count would not. It does not bound a single `globSync` call,
-// which cannot be interrupted: a pattern several directories deep still costs
-// what the walk costs. Files after the deadline are not scanned, and a `.env`
-// name reached after it falls back on the name.
+// A byte budget bounds the reading and not the walking: a pattern reaching one
+// level under a home directory costs ten seconds, close enough to the PreToolUse
+// timeout to matter, and a hook killed by that timeout does not block. This is
+// checked between files, so it bounds the reading of many files where a byte
+// count would not. It does not bound a single `globSync` call, which cannot be
+// interrupted: a pattern several directories deep still costs what the walk
+// costs. Files after the deadline are not scanned, and a `.env` name reached
+// after it falls back on the name.
+//
 // Both clocks start when the payload arrives, not when the process does. The
-// wait for stdin is the runtime's, and counting it against the scan meant a
-// slow handover spent the whole allowance before a single file was read — five
-// seconds of it and nothing was scanned, on an exit code of 0.
+// wait for stdin belongs to the runtime, and counting it against the scan lets
+// a slow handover spend the whole allowance before a single file is read.
 let DEADLINE = Number.POSITIVE_INFINITY;
 
 function startTheClock(): void {
@@ -140,12 +142,12 @@ let baseDirectory = currentDirectoryOrRoot();
 
 // `process.cwd()` throws when the directory the hook was started in has been
 // removed, which a build script does every time it runs `rm -rf dist` from
-// inside `dist`, and `git worktree remove` does to a worktree. That throw
-// happens while this module is still being evaluated — before the transcript is
-// read — so it stopped every tool call with a message telling the user to add
-// an allow tag that could not possibly be honoured. There is nothing sensitive
-// about a missing directory: a relative path simply has no base, and one that
-// resolves to nothing is scanned as the name it is.
+// inside `dist`, and `git worktree remove` does to a worktree. The throw would
+// happen while this module is still being evaluated, before the transcript is
+// read, so it would stop every tool call with a message telling the user to add
+// an allow tag that could not be honoured. There is nothing sensitive about a
+// missing directory: a relative path simply has no base, and one that resolves
+// to nothing is scanned as the name it is.
 function currentDirectoryOrRoot(): string {
   try {
     return process.cwd();
@@ -267,14 +269,14 @@ function block(
 
   // Exit 2 blocks the tool call and stderr is the documented way to say why.
   //
-  // The reason used to be written to stdout as `{"decision":"block", …}`. That
-  // does reach Claude on the current version — measured with a probe hook, not
-  // assumed — but the documentation says stdout is ignored on a non-zero exit
-  // and that PreToolUse takes its decision from `hookSpecificOutput`, not from a
-  // top-level `decision` field. So the old form worked by way of behaviour no
-  // longer described anywhere, and a release could drop it without breaking a
-  // documented contract. Blocking would survive that (exit 2 is the block), but
-  // the reason and the allow-tag guidance would not.
+  // Not stdout as `{"decision":"block", …}`. That form does reach Claude on the
+  // current version — measured with a probe hook, not assumed — but the
+  // documentation says stdout is ignored on a non-zero exit, and that PreToolUse
+  // takes its decision from `hookSpecificOutput` rather than a top-level
+  // `decision` field. It would work by way of behaviour described nowhere, which
+  // a release could drop without breaking a documented contract. Blocking would
+  // survive that (exit 2 is the block); the reason and the allow-tag guidance
+  // would not.
   //
   // When both channels carry text, stdout wins and stderr is discarded, so
   // writing both would leave the documented one dead. Hence stderr alone.
@@ -292,8 +294,8 @@ function block(
 // ── Core scan logic ───────────────────────────────────────────────────────────
 
 // Characters that make a token a pattern rather than a filename. `{` is here
-// because the shell expands `{a,b}` too, and `cat .env{,.bak}` reached the name
-// guard as the single name `.env{`.
+// because the shell expands `{a,b}` too, and without it `cat .env{,.bak}`
+// reaches the name guard as the single name `.env{`, which is nothing on disk.
 const GLOB_METACHARACTERS = /[*?[{]/;
 
 // How many matches of one pattern are scanned. This bounds the reading, not the
@@ -304,10 +306,11 @@ const MAX_GLOB_MATCHES = 256;
 // The paths a candidate stands for.
 //
 // A token carrying glob metacharacters names whatever the shell will expand it
-// to, and the file is in the expansion, not in the token: `cat sec*` collected
-// `sec*`, found no file by that name, and allowed the read. `cat .env*` did the
-// same, one character away from `cat .env`, which is blocked on its name — so
-// the guard this hook is most sure of was a wildcard away from being skipped.
+// to, and the file is in the expansion rather than in the token. Without this,
+// `cat sec*` collects `sec*`, finds no file by that name and allows the read;
+// `cat .env*` does the same, one character away from `cat .env`, which is
+// blocked on its name — the guard this hook is most sure of, a wildcard away
+// from being skipped.
 //
 // Expanded here rather than in the tokenizer because it needs the filesystem,
 // which is also why it can differ from what the shell will do a moment later.
@@ -317,13 +320,13 @@ function expandCandidate(candidate: string): string[] {
     expandPath(fromFileUrl(candidate)),
   );
   if (!GLOB_METACHARACTERS.test(literal)) return [literal];
-  // `**` matches across directories, and expanding it walked a whole tree:
-  // `cat ~/**/*` ran until the hook was killed, which is the failure this file
-  // spends a `stat` per path to avoid. Refusing it outright was worse — the
-  // shell still expands it and reads the files, so `cat **` was scanned not at
-  // all. Collapsed to one `*`, which costs a listing per matching directory the
-  // way every other pattern here does, and reaches one level rather than every
-  // level. Written up as a limitation.
+  // `**` matches across directories, and expanding it walks a whole tree:
+  // `cat ~/**/*` runs until the hook is killed, which is the failure this file
+  // spends a `stat` per path to avoid. Refusing the pattern outright is worse,
+  // since the shell still expands it and reads the files. Collapsed to one `*`,
+  // which costs a listing per matching directory the way every other pattern
+  // here does, and reaches one level rather than every level. Written up as a
+  // limitation.
   const pattern = literal.replace(/\*{2,}/g, "*");
   let matches: string[] = [];
   try {
@@ -331,12 +334,13 @@ function expandCandidate(candidate: string): string[] {
   } catch {
     matches = [];
   }
-  // The literal is kept as well as the expansion, and returning only the matches
-  // was a way through that this hook did not have before the expansion existed:
-  // `cat /nonexistent/.env.*` matches nothing, so nothing was scanned and the
-  // `.env` name guard — which reads the name, not the disk — never ran. A file
-  // really named `report[2].txt` was lost the same way, since glob reads `[2]`
-  // as a character class and expands it to `report2.txt`.
+  // The literal is kept as well as the expansion. Returning only the matches
+  // would be a way through that this hook did not have before the expansion
+  // existed: `cat /nonexistent/.env.*` matches nothing, so nothing would be
+  // scanned and the `.env` name guard — which reads the name, not the disk —
+  // would never run. A file really named `report[2].txt` goes the same way,
+  // since glob reads `[2]` as a character class and expands it to
+  // `report2.txt`.
   return [literal, ...matches];
 }
 
@@ -793,7 +797,7 @@ process.stdin.on("end", () => {
   try {
     // Empty stdin is nothing to check. Bytes that do not parse are a check that
     // could not read its input, which is not the same as safe: two characters
-    // missing from the end of a payload used to pass a key through.
+    // missing from the end of a payload are enough to hide a key.
     if (raw.trim().length === 0) process.exit(0);
     const parsed: unknown = JSON.parse(raw);
     // `JSON.parse("null")` succeeds and returns null, which then threw on the
@@ -838,8 +842,8 @@ process.stdin.on("end", () => {
 
   if (tool === "Bash") {
     // A tool input is whatever the tool declares, so a `command` that is not a
-    // string is a shape this really receives. It used to throw, and an exception
-    // exits 1, which does not block: the call went through unscanned.
+    // string is a shape this really receives. Throwing on it exits 1, which does
+    // not block, so the call goes through unscanned.
     const command = Array.isArray(input.command)
       ? input.command
           .filter((v): v is string => typeof v === "string")

--- a/src/user-prompt-submit-hook.ts
+++ b/src/user-prompt-submit-hook.ts
@@ -53,7 +53,7 @@ process.stdin.on("end", () => {
   try {
     // Empty stdin is nothing to check. Bytes that do not parse are a check that
     // could not read its input, which is not the same as safe: two characters
-    // missing from the end of a payload used to pass a key through.
+    // missing from the end of a payload are enough to hide a key.
     if (raw.trim().length === 0) process.exit(0);
     const parsed: unknown = JSON.parse(raw);
     // `JSON.parse("null")` succeeds and returns null, which then threw on the
@@ -79,9 +79,9 @@ process.stdin.on("end", () => {
   if (allFindings.length === 0) process.exit(0);
 
   // From what the user typed, not from what they pasted: a fenced log or a
-  // README quoting `[allow-secret]` used to lift the guard on the key in the
-  // same message. The other hook already read tags this way, so the two gave
-  // different answers to the same text.
+  // README quoting `[allow-secret]` would otherwise lift the guard on the key in
+  // the same message. Both hooks read tags this way, so the same text gets the
+  // same answer whichever one sees it.
   const { effectiveAllow, effectiveMask } = resolveTagPriority(
     typedTextOf(prompt),
   );


### PR DESCRIPTION
docs: comments explain the code, not what it used to be

No behaviour change; comments only. 2415 passed before and after.

A comment that says "X was broken, so now Y" costs a reader the paragraph
and leaves them knowing about a bug that no longer exists. The same
comment written as "Y, because X does not work: [mechanism]" costs the
same paragraph and leaves them able to change the code. The reasoning is
what is worth keeping — every one of these was rewritten to keep it and
drop the chronology.

Sixteen comments across six files:

    the byte cap and the total budget      what happens without them
    the deadline and both clocks           what the clock is measuring
    a missing working directory            what would throw, and why it is safe
    glob expansion, `**`, the literal      what each case costs if dropped
    the block channel                      why not stdout, in the present tense
    the scan budget                        what an unbounded pattern does
    heredoc delimiters and keywords        what a narrower class would cut
    a substitution among the operands      what ending the segment would do
    the write-verb boundary test           what a substring test would exempt
    a payload that will not parse          why unread is not the same as safe

One is a comment about a comment — a note that the text which used to sit
there had been wrong — which is two removes from anything a reader of this
function needs.

Left as they are: `env … being used to run another command`, which is
ordinary English rather than a chronology, and the note that a heredoc fed
to a remote shell is not caught, which describes what the code does today
and is written up as a known limitation.
