### PR TITLE
test: cover the four paths nothing was watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then add to `~/.claude/settings.json`:
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Bash|Grep|mcp__.*",
+        "matcher": "Read|NotebookRead|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -151,7 +151,7 @@ Then add to `~/.claude/settings.json`:
     ],
     "PreToolUse": [
       {
-        "matcher": "Read|Bash|Grep|mcp__.*",
+        "matcher": "Read|NotebookRead|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -513,7 +513,7 @@ The `/` is what separates a path from a word, and it is there so that a search p
 
 Values are found up to four levels down and inside arrays, both of strings and of objects, so `{ "path": "…" }`, `{ "paths": ["…"] }`, `{ "args": ["/abs/…"] }` and `{ "args": { "paths": [{ "path": "…" }] } }` are all covered. A field naming a directory is left alone.
 
-Which tools reach the hook at all is the matcher's business, and the default (`Read|Bash|Grep|mcp__.*`) sends it `Read`, `Bash`, `Grep` and every MCP tool. Widen the matcher and the same field search applies to whatever else arrives.
+Which tools reach the hook at all is the matcher's business, and the default (`Read|NotebookRead|Bash|Grep|mcp__.*`) sends it `Read`, `NotebookRead`, `Bash`, `Grep` and every MCP tool. Widen the matcher and the same field search applies to whatever else arrives.
 
 Commands that only measure a file (`wc`, `cksum`, `sha256sum`) are not treated as reads, whether the file is named or fed in over `<`: they print counts and digests, never the bytes. Neither are the tools that surface no file contents — `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `TodoWrite`, `Glob`, `WebFetch`, `WebSearch`, `ExitPlanMode`, `AskUserQuestion` — nor any tool whose name leads with a write verb, such as `mcp__fs__write_file` or `createPage`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -87,7 +87,7 @@ in place of `<dist>` below, in `~/.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash|Grep|mcp__.*",
+        "matcher": "Read|NotebookRead|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -168,7 +168,7 @@ Add the following to `~/.claude/settings.json`:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Bash|Grep|mcp__.*",
+        "matcher": "Read|NotebookRead|Bash|Grep|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -222,7 +222,7 @@ To allow, add a tag to your prompt:
 
 ### PreToolUse hook
 
-Runs before Claude uses `Read`, `Bash`, `Grep` or any MCP tool. It blocks:
+Runs before Claude uses `Read`, `NotebookRead`, `Bash`, `Grep` or any MCP tool. It blocks:
 
 - `.env` and `.env.*` files by filename (a secret guard; only while the `secret` category is enabled)
 - Any file whose contents contain secrets or PII

--- a/src/__tests__/manifest.test.ts
+++ b/src/__tests__/manifest.test.ts
@@ -112,6 +112,39 @@ describe("hooks.json", () => {
   });
 });
 
+// The install guide is a second manifest, kept by hand. A plugin install reads
+// `hooks/hooks.json`; an npm or from-source install is whatever the reader
+// copied out of the documentation, and the two are only the same while someone
+// remembers. They were not: `NotebookRead` was added to the matcher and to the
+// tests above, and all four documented snippets kept the matcher without it —
+// green here, and a narrower guard for everyone who installs by the guide.
+//
+// README.md ships inside the npm package, so a stale snippet there is published
+// rather than merely posted.
+describe("the documented matcher", () => {
+  const matcher = (events["PreToolUse"] ?? [])[0]?.matcher ?? "";
+
+  it.each(["README.md", "docs/install.md"])(
+    "%s registers the matcher hooks.json declares",
+    (relative) => {
+      const text = readFileSync(join(ROOT, relative), "utf8");
+      const quoted = [...text.matchAll(/"matcher":\s*"([^"]+)"/g)].map(
+        (m) => m[1],
+      );
+      // A guide that stopped showing a matcher would otherwise pass by having
+      // nothing to disagree with.
+      expect(quoted.length).toBeGreaterThan(0);
+      for (const found of quoted) expect(found).toBe(matcher);
+    },
+  );
+
+  // The prose beside the snippets names the same default. It drifted with them.
+  it("README describes the matcher it tells the reader to paste", () => {
+    const text = readFileSync(join(ROOT, "README.md"), "utf8");
+    expect(text).toContain(`the default (\`${matcher}\`)`);
+  });
+});
+
 describe("plugin.json", () => {
   const plugin = readJson(".claude-plugin/plugin.json");
   const pkg = readJson("package.json");

--- a/src/__tests__/pre-tool-use-hook-files.test.ts
+++ b/src/__tests__/pre-tool-use-hook-files.test.ts
@@ -1,6 +1,13 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  chmodSync,
+  globSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   AWS_KEY,
@@ -298,6 +305,109 @@ describe("pre-tool-use-hook — the documented limits", () => {
     writeFixture("g-clean.txt", "nothing here");
     writeFixture("g-secret.txt", `key=${AWS_KEY}`);
     expect(runBashHook(`cat ${dir}/g-*.txt`).exitCode).toBe(2);
+  });
+
+  // Both sides of the number the README states: "at most 256 matches of one
+  // pattern are scanned". The test above says the cap is not 1; this says what
+  // it is. Written as a pair because only the pair pins a number — a cap of 512
+  // passes the first case and the 256th here, and fails nothing else.
+  //
+  // The secret goes in the last match, so the case rests on the order of the
+  // expansion. That assumption is asserted rather than trusted: `globSync`
+  // returning its matches in another order would otherwise turn the second case
+  // into a test that passes or fails by chance.
+  describe("the 256-match cap on one pattern", () => {
+    const spread = (label: string, count: number): string => {
+      const dir = join(writeFixture.path(), label);
+      mkdirSync(dir, { recursive: true });
+      for (let i = 0; i < count; i++) {
+        // Zero-padded, so sorted order is the order they were made in.
+        const name = `sec${String(i).padStart(4, "0")}.txt`;
+        const last = i === count - 1;
+        writeFileSync(join(dir, name), last ? `key=${AWS_KEY}\n` : "nothing\n");
+      }
+      const expanded = globSync(join(dir, "sec*.txt"));
+      expect(expanded).toHaveLength(count);
+      expect(basename(expanded[count - 1] ?? "")).toBe(
+        `sec${String(count - 1).padStart(4, "0")}.txt`,
+      );
+      return dir;
+    };
+
+    it("the 256th match is scanned", () => {
+      const dir = spread("at-cap", 256);
+      expect(runBashHook(`cat ${dir}/sec*.txt`).exitCode).toBe(2);
+    });
+
+    // What the cap costs, stated as a test so it is a decision and not a
+    // surprise. README lists it under Known Limitations.
+    it("the 257th is not", () => {
+      const dir = spread("over-cap", 257);
+      expect(runBashHook(`cat ${dir}/sec*.txt`).exitCode).toBe(0);
+    });
+  });
+});
+
+// The read itself can fail after every check that it should not have. The
+// `catch` around it returns rather than blocking, which is right — a file the
+// hook cannot open is one the tool cannot read either — but nothing said so,
+// and the branch could be changed to anything without a test noticing.
+describe("pre-tool-use-hook — a file the scan cannot open", () => {
+  const writeFixture = useFixtureDir("unreadable");
+
+  // Skipped for a root user, who can open a mode-000 file and would see the
+  // content block this is asserting the absence of.
+  const unreadable = (name: string, content: string): string | null => {
+    const file = writeFixture(name, content);
+    chmodSync(file, 0o000);
+    try {
+      readFileSync(file);
+      chmodSync(file, 0o600);
+      return null;
+    } catch {
+      return file;
+    }
+  };
+
+  it("a file whose permissions forbid the read is allowed", () => {
+    const file = unreadable("locked.txt", `key=${AWS_KEY}\n`);
+    if (file === null) return;
+    expect(runHook("Read", file).exitCode).toBe(0);
+    chmodSync(file, 0o600);
+  });
+
+  // The name guard runs before the open and does not depend on it, so the one
+  // file where an unreadable read still matters is still blocked.
+  it("an unreadable .env is blocked on its name", () => {
+    const file = unreadable(".env", `TOKEN=${AWS_KEY}\n`);
+    if (file === null) return;
+    const result = runHook("Read", file);
+    expect(result.exitCode).toBe(2);
+    chmodSync(file, 0o600);
+  });
+
+  // A symlink is followed, because the read follows it: judging the link by its
+  // own name would scan nothing and allow a `notes.txt` pointing at a key.
+  it("a symlink is judged by what it points at", () => {
+    const target = writeFixture("link-target.txt", `key=${AWS_KEY}\n`);
+    const link = join(writeFixture.path(), "notes.txt");
+    symlinkSync(target, link);
+    expect(runHook("Read", link).exitCode).toBe(2);
+  });
+
+  // A link to nothing is not a read. `.env` is still blocked, because that
+  // guard reads the name; `.env.example` is not, because a path that names
+  // nothing has nothing to leak.
+  it.each([
+    [".env", 2],
+    [".env.example", 0],
+    ["notes.txt", 0],
+  ])("a broken symlink named %s exits %i", (name, want) => {
+    const dir = join(writeFixture.path(), `broken-${name}`);
+    mkdirSync(dir, { recursive: true });
+    const link = join(dir, name);
+    symlinkSync(join(dir, "nowhere"), link);
+    expect(runHook("Read", link).exitCode).toBe(want);
   });
 });
 

--- a/src/__tests__/pre-tool-use-hook-paths.test.ts
+++ b/src/__tests__/pre-tool-use-hook-paths.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   AWS_KEY,
@@ -195,6 +196,68 @@ describe("pre-tool-use-hook — shell expansion of a path", () => {
   it("a file whose name contains glob characters is scanned", () => {
     const file = writeFixture("report[2].txt", `key=${AWS_KEY}`);
     expect(runBashHook(`cat ${file}`).exitCode).toBe(2);
+  });
+});
+
+// ── file:// URIs ─────────────────────────────────────────────────────────────
+
+// MCP servers pass a `file://` URI under `uri` where another tool would pass
+// `path`. Resolved as a relative path it named nothing, so it fell to the
+// not-a-file check before the `.env` name guard could read it. Nothing here
+// exercised the conversion: it could be deleted and the suite stayed green.
+describe("pre-tool-use-hook — a file:// URI names a path", () => {
+  const writeFixture = useFixtureDir("file-url");
+
+  it("a URI naming a .env is blocked on the name", () => {
+    const file = writeFixture(".env", `TOKEN=${AWS_KEY}`);
+    const result = runToolHook("mcp__fs__read_resource", {
+      uri: pathToFileURL(file).href,
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.blocked).toBe(true);
+  });
+
+  it("a URI naming an ordinary file is scanned for content", () => {
+    const file = writeFixture("notes.txt", `key=${AWS_KEY}`);
+    const result = runToolHook("mcp__fs__read_resource", {
+      uri: pathToFileURL(file).href,
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  // The conversion belongs to the candidate, not to the field it arrived in.
+  it("a URI under file_path is converted too", () => {
+    const file = writeFixture("under-file-path.txt", `key=${AWS_KEY}`);
+    const result = runToolHook("Read", {
+      file_path: pathToFileURL(file).href,
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  // A percent-encoded name is the reason the conversion exists rather than a
+  // `slice(7)`: the URI for a file with a space in its name carries `%20`, and
+  // trimming the scheme by hand hands the filesystem a name nothing is called.
+  it("a URI for a name with a space is resolved, not trimmed", () => {
+    const file = writeFixture("my secrets.txt", `key=${AWS_KEY}`);
+    const result = runToolHook("mcp__fs__read_resource", {
+      uri: pathToFileURL(file).href,
+    });
+    expect(result.reason).toContain("my secrets.txt");
+    expect(result.exitCode).toBe(2);
+  });
+
+  // Both ways the conversion can refuse. `fileURLToPath` throws on a URI it
+  // cannot read and on one naming another host, and the candidate is then left
+  // as written — which names nothing on this disk. The hook has to come back
+  // either way: a throw here reaches the top level, and an unhandled throw is a
+  // hook that does not block.
+  it.each([
+    ["malformed", "file://%%%/nope"],
+    ["another host", "file://server/share/.env"],
+  ])("a URI that cannot be converted (%s) returns", (_label, uri) => {
+    const result = runToolHook("mcp__fs__read_resource", { uri });
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("ERR_INVALID");
   });
 });
 

--- a/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tool-inputs.test.ts
@@ -134,6 +134,70 @@ describe("pre-tool-use-hook — Grep and MCP tool inputs", () => {
     });
   });
 
+  // A search with no path runs where the tool runs, and the field carrying the
+  // term is the server's to name. `pattern` had a case; `query` and `regex` did
+  // not, so either could be dropped from the test that recognises a search and
+  // the suite stayed green — and an MCP search would then print from a
+  // directory nobody looked at.
+  describe("a search term under any of its names", () => {
+    const withEnv = (label: string): string => {
+      const dir = writeFixture.path(`search-${label}`);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, ".env"), `TOKEN=${TOKEN_VALUE}\n`, "utf8");
+      return dir;
+    };
+
+    it.each(["pattern", "query", "regex"])(
+      "an MCP search under %s blocks when a .env sits where it runs",
+      (field) => {
+        const result = runToolHook(
+          "mcp__example__search",
+          { [field]: "TODO" },
+          { cwd: withEnv(field) },
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.blocked).toBe(true);
+      },
+    );
+
+    // Names only, for every spelling. Content-scanning a directory nobody named
+    // stopped a plain `rg TODO` in a third of the checkouts it was measured
+    // against, and the reason has nothing to do with which field the term is in.
+    it.each(["pattern", "query", "regex"])(
+      "an MCP search under %s allows ordinary files that mention secrets",
+      (field) => {
+        const dir = writeFixture.path(`prose-${field}`);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+          join(dir, "CHANGELOG.md"),
+          `- redact a key such as ${AWS_KEY} in the terminal\n`,
+          "utf8",
+        );
+        const result = runToolHook(
+          "mcp__example__search",
+          { [field]: "TODO" },
+          { cwd: dir },
+        );
+        expect(result.exitCode).toBe(0);
+      },
+    );
+
+    // The other half of the rule: the term makes it a search, the tool makes it
+    // one that searches here. Without the tool test every input with a `query`
+    // would scan the working directory.
+    it.each(["Read", "Write", "mcp__example__write_file"])(
+      "%s carrying a query does not scan the working directory",
+      (tool) => {
+        const result = runToolHook(
+          tool,
+          { query: "TODO" },
+          { cwd: withEnv(tool) },
+        );
+        expect(result.exitCode).toBe(0);
+      },
+    );
+  });
+
   describe("other tools and MCP", () => {
     it("mcp__filesystem__read_text_file should block on secret", () => {
       const file = writeFixture("mcp_secret.txt", `key=${AWS_KEY}`);


### PR DESCRIPTION
Closes the four test gaps recorded as **T-7** in the third-pass review of #190, and the half of #214 that was left in the documentation.

No product code changed. `2404 -> 2430` tests.

## The four branches

Each of these could be deleted or rewritten and the suite stayed green. Each case was measured first and asserted afterwards.

| | what it pins |
| --- | --- |
| `file://` conversion | a URI naming a `.env`, one naming a file with a key, one under `file_path`, one whose name has a space (`%20`), and the two ways the conversion refuses |
| `query` and `regex` | all three spellings of a search term block, allow names-only, and need a searching tool |
| `MAX_GLOB_MATCHES` | the 256th match is scanned, the 257th is not |
| the `catch` around the read | mode-000 allowed, mode-000 `.env` blocked on the name, symlink judged by its target, broken symlink by its name alone |

A URI that cannot be converted has to come back rather than throw. An unhandled throw is a hook that does not block, which is the failure this repository exists to prevent.

The cap is written as a pair because only a pair pins a number: a cap of 512 passes either case on its own. The secret sits in the last match, so the case rests on the order of the expansion. That order is asserted rather than trusted — a `globSync` returning another order would turn the second case into one that passes by chance. Measured stable over five runs.

`.env.example` pointing at nothing is allowed, and that is not an oversight: `blockUnreadEnvFile` returns on `existsSync`, because a path that names nothing has nothing to leak. The first draft of this test expected a block and the code was right.

## Mutation-checked

Every case was confirmed by breaking what it watches.

```
fromFileUrl returns the URI unchanged   4 of the 6 file:// cases fail
query and regex dropped from the term   2 fail
MAX_GLOB_MATCHES 256 -> 512             "the 257th is not" fails
MAX_GLOB_MATCHES 256 -> 128             "the 256th match is scanned" fails
the catch blocks instead of returning   "permissions forbid the read" fails
statSync -> lstatSync                   "a symlink is judged by its target" fails
one docs snippet reverted               the new documented-matcher test fails
```

## The install guide

`NotebookRead` went into the matcher in #214 and into the tests that guard it. All four documented snippets kept the matcher without it, so a plugin install was covered and an install made by copying the guide was not.

Whether that is a hole turns on whether Claude Code anchors the matcher, which this repository cannot check. That uncertainty is exactly why `manifest.test.ts` runs the matcher both ways instead of picking one, and the guide had no business assuming the answer either. `README.md` ships inside the npm package, so the stale snippet was published rather than merely posted.

Fixed in README.md (two snippets and the prose) and docs/install.md (two snippets and the prose).

The drift happened because nothing tied the guide to the manifest. `manifest.test.ts` now reads every `"matcher"` out of both documents and requires it to be the one `hooks/hooks.json` declares, and requires the prose beside them to name the same default.

## Checked

```
pnpm run ci           2430 passed | 2 skipped
pnpm run docs:build   build complete
git diff src/lib src/*.ts   empty
```

## After this

#190's body still reports `2,415 passed`, one generation stale. Correcting it to `2,404` now would go stale again the moment this merges, so it should be set to the final number once this is in.
