### PR TITLE
fix: act on the review of #190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -772,6 +772,14 @@
   green
 - Install with `--frozen-lockfile` in CI. A lockfile CI is allowed to rewrite is
   a lockfile CI does not check
+- Take CodeQL off GitHub's default setup and run it from `codeql.yml`. Default
+  setup only analyses a pull request whose base is the default or a protected
+  branch, so a PR stacked on another feature branch was never scanned — the same
+  gap `ci.yml` had, and the branches it covers cannot be configured. The new
+  workflow analyses pull requests, pushes to `main` and `develop`, and a weekly
+  schedule, because an advisory lands after a change merges rather than only
+  alongside one. The two setups cannot coexist: default setup has to be off for
+  these analyses to be accepted
 - Fail the lint on warnings, and check `docs/.vitepress/` the way `src/` is
   checked. `biome lint` exits 0 on a warning, so the dead `tokenize` in
   `src/lib/rules.ts` — superseded by `contextTokens`, and carrying a comment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ If the backport PR has conflicts, resolve them manually before merging.
 
 ## Adding a New Detection Rule
 
-1. Add the rule to `src/lib/default-config.json` — define `id`, `description`, `regex`, `category`, and optionally `entropyThreshold` and `flags`. `src/lib/rules.ts` reads that file; it holds the checksum validators, not the rules
+1. Add the rule to `src/lib/default-config.json` — define `id`, `description`, `regex`, `category`, and optionally `entropyThreshold` and `flags`. `src/lib/rules.ts` reads that file; the checksum validators it calls by name live in `src/lib/validators.ts`, which is where a new one goes
 2. Add tests — cover true positives, false negatives, and entropy filtering
    - Add the rule to the `EXAMPLES` table in `src/lib/__tests__/rule-patterns.test.ts`. Every rule needs one value it must find, or the id list proves only that a name is present: four rules shipped with patterns that could be disabled in silence because nothing asked them to match anything
    - The same file pads every example and requires the rule to still match, so a length you guessed too tight fails there rather than in a release. If the format really is exact — a checksum, a fixed-width field — add the id to `LONGER_IS_A_DIFFERENT_THING` with the reason

--- a/src/__tests__/pre-tool-use-hook-tags.test.ts
+++ b/src/__tests__/pre-tool-use-hook-tags.test.ts
@@ -480,10 +480,12 @@ describe("pre-tool-use-hook — allow tag single-use (consumed by first tool cal
 // the block was a false positive.
 // README: "[allow-secret] does not bypass PII blocks (and vice versa)."
 //
-// Deduplication keys on the value, so a string that a secret rule and a PII rule
-// both match yields two findings with the same value. Deduplicating first threw
-// the PII one away, and the tag then removed what was left — so the tag lifted a
-// PII block. Allow first, then dedupe.
+// A string that a secret rule and a PII rule both match yields two findings with
+// the same value, and they stay two because the deduplication key carries the
+// category. Collapse them on the value alone and one category is thrown away
+// before any tag is read, which is a tag lifting the other category's block.
+// `dedupeFindings` is where that key is guarded; this is the same promise seen
+// from the outside, on a real value and through the hook.
 describe("pre-tool-use-hook — a tag lifts only its own category", () => {
   const writeFixture = useFixtureDir("tag-categories");
 

--- a/src/lib/tool-inputs.ts
+++ b/src/lib/tool-inputs.ts
@@ -141,6 +141,22 @@ function isPathCandidate(key: string, value: string): boolean {
 // an arbitrary tree before a tool call.
 const MAX_PATH_FIELD_DEPTH = 4;
 
+// Input field names that carry something to run rather than something to read.
+// Compared with separators and case removed, the way path field names are.
+export const COMMAND_FIELD_NAMES = new Set([
+  "command",
+  "commands",
+  "cmd",
+  "script",
+  "code",
+  "shellcommand",
+  "commandline",
+]);
+
+// How far into a nested input a command field is looked for. The same depth the
+// path fields use, and for the same reason: a tool wraps its arguments.
+const MAX_COMMAND_FIELD_DEPTH = 4;
+
 export function collectPathFields(
   input: Record<string, unknown>,
   depth = 0,
@@ -180,5 +196,40 @@ export function collectPathFields(
     }
   }
 
+  return found;
+}
+
+// Every command an input carries, whatever shape it arrives in.
+//
+// Reading only top-level strings left two shapes through, and both reach the
+// `.env` name guard by a name with no slash in it, which the path rules do not
+// collect: an argv array (`{"command":["cat",".env"]}`) and a command nested
+// under another key (`{"args":{"command":"cat .env"}}`). Depth-limited the way
+// path fields are, for the same reason.
+//
+// Beside `collectPathFields` rather than in the hook: the two walk the same tree
+// to the same depth and differ only in which field names count, and that
+// question — along with `normalizeFieldName` and both name sets — belongs in one
+// module rather than split across two.
+export function collectCommandFields(
+  input: Record<string, unknown>,
+  depth = 0,
+): string[] {
+  if (depth > MAX_COMMAND_FIELD_DEPTH) return [];
+  const found: string[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    const named = COMMAND_FIELD_NAMES.has(normalizeFieldName(key));
+    if (named && typeof value === "string") {
+      found.push(value);
+    } else if (named && Array.isArray(value)) {
+      // An argv array is one command line with the spaces taken out.
+      const argv = value.filter((v): v is string => typeof v === "string");
+      if (argv.length > 0) found.push(argv.join(" "));
+    } else if (value !== null && typeof value === "object") {
+      found.push(
+        ...collectCommandFields(value as Record<string, unknown>, depth + 1),
+      );
+    }
+  }
   return found;
 }

--- a/src/pre-tool-use-hook.ts
+++ b/src/pre-tool-use-hook.ts
@@ -28,9 +28,9 @@ import {
   tokenizeCommand,
 } from "./lib/shell.ts";
 import {
+  collectCommandFields,
   collectPathFields,
   isWritingTool,
-  normalizeFieldName,
   TOOLS_WITHOUT_FILE_OUTPUT,
 } from "./lib/tool-inputs.ts";
 import { loadAllowTagsFromTranscript } from "./lib/transcript.ts";
@@ -86,22 +86,6 @@ const MAX_FILE_SCAN_BYTES = 1_048_576; // 1 MiB
 // hook well inside the timeout while making that trick need sixty-four files
 // rather than eight. It does not remove it — written up as a limitation.
 const MAX_TOTAL_SCAN_BYTES = 64 * 1_048_576; // 64 MiB
-
-// Input field names that carry something to run rather than something to read.
-// Compared with separators and case removed, the way path field names are.
-const COMMAND_FIELD_NAMES = new Set([
-  "command",
-  "commands",
-  "cmd",
-  "script",
-  "code",
-  "shellcommand",
-  "commandline",
-]);
-
-// How far into a nested input a command field is looked for. The same depth the
-// path fields use, and for the same reason: a tool wraps its arguments.
-const MAX_COMMAND_FIELD_DEPTH = 4;
 
 const ENABLED_CATEGORIES = enabledCategoriesFromEnv();
 
@@ -291,6 +275,38 @@ function block(
   process.exit(2);
 }
 
+// Scan a piece of text and block if anything survives the tags.
+//
+// Five places did this — an environment variable's value, each end of a file, a
+// Bash command line, and a command carried in a tool input — and each wrote out
+// the same four steps and the same message shape, differing only in the source,
+// the header and the hint. Gathered here so the shape is one thing rather than
+// five things that agree for now.
+//
+// `[allow-secret]` never lifts a PII block, and what holds that is the
+// deduplication key: it carries the category, so one value matched by a rule of
+// each kind stays two findings and the tag removes only its own. Tagging before
+// deduplicating gives the same answer — measured, by swapping the two and
+// watching the suite stay green — and is kept because it is also the order that
+// survives the key ever narrowing back to the value alone.
+function scanTextAndBlock(
+  text: string,
+  source: string,
+  header: string,
+  hintContext: string,
+  allowTags: Set<string>,
+): void {
+  const findings = dedupeFindings(
+    applyAllowTags(scan(text, ENABLED_CATEGORIES), allowTags),
+  );
+  if (findings.length === 0) return;
+  block(
+    source,
+    [header, "", ...findingsToLines(findings)],
+    buildAllowHints(hintContext, findings),
+  );
+}
+
 // ── Core scan logic ───────────────────────────────────────────────────────────
 
 // Characters that make a token a pattern rather than a filename. `{` is here
@@ -411,36 +427,6 @@ function filesDirectlyUnder(candidate: string): string[] {
   }
 }
 
-// Every command an input carries, whatever shape it arrives in.
-//
-// Reading only top-level strings left two shapes through, and both reach the
-// `.env` name guard by a name with no slash in it, which the path rules do not
-// collect: an argv array (`{"command":["cat",".env"]}`) and a command nested
-// under another key (`{"args":{"command":"cat .env"}}`). Depth-limited the way
-// path fields are, for the same reason.
-function collectCommandFields(
-  input: Record<string, unknown>,
-  depth = 0,
-): string[] {
-  if (depth > MAX_COMMAND_FIELD_DEPTH) return [];
-  const found: string[] = [];
-  for (const [key, value] of Object.entries(input)) {
-    const named = COMMAND_FIELD_NAMES.has(normalizeFieldName(key));
-    if (named && typeof value === "string") {
-      found.push(value);
-    } else if (named && Array.isArray(value)) {
-      // An argv array is one command line with the spaces taken out.
-      const argv = value.filter((v): v is string => typeof v === "string");
-      if (argv.length > 0) found.push(argv.join(" "));
-    } else if (value !== null && typeof value === "object") {
-      found.push(
-        ...collectCommandFields(value as Record<string, unknown>, depth + 1),
-      );
-    }
-  }
-  return found;
-}
-
 // Whether a path names something whose bytes can be read to the end.
 //
 // A character device or a FIFO can be opened and read from forever: `cat
@@ -532,18 +518,12 @@ function scanEnvironment(names: string[], allowTags: Set<string>): void {
   for (const varName of names) {
     const value = process.env[varName];
     if (!value) continue;
-    const findings = dedupeFindings(
-      applyAllowTags(scan(value, ENABLED_CATEGORIES), allowTags),
-    );
-    if (findings.length === 0) continue;
-    block(
+    scanTextAndBlock(
+      value,
       "bash command",
-      [
-        `🚫 Blocked: environment variable $${varName} contains sensitive data`,
-        "",
-        ...findingsToLines(findings),
-      ],
-      buildAllowHints("please run the command", findings),
+      `🚫 Blocked: environment variable $${varName} contains sensitive data`,
+      "please run the command",
+      allowTags,
     );
   }
 }
@@ -747,41 +727,23 @@ function scanFile(filePath: string, allowTags: Set<string>): void {
   // A second window over the same file, judged on its own: a finding in either
   // end is a finding.
   if (tailContent.length > 0) {
-    const tailFindings = dedupeFindings(
-      applyAllowTags(scan(tailContent, ENABLED_CATEGORIES), allowTags),
+    scanTextAndBlock(
+      tailContent,
+      filePath,
+      "🚫 Blocked: file contains sensitive data",
+      `please read ${forOutput(filePath)}`,
+      allowTags,
     );
-    if (tailFindings.length > 0) {
-      block(
-        filePath,
-        [
-          "🚫 Blocked: file contains sensitive data",
-          "",
-          ...findingsToLines(tailFindings),
-        ],
-        buildAllowHints(`please read ${forOutput(filePath)}`, tailFindings),
-      );
-    }
   }
 
   if (content.length === 0) return;
 
-  // Allow first, then dedupe. The other way round, a value that a secret rule
-  // and a PII rule both match loses the PII finding to deduplication before the
-  // tag is consulted, and `[allow-secret]` then removes the secret finding too —
-  // so the tag lifted a PII block, which the README says it cannot.
-  const findings = dedupeFindings(
-    applyAllowTags(scan(content, ENABLED_CATEGORIES), allowTags),
-  );
-  if (findings.length === 0) return;
-
-  block(
+  scanTextAndBlock(
+    content,
     filePath,
-    [
-      "🚫 Blocked: file contains sensitive data",
-      "",
-      ...findingsToLines(findings),
-    ],
-    buildAllowHints(`please read ${forOutput(filePath)}`, findings),
+    "🚫 Blocked: file contains sensitive data",
+    `please read ${forOutput(filePath)}`,
+    allowTags,
   );
 }
 
@@ -892,20 +854,13 @@ process.stdin.on("end", () => {
 
     scanEnvironment(environmentNamed(command, refs), allowTags);
 
-    const cmdFindings = dedupeFindings(
-      applyAllowTags(scan(command, ENABLED_CATEGORIES), allowTags),
+    scanTextAndBlock(
+      command,
+      "bash command",
+      "🚫 Blocked: bash command contains sensitive data",
+      "please run the command",
+      allowTags,
     );
-    if (cmdFindings.length > 0) {
-      block(
-        "bash command",
-        [
-          "🚫 Blocked: bash command contains sensitive data",
-          "",
-          ...findingsToLines(cmdFindings),
-        ],
-        buildAllowHints("please run the command", cmdFindings),
-      );
-    }
 
     scanPathsLiteralsFirst(refs.paths, allowTags);
     // `rg PATTERN` and `grep -r PATTERN` name nothing and print from the working
@@ -931,20 +886,13 @@ process.stdin.on("end", () => {
     for (const value of collectCommandFields(input)) {
       // What the command says, as well as what it opens. A key in an argument
       // list is a key whichever tool runs the shell.
-      const commandFindings = dedupeFindings(
-        applyAllowTags(scan(value, ENABLED_CATEGORIES), allowTags),
+      scanTextAndBlock(
+        value,
+        `${tool} command`,
+        "🚫 Blocked: tool command contains sensitive data",
+        "please run the command",
+        allowTags,
       );
-      if (commandFindings.length > 0) {
-        block(
-          `${tool} command`,
-          [
-            "🚫 Blocked: tool command contains sensitive data",
-            "",
-            ...findingsToLines(commandFindings),
-          ],
-          buildAllowHints("please run the command", commandFindings),
-        );
-      }
 
       const refs = extractCommandRefs(value);
       // Code is not a command line: `print(open("secrets").read())` has no


### PR DESCRIPTION
Acts on the review of #190. Four of the five comments are fixed here; the fifth is answered on its own thread.

`pre-tool-use-hook.ts` 991 → 939 lines. 2430 tests before and after, and the packed-artifact smoke gate passes both installation flavours.

## Fixed

**CONTRIBUTING.md sent a contributor to the wrong file.** Step 1 said `src/lib/rules.ts` "holds the checksum validators, not the rules". This release moved them: `rules.ts:12` imports `getValidator` from the new `src/lib/validators.ts`, which is where `luhn`, the PAN and national identifier validators and the registry live.

**CodeQL had no changelog entry.** `codeql.yml` is new in this release and the `### CI` section documents every comparable workflow change. The workflow that decides which pull requests get scanned at all should not be the omission.

**Five copies of scan → tag → dedupe → block.** An environment variable's value, each end of a file, a Bash command line, and a command carried in a tool input each wrote out the same four steps and the same message shape, differing only in the source, the header and the hint. `scanTextAndBlock` holds it once.

**`collectCommandFields` moved to `src/lib/tool-inputs.ts`,** beside `collectPathFields`, `PATH_FIELD_NAMES` and the `normalizeFieldName` both walkers share. The two walk the same tree to the same depth and differ only in which field names count, and that question was split across two files. The move took the hook's last use of `normalizeFieldName` with it.

## What the extraction turned up

The reason all five sites gave for their ordering is stale, and correcting it is most of the diff's comment churn.

They said `[allow-secret]` leaves a PII block standing because tags are applied before deduplication. What actually holds that now is the deduplication key carrying the category — one value matched by a rule of each kind stays two findings, so the tag removes only its own. Swapping the two steps changes no test outcome; that is measured, not assumed, and it is why a mutation of the order passed.

The order is kept, because it is the one that survives the key ever narrowing back to the value alone. It is no longer described as the thing doing the work. `dedupeFindings` already guards the key from both directions, and the end-to-end promise is already covered in `pre-tool-use-hook-tags.test.ts`; both stay where they are.

## Not done

**The anchored version regex in three places** (`release.yml` twice, `ci.yml` once) is real duplication, and the fix does not belong in this PR. Sourcing a shared script would put a new file-resolution step into `release.yml`, which runs only on a push to `main` and has never executed in its current form. That trades three copies of one regex for an untested failure mode on the release path, days before the release. Worth doing straight after.

## Checked

```
pnpm run ci                    2430 passed | 2 skipped
five call sites, by hand       all five still block; a clean file still allowed
packed smoke gate              16 assertions, both flavours
```
