### PR TITLE
chore: release v0.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sensitive-canary",
   "description": "Blocks secrets and PII before they reach the Anthropic API",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "coo-quack"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.8.1 (2026-08-18)
+
+### Maintenance
+
+- Add a workflow to deprecate a published npm version from Actions (#219)
+- Update pnpm to 11.22.0 (#220); lock file maintenance (#221, #223)
+
 ## v0.8.0 (2026-08-16)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coo-quack/sensitive-canary",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Claude Code hooks that block secrets and PII before they reach the Anthropic API",
   "license": "MIT",
   "author": "coo-quack",


### PR DESCRIPTION
Maintenance-only release: npm deprecation workflow, pnpm 11.22.0, lock file maintenance. No runtime changes. Promotes to main after merge to cut v0.8.1.